### PR TITLE
e2e: poll for ready services instead of sleep

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -418,11 +418,9 @@ func nodeUpCondition(target string) (bool, error) {
 		return false, err
 	}
 
-	type response struct {
+	r := struct {
 		Result bool
-	}
-
-	r := response{}
+	}{}
 	err = json.Unmarshal(body, &r)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Closes #174

### What does this PR do?

Introduces a `waitPoll` function that accepts generic conditions to be fulfilled before a deadline and replaces all `time.Sleep` calls in e2e to use it.

### Reviewers
@cool-develope 

Codeowner reviewers:

@arnaubennassar 
@tclemos
