### PR TITLE
Add pre-commit hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Only run lint if .go files changed
+git diff --cached --name-only | if grep --quiet ".*go$"
+then
+  make lint
+fi

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ restart: stop run ## Executes `make stop` and `make run` commands
 run-db-scripts: ## executes scripts on the db after it has been initialized, potentially using info from the environment
 	./scripts/postgres/run.sh
 
+.PHONY: install-git-hooks
+install-git-hooks: ## Moves hook files to the .git/hooks directory
+	cp .github/hooks/* .git/hooks
+
 ## Help display.
 ## Pulls comments from beside commands and prints a nicely formatted
 ## display with the commands and their usage information.


### PR DESCRIPTION
Closes #265

### What does this PR does?

Adds pre-commit hook that runs `make lint` if "*.go" files changed. Also includes a `make install-git-hooks` target to copy the hook files into the right dir (`.git/hooks` is not included under version control). 

### Reviewers

Main reviewers:

@arnaubennassar 
@tclemos 
@cool-develope 
