### PR TITLE
aggregator continue to work if conn to prover failed

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -80,7 +80,7 @@ func (a *Aggregator) Start() {
 			getProofClient, err := a.ZkProverClient.GenProof(a.ctx, opts...)
 			if err != nil {
 				log.Errorf("failed to connect to the prover, err: %v", err)
-				return
+				continue
 			}
 
 			// 1. check, if state is synced


### PR DESCRIPTION
Closes #309

What does this PR do?
Aggregator doesn't stop working if connection to the prover failed

Reviewers
Main reviewers:

@arnaubennassar
@ARR552