### PR TITLE
Set Docker network name explicitly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
             - COIN=ETH
             - ETHEREUM_JSONRPC_VARIANT=geth
             - ETHEREUM_JSONRPC_HTTP_URL=http://hez-core:8123
-            - DATABASE_URL=postgres://test_user:test_password@explorerdb:5432/explorer
+            - DATABASE_URL=postgres://test_user:test_password@hez-explorer-postgres:5432/explorer
             - ECTO_USE_SSL=false
             - MIX_ENV=prod
             - LOGO=/images/blockscout_logo.svg
@@ -50,8 +50,6 @@ services:
 
     hez-explorer-postgres:
         container_name: hez-explorer-postgres
-        # hez-explorer throws an error when the hostname of the DATABASE_URL includes underscores or hyphens
-        hostname: explorerdb
         image: postgres
         ports:
             - 5433:5432


### PR DESCRIPTION
### What does this PR do?

This PR explicitly sets the Docker network name used to deploy the stack. We (the frontend team) need to connect a Blockscout instance to this network in development mode to be able to make changes to the Blockscout code.

Currently, you are not using a name for the stack when spinning up the containers, so a default network `hermez-core_default` (`[REPO-NAME]_default`) is being created. This can change in future versions of your code if you set-up the `-p` option when launching the `docker-compose` cmd or even how the name is generated by Docker can change in the future, so is better to explicitly set the name of the network so we can always connect to it without experiencing any error.

~~This PR also adds a `hostname` to the service `hez-explorer-postgres`. The reason is that after syncing our Blockscout repository with the last changes present in the Blockscout base repository, the app `block_scout_web` throws an error related to the name of the host of the DB. From our tests, the error occurs when the hostname of the DB includes a hyphen. This should be further investigated, but [this PR](https://github.com/blockscout/blockscout/pull/5192) and [this line](https://github.com/blockscout/blockscout/pull/5192/files#diff-7b57215bdff0cfde213c7c40b982cb319e0a7f38ce4fae65d0202389ebb526d6R32) look suspicious. We have opened an [issue in Blockscout](https://github.com/blockscout/blockscout/issues/5234).~~

![blockscout-hyphen-db-hostname](https://user-images.githubusercontent.com/15896177/155732597-9669662b-81f6-4adc-a085-fcc1eadea391.gif)

### Reviewers

Main reviewers:

- @arnaubennassar 
- @tclemos 
