### PR TITLE
Possibility to read db config from well-known env vars

### DIFF
--- a/db/config.go
+++ b/db/config.go
@@ -1,7 +1,5 @@
 package db
 
-import "os"
-
 // Config provide fields to configure the pool
 type Config struct {
 	// Database name
@@ -18,24 +16,4 @@ type Config struct {
 
 	// Port Number
 	Port string
-}
-
-// NewConfigFromEnv creates config from standard postgres environment variables,
-// see https://www.postgresql.org/docs/11/libpq-envars.html for details
-func NewConfigFromEnv() Config {
-	return Config{
-		Database: getEnv("PGDATABASE", "polygon-hermez"),
-		User:     getEnv("PGUSER", "hermez"),
-		Password: getEnv("PGPASSWORD", "polygon"),
-		Host:     getEnv("PGHOST", "localhost"),
-		Port:     getEnv("PGPORT", "5432"),
-	}
-}
-
-func getEnv(key string, defaultValue string) string {
-	value, exists := os.LookupEnv(key)
-	if exists {
-		return value
-	}
-	return defaultValue
 }

--- a/test/dbutils/dbutils.go
+++ b/test/dbutils/dbutils.go
@@ -2,6 +2,7 @@ package dbutils
 
 import (
 	"context"
+	"os"
 
 	"github.com/hermeznetwork/hermez-core/db"
 )
@@ -32,4 +33,24 @@ func InitOrReset(cfg db.Config) error {
 		return err
 	}
 	return nil
+}
+
+// NewConfigFromEnv creates config from standard postgres environment variables,
+// see https://www.postgresql.org/docs/11/libpq-envars.html for details
+func NewConfigFromEnv() db.Config {
+	return db.Config{
+		Database: getEnv("PGDATABASE", "polygon-hermez"),
+		User:     getEnv("PGUSER", "hermez"),
+		Password: getEnv("PGPASSWORD", "polygon"),
+		Host:     getEnv("PGHOST", "localhost"),
+		Port:     getEnv("PGPORT", "5432"),
+	}
+}
+
+func getEnv(key string, defaultValue string) string {
+	value, exists := os.LookupEnv(key)
+	if exists {
+		return value
+	}
+	return defaultValue
 }


### PR DESCRIPTION
Usage example:
```golang
func TestSomething(t *testing.T) {
	dbCfg := db.NewConfigFromEnv()

	err = db.RunMigrations(dbCfg)
	require.NoError(t, err)

	mtDb, err := db.NewSQLDB(dbCfg)
	require.NoError(t, err)

	defer mtDb.Close()

        // do something with the database
}
```