### PR TITLE
Add stack trace while logging errors using tracerr

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -123,7 +123,6 @@ func Info(args ...interface{}) {
 
 // Warn calls log.Warn
 func Warn(args ...interface{}) {
-	args = appendStackTraceMaybeArgs(args)
 	getDefaultLog().Warn(args...)
 }
 
@@ -193,7 +192,6 @@ func Infow(template string, kv ...interface{}) {
 
 // Warnw calls log.Warnw
 func Warnw(template string, kv ...interface{}) {
-	template = appendStackTraceMaybeKV(template, kv)
 	getDefaultLog().Warnw(template, kv...)
 }
 


### PR DESCRIPTION
Closes #218

### What does this PR do?

Wraps all the errors sent to `log.{Error,Fatal,Errorw,Fatalw,Errorf,Fatalf}` methods to show stack trace using tracerr, they look like this:
```
2022-01-27T16:11:07Z	ERROR	cmd/run.go:32	testtest
/src/log/log.go:107 github.com/hermeznetwork/hermez-core/log.appendStackTraceMaybeArgs()
/src/log/log.go:133 github.com/hermeznetwork/hermez-core/log.Error()
/src/cmd/run.go:32 main.start()
/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 github.com/urfave/cli/v2.(*Command).Run()
/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 github.com/urfave/cli/v2.(*App).RunContext()
/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224 github.com/urfave/cli/v2.(*App).Run()
/src/cmd/main.go:95 main.main()
```

### Reviewers

Main reviewers:

@arnaubennassar 
@tclemos 
@cool-develope 