### PR TITLE
Fix transfer during Smart Contract creation - Transfer refactor

### DIFF
--- a/cmd/register.go
+++ b/cmd/register.go
@@ -56,7 +56,8 @@ func registerSequencer(ctx *cli.Context) error {
 	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
 
 	stateCfg := state.Config{
-		DefaultChainID: c.NetworkConfig.L2DefaultChainID,
+		DefaultChainID:       c.NetworkConfig.L2DefaultChainID,
+		MaxCumulativeGasUsed: c.NetworkConfig.MaxCumulativeGasUsed,
 	}
 
 	stateDb := pgstatestorage.NewPostgresStorage(sqlDB)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,7 +55,8 @@ func start(ctx *cli.Context) error {
 	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
 
 	stateCfg := state.Config{
-		DefaultChainID: c.NetworkConfig.L2DefaultChainID,
+		DefaultChainID:       c.NetworkConfig.L2DefaultChainID,
+		MaxCumulativeGasUsed: c.NetworkConfig.MaxCumulativeGasUsed,
 	}
 
 	stateDb := pgstatestorage.NewPostgresStorage(sqlDB)

--- a/config/network.go
+++ b/config/network.go
@@ -10,14 +10,15 @@ import (
 
 //NetworkConfig is the configuration struct for the different environments
 type NetworkConfig struct {
-	Arity            uint8
-	GenBlockNumber   uint64
-	PoEAddr          common.Address
-	BridgeAddr       common.Address
-	MaticAddr        common.Address
-	L1ChainID        uint64
-	L2DefaultChainID uint64
-	Balances         map[common.Address]*big.Int
+	Arity                uint8
+	GenBlockNumber       uint64
+	PoEAddr              common.Address
+	BridgeAddr           common.Address
+	MaticAddr            common.Address
+	L1ChainID            uint64
+	L2DefaultChainID     uint64
+	Balances             map[common.Address]*big.Int
+	MaxCumulativeGasUsed uint64
 }
 
 const (
@@ -40,6 +41,7 @@ var (
 			common.HexToAddress("0xb1D0Dc8E2Ce3a93EB2b32f4C7c3fD9dDAf1211FA"): big.NewInt(1000),
 			common.HexToAddress("0xb1D0Dc8E2Ce3a93EB2b32f4C7c3fD9dDAf1211FB"): big.NewInt(2000),
 		},
+		MaxCumulativeGasUsed: 800000,
 	}
 	testnetConfig = NetworkConfig{
 		Arity:            4,
@@ -53,6 +55,7 @@ var (
 			common.HexToAddress("0xb1D0Dc8E2Ce3a93EB2b32f4C7c3fD9dDAf1211FA"): big.NewInt(1000),
 			common.HexToAddress("0xb1D0Dc8E2Ce3a93EB2b32f4C7c3fD9dDAf1211FB"): big.NewInt(2000),
 		},
+		MaxCumulativeGasUsed: 800000,
 	}
 	internalTestnetConfig = NetworkConfig{
 		Arity:            4,
@@ -101,6 +104,7 @@ var (
 			common.HexToAddress("0x0E7020134410931C9eC16c4dFB251d78E9fC3cAB"): bigIntFromBase10String("1000000000000000000000"),
 			common.HexToAddress("0x5A2A939c7D30F24912C97F93EbA321cDe25Dcc26"): bigIntFromBase10String("1000000000000000000000"),
 		},
+		MaxCumulativeGasUsed: 800000,
 	}
 	localConfig = NetworkConfig{
 		Arity:            4,
@@ -132,6 +136,7 @@ var (
 			common.HexToAddress("0xdD2FD4581271e230360230F9337D5c0430Bf44C0"): bigIntFromBase10String("1000000000000000000000"),
 			common.HexToAddress("0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199"): bigIntFromBase10String("1000000000000000000000"),
 		},
+		MaxCumulativeGasUsed: 800000,
 	}
 )
 

--- a/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
+++ b/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
@@ -35,7 +35,8 @@ var (
 var dbCfg = dbutils.NewConfigFromEnv()
 
 var stateCfg = state.Config{
-	DefaultChainID: 1000,
+	DefaultChainID:       1000,
+	MaxCumulativeGasUsed: 800000,
 }
 
 func TestMain(m *testing.M) {

--- a/state/config.go
+++ b/state/config.go
@@ -4,4 +4,6 @@ package state
 type Config struct {
 	// DefaultChainID is the common ChainID to all the sequencers
 	DefaultChainID uint64
+	// MaxCumulativeGasUsed is the max gas allowed per batch
+	MaxCumulativeGasUsed uint64
 }

--- a/state/state.go
+++ b/state/state.go
@@ -117,7 +117,7 @@ func (s *BasicState) NewBatchProcessor(sequencerAddress common.Address, lastBatc
 		return nil, err
 	}
 
-	batchProcessor := &BasicBatchProcessor{State: s, stateRoot: stateRoot, SequencerAddress: sequencerAddress, SequencerChainID: chainID, LastBatch: lastBatch}
+	batchProcessor := &BasicBatchProcessor{State: s, stateRoot: stateRoot, SequencerAddress: sequencerAddress, SequencerChainID: chainID, LastBatch: lastBatch, MaxCumulativeGasUsed: s.cfg.MaxCumulativeGasUsed}
 	batchProcessor.setRuntime(evm.NewEVM())
 	blockNumber, err := s.GetLastBlockNumber(context.Background())
 	if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -46,7 +46,8 @@ var (
 var cfg = dbutils.NewConfigFromEnv()
 
 var stateCfg = state.Config{
-	DefaultChainID: 1000,
+	DefaultChainID:       1000,
+	MaxCumulativeGasUsed: 800000,
 }
 
 func TestMain(m *testing.M) {

--- a/test/e2e/jsonrpc_test.go
+++ b/test/e2e/jsonrpc_test.go
@@ -19,12 +19,13 @@ import (
 )
 
 const (
-	defaultArity               = 4
-	defaultChainID             = 1000
-	defaultSequencerAddress    = "0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D"
-	defaultSequencerPrivateKey = "0x28b2b0318721be8c8339199172cd7cc8f5e273800a35616ec893083a4b32c02e"
-	defaultSequencerChainID    = 400
-	defaultSequencerBalance    = 400000
+	defaultArity                = 4
+	defaultChainID              = 1000
+	defaultSequencerAddress     = "0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D"
+	defaultSequencerPrivateKey  = "0x28b2b0318721be8c8339199172cd7cc8f5e273800a35616ec893083a4b32c02e"
+	defaultSequencerChainID     = 400
+	defaultSequencerBalance     = 400000
+	defaultMaxCumulativeGasUsed = 800000
 )
 
 // TestJSONRPC tests JSON RPC methods on a running environment.
@@ -36,8 +37,11 @@ func TestJSONRPC(t *testing.T) {
 	ctx := context.Background()
 
 	opsCfg := &operations.Config{
-		Arity:          defaultArity,
-		DefaultChainID: defaultChainID,
+		Arity: defaultArity,
+		State: &state.Config{
+			DefaultChainID:       defaultChainID,
+			MaxCumulativeGasUsed: defaultMaxCumulativeGasUsed,
+		},
 		Sequencer: &operations.SequencerConfig{
 			Address:    defaultSequencerAddress,
 			PrivateKey: defaultSequencerPrivateKey,

--- a/test/e2e/state_test.go
+++ b/test/e2e/state_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-core/encoding"
+	"github.com/hermeznetwork/hermez-core/state"
 	"github.com/hermeznetwork/hermez-core/test/operations"
 	"github.com/hermeznetwork/hermez-core/test/vectors"
 	"github.com/stretchr/testify/require"
@@ -33,8 +34,12 @@ func TestStateTransition(t *testing.T) {
 			ctx := context.Background()
 
 			opsCfg := &operations.Config{
-				Arity:          testCase.Arity,
-				DefaultChainID: testCase.DefaultChainID,
+				Arity: testCase.Arity,
+				State: &state.Config{
+					DefaultChainID:       testCase.DefaultChainID,
+					MaxCumulativeGasUsed: 800000,
+				},
+
 				Sequencer: &operations.SequencerConfig{
 					Address:    testCase.SequencerAddress,
 					PrivateKey: testCase.SequencerPrivateKey,

--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -66,9 +66,9 @@ type SequencerConfig struct {
 
 // Config is the main Manager configuration.
 type Config struct {
-	Arity          uint8
-	DefaultChainID uint64
-	Sequencer      *SequencerConfig
+	Arity     uint8
+	State     *state.Config
+	Sequencer *SequencerConfig
 }
 
 // Manager controls operations and has knowledge about how to set up and tear
@@ -93,7 +93,7 @@ func NewManager(ctx context.Context, cfg *Config) (*Manager, error) {
 		cfg: cfg,
 		ctx: ctx,
 	}
-	st, err := initState(cfg.Arity, cfg.DefaultChainID)
+	st, err := initState(cfg.Arity, cfg.State.DefaultChainID, cfg.State.MaxCumulativeGasUsed)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func Teardown() error {
 	return nil
 }
 
-func initState(arity uint8, defaultChainID uint64) (state.State, error) {
+func initState(arity uint8, defaultChainID uint64, maxCumulativeGasUsed uint64) (state.State, error) {
 	sqlDB, err := db.NewSQLDB(dbConfig)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,8 @@ func initState(arity uint8, defaultChainID uint64) (state.State, error) {
 	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
 
 	stateCfg := state.Config{
-		DefaultChainID: defaultChainID,
+		DefaultChainID:       defaultChainID,
+		MaxCumulativeGasUsed: maxCumulativeGasUsed,
 	}
 
 	stateDB := pgstatestorage.NewPostgresStorage(sqlDB)


### PR DESCRIPTION
Closes #182
Closes #370
Closes #371

### What does this PR do?

- Properly transfer Tx Value to SC address during SC creation.
- Refactor transfer using a mapping <addr,balance> to simplify code.
- Check cumulative gas used in processTransaction method

Test has not been updated, as it look like SC deployment code checks for the value of the transaction to be 0 before doing the creation of the smart contract. I will need to check this with Protocol team, but it is the conclusion I get after debugging smart contract code deployment. If value is added to the TX, the TX is reverted.

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @arnaubennassar 
- @tclemos 
- @Mikelle 