### PR TITLE
Increase timeout to wait for prover up in e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -113,7 +113,7 @@ func TestStateTransition(t *testing.T) {
 			require.NoError(t, err)
 
 			// Wait prover to be ready
-			err = waitPoll(1*time.Second, 5*time.Second, proverUpCondition)
+			err = waitPoll(1*time.Second, 10*time.Second, proverUpCondition)
 			require.NoError(t, err)
 
 			// Eth client


### PR DESCRIPTION

### What does this PR do?

Increases the timeout to wait for the prover to respond, the current value is causing errors like https://github.com/hermeznetwork/hermez-core/runs/4950545477?check_suite_focus=true
### Reviewers

Main reviewers:

@arnaubennassar 
@tclemos 
@cool-develope 