### PR TITLE
fix loading config for files with multiple dots on its name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,13 +47,14 @@ func Load(configFilePath string, network string) (*Config, error) {
 		return nil, err
 	}
 	if configFilePath != "" {
-		path, fullFile := filepath.Split(configFilePath)
+		dirName, fileName := filepath.Split(configFilePath)
 
-		file := strings.Split(fullFile, ".")
+		fileExtension := strings.TrimPrefix(filepath.Ext(fileName), ".")
+		fileNameWithoutExtension := strings.TrimSuffix(fileName, "."+fileExtension)
 
-		viper.AddConfigPath(path)
-		viper.SetConfigName(file[0])
-		viper.SetConfigType(file[1])
+		viper.AddConfigPath(dirName)
+		viper.SetConfigName(fileNameWithoutExtension)
+		viper.SetConfigType(fileExtension)
 	}
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")


### PR DESCRIPTION
Closes #397.

### What does this PR do?

Allow files with multiple dots on their name to be used as a config file.

### Reviewers

Main reviewers:

- @ARR552