### PR TITLE
tests: wait for DB up and stop it on exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ build-docker: ## Build a docker image with the core binary
 .PHONY: test
 test: ## runs only short tests without checking race conditions
 	$(STOPDB) || true
-	$(RUNDB)
+	$(RUNDB); sleep 5
 	trap '$(STOPDB)' EXIT; go test -short -p 1 ./...
 
 .PHONY: test-full
 test-full: ## runs all tests checking race conditions
 	$(STOPDB) || true
-	$(RUNDB)
+	$(RUNDB); sleep 5
 	trap '$(STOPDB)' EXIT; MallocNanoZone=0 go test -race -p 1 -timeout 600s ./...
 
 .PHONY: install-linter


### PR DESCRIPTION
Closes #230, closes #229 

Adds a trap to always clean up the db on exit, no matter the test result; also waits a bit after the db has been created to give time to start responding to requests.