### PR TITLE
Use make commands in linter GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
-          $(go env GOPATH)/bin/golangci-lint run --timeout=5m -E whitespace -E gosec -E gci -E misspell -E gomnd -E gofmt -E goimports -E golint --exclude-use-default=false --max-same-issues 0
+          make install-linter
+          make lint

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test-full: ## runs all tests checking race conditions
 
 .PHONY: install-linter
 install-linter: ## install linter
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.30.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.39.0
 
 .PHONY: lint
 lint: ## runs linter


### PR DESCRIPTION
Closes #239 

Also bumps the version installed by `make install-linter` to 1.39.0 (same as we had in the GH action).

/cc @arnaubennassar @tclemos  