### PR TITLE
Remove current root field from merkletree struct

### DIFF
--- a/cmd/register.go
+++ b/cmd/register.go
@@ -53,7 +53,7 @@ func registerSequencer(ctx *cli.Context) error {
 	store := tree.NewPostgresStore(sqlDB)
 	mt := tree.NewMerkleTree(store, c.NetworkConfig.Arity, poseidon.Hash)
 	scCodeStore := tree.NewPostgresSCCodeStore(sqlDB)
-	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
+	tr := tree.NewStateTree(mt, scCodeStore)
 
 	stateCfg := state.Config{
 		DefaultChainID:       c.NetworkConfig.L2DefaultChainID,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -51,7 +51,7 @@ func start(ctx *cli.Context) error {
 	store := tree.NewPostgresStore(sqlDB)
 	mt := tree.NewMerkleTree(store, c.NetworkConfig.Arity, poseidon.Hash)
 	scCodeStore := tree.NewPostgresSCCodeStore(sqlDB)
-	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
+	tr := tree.NewStateTree(mt, scCodeStore)
 
 	stateCfg := state.Config{
 		DefaultChainID:       c.NetworkConfig.L2DefaultChainID,

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -66,7 +66,8 @@ CREATE TABLE state.receipt
 CREATE TABLE state.misc
 (
     last_batch_num_seen BIGINT,
-    last_batch_num_consolidated BIGINT
+    last_batch_num_consolidated BIGINT,
+    current_mt_root BYTEA
 );
 
 -- Insert default values into misc table

--- a/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
+++ b/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	store := tree.NewPostgresStore(stateDB)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDB)
-	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore, nil))
+	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore))
 	tx := types.NewTransaction(uint64(0), common.Address{}, big.NewInt(10), uint64(1), big.NewInt(10), []byte{})
 	txs = []*types.Transaction{tx}
 

--- a/state/batchprocessor.go
+++ b/state/batchprocessor.go
@@ -236,7 +236,6 @@ func (b *BasicBatchProcessor) transfer(tx *types.Transaction, senderAddress, rec
 	root := b.stateRoot
 
 	// reset MT currentRoot in case it was modified by failed transaction
-	b.State.tree.SetCurrentRoot(root)
 	log.Debugf("processing transfer [%s]: root: %v", tx.Hash().Hex(), new(big.Int).SetBytes(root).String())
 
 	senderBalance, err := b.State.tree.GetBalance(senderAddress, root)
@@ -268,7 +267,7 @@ func (b *BasicBatchProcessor) transfer(tx *types.Transaction, senderAddress, rec
 	log.Debugf("processing transfer [%s]: new nonce: %v", tx.Hash().Hex(), senderNonce.Text(encoding.Base10))
 
 	// Store new nonce
-	_, _, err = b.State.tree.SetNonce(senderAddress, senderNonce)
+	root, _, err = b.State.tree.SetNonce(senderAddress, senderNonce, root)
 	if err != nil {
 		result.Err = err
 		return result
@@ -323,7 +322,7 @@ func (b *BasicBatchProcessor) transfer(tx *types.Transaction, senderAddress, rec
 
 	// Store new balances
 	for address, balance := range balances {
-		root, _, err = b.State.tree.SetBalance(address, balance)
+		root, _, err = b.State.tree.SetBalance(address, balance, root)
 		if err != nil {
 			result.Err = err
 			return result
@@ -360,6 +359,11 @@ func (b *BasicBatchProcessor) CheckTransaction(tx *types.Transaction) error {
 }
 
 func (b *BasicBatchProcessor) checkTransaction(tx *types.Transaction, senderNonce, senderBalance *big.Int) error {
+	// Check Signature
+	if err := CheckSignature(tx); err != nil {
+		return err
+	}
+
 	// Check ChainID
 	if tx.ChainId().Uint64() != b.SequencerChainID && tx.ChainId().Uint64() != b.State.cfg.DefaultChainID {
 		log.Debugf("Batch ChainID: %v", b.SequencerChainID)
@@ -515,7 +519,7 @@ func (b *BasicBatchProcessor) create(tx *types.Transaction, senderAddress, seque
 		senderNonce.Add(senderNonce, big.NewInt(1))
 
 		// Store new nonce
-		_, _, err = b.State.tree.SetNonce(senderAddress, senderNonce)
+		root, _, err = b.State.tree.SetNonce(senderAddress, senderNonce, root)
 		if err != nil {
 			return &runtime.ExecutionResult{
 				GasLeft: 0,
@@ -552,7 +556,7 @@ func (b *BasicBatchProcessor) create(tx *types.Transaction, senderAddress, seque
 	}
 
 	result.GasLeft -= gasCost
-	root, _, err = b.State.tree.SetCode(address, result.ReturnValue)
+	root, _, err = b.State.tree.SetCode(address, result.ReturnValue, root)
 	if err != nil {
 		return &runtime.ExecutionResult{
 			GasLeft: gasLimit,
@@ -588,7 +592,7 @@ func (b *BasicBatchProcessor) GetStorage(address common.Address, key common.Hash
 // SetStorage sets storage for a given address
 func (b *BasicBatchProcessor) SetStorage(address common.Address, key common.Hash, value common.Hash, config *runtime.ForksInTime) runtime.StorageStatus {
 	// TODO: Check if we have to charge here
-	root, _, err := b.State.tree.SetStorageAt(address, key, new(big.Int).SetBytes(value.Bytes()))
+	root, _, err := b.State.tree.SetStorageAt(address, key, new(big.Int).SetBytes(value.Bytes()), b.stateRoot)
 
 	if err != nil {
 		log.Errorf("error on SetStorage for address %v", address)

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -16,11 +16,9 @@ type merkletree interface {
 	GetCode(address common.Address, root []byte) ([]byte, error)
 	GetCodeHash(address common.Address, root []byte) ([]byte, error)
 	GetStorageAt(address common.Address, position common.Hash, root []byte) (*big.Int, error)
-	GetCurrentRoot() ([]byte, error)
 
-	SetBalance(address common.Address, balance *big.Int) (newRoot []byte, proof *tree.UpdateProof, err error)
-	SetNonce(address common.Address, nonce *big.Int) (newRoot []byte, proof *tree.UpdateProof, err error)
-	SetCode(address common.Address, code []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
-	SetStorageAt(address common.Address, key common.Hash, value *big.Int) (newRoot []byte, proof *tree.UpdateProof, err error)
-	SetCurrentRoot([]byte)
+	SetBalance(address common.Address, balance *big.Int, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
+	SetNonce(address common.Address, nonce *big.Int, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
+	SetCode(address common.Address, code []byte, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
+	SetStorageAt(address common.Address, key common.Hash, value *big.Int, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
 }

--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -44,6 +44,8 @@ const (
 	getLastBatchSeenSQL                    = "SELECT last_batch_num_seen FROM state.misc LIMIT 1"
 	updateLastBatchConsolidatedSQL         = "UPDATE state.misc SET last_batch_num_consolidated = $1"
 	getLastBatchConsolidatedSQL            = "SELECT last_batch_num_consolidated FROM state.misc LIMIT 1"
+	updateCurrentMTRootSQL                 = "UPDATE state.misc SET current_mt_root = $1"
+	getCurrentMTRootSQL                    = "SELECT current_mt_root FROM state.misc LIMIT 1"
 	getSequencerSQL                        = "SELECT * FROM state.sequencer WHERE address = $1"
 	getReceiptSQL                          = "SELECT * FROM state.receipt WHERE tx_hash = $1"
 	resetSQL                               = "DELETE FROM state.block WHERE block_num > $1"
@@ -581,6 +583,23 @@ func (s *PostgresStorage) AddTransaction(ctx context.Context, tx *types.Transact
 // AddReceipt adds a new receipt to the State Store
 func (s *PostgresStorage) AddReceipt(ctx context.Context, receipt *state.Receipt) error {
 	_, err := s.exec(ctx, addReceiptSQL, receipt.Type, receipt.PostState, receipt.Status, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.BlockNumber.Uint64(), receipt.BlockHash.Bytes(), receipt.TxHash.Bytes(), receipt.TransactionIndex, receipt.From.Bytes(), receipt.To.Bytes())
+	return err
+}
+
+// GetCurrentMTRoot queries and returns the current merkle tree root.
+func (s *PostgresStorage) GetCurrentMTRoot(ctx context.Context) ([]byte, error) {
+	var root []byte
+	err := s.queryRow(ctx, getCurrentMTRootSQL, common.Hash{}).Scan(root)
+	if err != nil {
+		return nil, err
+	}
+
+	return root, nil
+}
+
+// SetCurrentMTRoot sets the current merkle tree root.
+func (s *PostgresStorage) SetCurrentMTRoot(ctx context.Context, root []byte) error {
+	_, err := s.exec(ctx, updateCurrentMTRootSQL, root)
 	return err
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	store := tree.NewPostgresStore(stateDb)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore, nil))
+	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 
 	setUpBlocks()
 	setUpBatches()
@@ -454,7 +454,7 @@ func TestStateTransition(t *testing.T) {
 			store := tree.NewPostgresStore(stateDb)
 			mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 			scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-			stateTree := tree.NewStateTree(mt, scCodeStore, nil)
+			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
 			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
@@ -599,7 +599,7 @@ func TestStateTransitionSC(t *testing.T) {
 			store := tree.NewPostgresStore(stateDb)
 			mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 			scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-			stateTree := tree.NewStateTree(mt, scCodeStore, nil)
+			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
 			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
@@ -632,7 +632,7 @@ func TestLastSeenBatch(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore, nil))
+	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -657,10 +657,7 @@ func TestLastSeenBatch(t *testing.T) {
 func TestReceipts(t *testing.T) {
 	// Load test vector
 	stateTransitionTestCases, err := vectors.LoadStateTransitionTestCases("../test/vectors/receipt-vector.json")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
 
 	for _, testCase := range stateTransitionTestCases {
 		t.Run(testCase.Description, func(t *testing.T) {
@@ -677,7 +674,7 @@ func TestReceipts(t *testing.T) {
 			store := tree.NewPostgresStore(stateDb)
 			mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 			scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-			stateTree := tree.NewStateTree(mt, scCodeStore, nil)
+			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
 			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
@@ -838,7 +835,7 @@ func TestLastConsolidatedBatch(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore, nil))
+	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -872,7 +869,7 @@ func TestStateErrors(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore, nil))
+	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -968,7 +965,7 @@ func TestSCExecution(t *testing.T) {
 	store := tree.NewPostgresStore(stateDb)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-	stateTree := tree.NewStateTree(mt, scCodeStore, nil)
+	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
 	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
@@ -1088,7 +1085,7 @@ func TestSCCall(t *testing.T) {
 	store := tree.NewPostgresStore(stateDb)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-	stateTree := tree.NewStateTree(mt, scCodeStore, nil)
+	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
 	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)

--- a/state/tree/server_test.go
+++ b/state/tree/server_test.go
@@ -40,7 +40,7 @@ func initStree() (*tree.StateTree, error) {
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
 
-	return tree.NewStateTree(mt, scCodeStore, []byte{}), nil
+	return tree.NewStateTree(mt, scCodeStore), nil
 }
 
 func initConn() (*grpc.ClientConn, context.CancelFunc, error) {
@@ -95,7 +95,7 @@ func Test_MTServer_GetBalance(t *testing.T) {
 	}
 
 	expectedBalance := big.NewInt(100)
-	root, _, err := stree.SetBalance(common.HexToAddress(ethAddress), expectedBalance)
+	root, _, err := stree.SetBalance(common.HexToAddress(ethAddress), expectedBalance, nil)
 	if err != nil {
 		t.Fatalf("could not set balance: %v", err)
 	}

--- a/state/tree/tree.go
+++ b/state/tree/tree.go
@@ -16,24 +16,20 @@ const DefaultMerkleTreeArity = 4
 type StateTree struct {
 	mt          *MerkleTree
 	scCodeStore Store
-	currentRoot *big.Int
 }
 
 // NewStateTree creates new StateTree
-func NewStateTree(mt *MerkleTree, scCodeStore Store, root []byte) *StateTree {
+func NewStateTree(mt *MerkleTree, scCodeStore Store) *StateTree {
 	return &StateTree{
 		mt:          mt,
 		scCodeStore: scCodeStore,
-		currentRoot: new(big.Int).SetBytes(root),
 	}
 }
 
 // GetBalance returns balance
 func (tree *StateTree) GetBalance(address common.Address, root []byte) (*big.Int, error) {
-	r := tree.currentRoot
-	if root != nil {
-		r = new(big.Int).SetBytes(root)
-	}
+	r := new(big.Int).SetBytes(root)
+
 	key, err := GetKey(LeafTypeBalance, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, err
@@ -52,10 +48,8 @@ func (tree *StateTree) GetBalance(address common.Address, root []byte) (*big.Int
 
 // GetNonce returns nonce
 func (tree *StateTree) GetNonce(address common.Address, root []byte) (*big.Int, error) {
-	r := tree.currentRoot
-	if root != nil {
-		r = new(big.Int).SetBytes(root)
-	}
+	r := new(big.Int).SetBytes(root)
+
 	key, err := GetKey(LeafTypeNonce, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, err
@@ -74,10 +68,8 @@ func (tree *StateTree) GetNonce(address common.Address, root []byte) (*big.Int, 
 
 // GetCodeHash returns code hash
 func (tree *StateTree) GetCodeHash(address common.Address, root []byte) ([]byte, error) {
-	r := tree.currentRoot
-	if root != nil {
-		r = new(big.Int).SetBytes(root)
-	}
+	r := new(big.Int).SetBytes(root)
+
 	key, err := GetKey(LeafTypeCode, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, err
@@ -118,10 +110,8 @@ func (tree *StateTree) GetCode(address common.Address, root []byte) ([]byte, err
 
 // GetStorageAt returns Storage Value at specified position
 func (tree *StateTree) GetStorageAt(address common.Address, position common.Hash, root []byte) (*big.Int, error) {
-	r := tree.currentRoot
-	if root != nil {
-		r = new(big.Int).SetBytes(root)
-	}
+	r := new(big.Int).SetBytes(root)
+
 	key, err := GetKey(LeafTypeStorage, address, position[:], tree.mt.arity, nil)
 	if err != nil {
 		return nil, err
@@ -138,18 +128,13 @@ func (tree *StateTree) GetStorageAt(address common.Address, position common.Hash
 	return proof.Value, nil
 }
 
-// GetCurrentRoot returns current MerkleTree root hash
-func (tree *StateTree) GetCurrentRoot() ([]byte, error) {
-	return tree.currentRoot.Bytes(), nil
-}
-
 // SetBalance sets balance
-func (tree *StateTree) SetBalance(address common.Address, balance *big.Int) (newRoot []byte, proof *UpdateProof, err error) {
+func (tree *StateTree) SetBalance(address common.Address, balance *big.Int, root []byte) (newRoot []byte, proof *UpdateProof, err error) {
 	if balance.Cmp(big.NewInt(0)) == -1 {
 		return nil, nil, fmt.Errorf("invalid balance")
 	}
 
-	r := tree.currentRoot
+	r := new(big.Int).SetBytes(root)
 	key, err := GetKey(LeafTypeBalance, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, nil, err
@@ -161,18 +146,16 @@ func (tree *StateTree) SetBalance(address common.Address, balance *big.Int) (new
 		return nil, nil, err
 	}
 
-	tree.currentRoot = updateProof.NewRoot
-
 	return updateProof.NewRoot.Bytes(), updateProof, nil
 }
 
 // SetNonce sets nonce
-func (tree *StateTree) SetNonce(address common.Address, nonce *big.Int) (newRoot []byte, proof *UpdateProof, err error) {
+func (tree *StateTree) SetNonce(address common.Address, nonce *big.Int, root []byte) (newRoot []byte, proof *UpdateProof, err error) {
 	if nonce.Cmp(big.NewInt(0)) == -1 {
 		return nil, nil, fmt.Errorf("invalid nonce")
 	}
 
-	r := tree.currentRoot
+	r := new(big.Int).SetBytes(root)
 	key, err := GetKey(LeafTypeNonce, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, nil, err
@@ -184,13 +167,11 @@ func (tree *StateTree) SetNonce(address common.Address, nonce *big.Int) (newRoot
 		return nil, nil, err
 	}
 
-	tree.currentRoot = updateProof.NewRoot
-
 	return updateProof.NewRoot.Bytes(), updateProof, nil
 }
 
 // SetCode sets smart contract code
-func (tree *StateTree) SetCode(address common.Address, code []byte) (newRoot []byte, proof *UpdateProof, err error) {
+func (tree *StateTree) SetCode(address common.Address, code []byte, root []byte) (newRoot []byte, proof *UpdateProof, err error) {
 	if code == nil {
 		return nil, nil, fmt.Errorf("invalid smart contract code")
 	}
@@ -213,7 +194,7 @@ func (tree *StateTree) SetCode(address common.Address, code []byte) (newRoot []b
 	}
 
 	// set smart contract code hash as a leaf value in merkle tree
-	r := tree.currentRoot
+	r := new(big.Int).SetBytes(root)
 	key, err := GetKey(LeafTypeCode, address, nil, tree.mt.arity, nil)
 	if err != nil {
 		return nil, nil, err
@@ -225,14 +206,12 @@ func (tree *StateTree) SetCode(address common.Address, code []byte) (newRoot []b
 		return nil, nil, err
 	}
 
-	tree.currentRoot = updateProof.NewRoot
-
 	return updateProof.NewRoot.Bytes(), updateProof, nil
 }
 
 // SetStorageAt sets storage value at specified position
-func (tree *StateTree) SetStorageAt(address common.Address, position common.Hash, value *big.Int) (newRoot []byte, proof *UpdateProof, err error) {
-	r := tree.currentRoot
+func (tree *StateTree) SetStorageAt(address common.Address, position common.Hash, value *big.Int, root []byte) (newRoot []byte, proof *UpdateProof, err error) {
+	r := new(big.Int).SetBytes(root)
 	key, err := GetKey(LeafTypeStorage, address, position[:], tree.mt.arity, nil)
 	if err != nil {
 		return nil, nil, err
@@ -244,12 +223,5 @@ func (tree *StateTree) SetStorageAt(address common.Address, position common.Hash
 		return nil, nil, err
 	}
 
-	tree.currentRoot = updateProof.NewRoot
-
 	return updateProof.NewRoot.Bytes(), updateProof, nil
-}
-
-// SetCurrentRoot sets current root of the state tree
-func (tree *StateTree) SetCurrentRoot(root []byte) {
-	tree.currentRoot = new(big.Int).SetBytes(root)
 }

--- a/state/tree/tree_test.go
+++ b/state/tree/tree_test.go
@@ -42,7 +42,7 @@ func TestBasicTree(t *testing.T) {
 	store := NewPostgresStore(mtDb)
 	mt := NewMerkleTree(store, DefaultMerkleTreeArity, nil)
 	scCodeStore := NewPostgresSCCodeStore(mtDb)
-	tree := NewStateTree(mt, scCodeStore, nil)
+	tree := NewStateTree(mt, scCodeStore)
 
 	address := common.Address{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
@@ -54,35 +54,35 @@ func TestBasicTree(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), bal)
 
-	_, _, err = tree.SetBalance(address, big.NewInt(1))
+	root, _, err := tree.SetBalance(address, big.NewInt(1), nil)
 	require.NoError(t, err)
 
-	bal, err = tree.GetBalance(address, nil)
+	bal, err = tree.GetBalance(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(1), bal)
 
 	// Nonce
-	nonce, err := tree.GetNonce(address, nil)
+	nonce, err := tree.GetNonce(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), nonce)
 
-	_, _, err = tree.SetNonce(address, big.NewInt(2))
+	root, _, err = tree.SetNonce(address, big.NewInt(2), root)
 	require.NoError(t, err)
 
-	nonce, err = tree.GetNonce(address, nil)
+	nonce, err = tree.GetNonce(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(2), nonce)
 
 	// Code
-	code, err := tree.GetCode(address, nil)
+	code, err := tree.GetCode(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{}, code)
 
 	scCode, _ := hex.DecodeString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
-	_, _, err = tree.SetCode(address, scCode)
+	root, _, err = tree.SetCode(address, scCode, root)
 	require.NoError(t, err)
 
-	code, err = tree.GetCode(address, nil)
+	code, err = tree.GetCode(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, scCode, code)
 
@@ -93,14 +93,14 @@ func TestBasicTree(t *testing.T) {
 		0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
 		0x30, 0x31,
 	}
-	storage, err := tree.GetStorageAt(address, position, nil)
+	storage, err := tree.GetStorageAt(address, position, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), storage)
 
-	_, _, err = tree.SetStorageAt(address, position, big.NewInt(4))
+	root, _, err = tree.SetStorageAt(address, position, big.NewInt(4), root)
 	require.NoError(t, err)
 
-	storage, err = tree.GetStorageAt(address, position, nil)
+	storage, err = tree.GetStorageAt(address, position, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(4), storage)
 
@@ -111,27 +111,27 @@ func TestBasicTree(t *testing.T) {
 		0x31, 0x31,
 	}
 
-	storage2, err := tree.GetStorageAt(address, position2, nil)
+	storage2, err := tree.GetStorageAt(address, position2, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), storage2)
 
-	root, _, err := tree.SetStorageAt(address, position2, big.NewInt(5))
+	root, _, err = tree.SetStorageAt(address, position2, big.NewInt(5), root)
 	require.NoError(t, err)
 
-	storage2, err = tree.GetStorageAt(address, position2, nil)
+	storage2, err = tree.GetStorageAt(address, position2, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(5), storage2)
 
-	storage, err = tree.GetStorageAt(address, position, nil)
+	storage, err = tree.GetStorageAt(address, position, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(4), storage)
 
-	bal, err = tree.GetBalance(address, nil)
+	bal, err = tree.GetBalance(address, root)
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(1), bal)
 
 	balX, _ := new(big.Int).SetString("200000000000000000000", 10)
-	newRoot, _, err := tree.SetBalance(address, balX)
+	newRoot, _, err := tree.SetBalance(address, balX, root)
 	require.NoError(t, err)
 
 	bal, err = tree.GetBalance(address, newRoot)
@@ -182,9 +182,8 @@ func TestMerkleTreeGenesis(t *testing.T) {
 	for ti, testVector := range testVectors {
 		t.Run(fmt.Sprintf("Test vector %d", ti), func(t *testing.T) {
 			var root []byte
-			var newRoot []byte
 			mt := NewMerkleTree(store, testVector.Arity, nil)
-			tree := NewStateTree(mt, scCodeStore, root)
+			tree := NewStateTree(mt, scCodeStore)
 			for _, addrState := range testVector.Addresses {
 				// convert strings to big.Int
 				addr := common.HexToAddress(addrState.Address)
@@ -195,14 +194,14 @@ func TestMerkleTreeGenesis(t *testing.T) {
 				nonce, success := new(big.Int).SetString(addrState.Nonce, 10)
 				require.True(t, success)
 
-				_, _, err = tree.SetBalance(addr, balance)
+				root, _, err = tree.SetBalance(addr, balance, root)
 				require.NoError(t, err)
 
-				newRoot, _, err = tree.SetNonce(addr, nonce)
+				root, _, err = tree.SetNonce(addr, nonce, root)
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, testVector.ExpectedRoot, new(big.Int).SetBytes(newRoot).String())
+			assert.Equal(t, testVector.ExpectedRoot, new(big.Int).SetBytes(root).String())
 		})
 	}
 }

--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -276,7 +276,7 @@ func initState(arity uint8, defaultChainID uint64, maxCumulativeGasUsed uint64) 
 	store := tree.NewPostgresStore(sqlDB)
 	mt := tree.NewMerkleTree(store, arity, poseidon.Hash)
 	scCodeStore := tree.NewPostgresSCCodeStore(sqlDB)
-	tr := tree.NewStateTree(mt, scCodeStore, []byte{})
+	tr := tree.NewStateTree(mt, scCodeStore)
 
 	stateCfg := state.Config{
 		DefaultChainID:       defaultChainID,


### PR DESCRIPTION
Closes #415

### What does this PR do?

* Instead of storing the current root in a field of the merkle tree struct, the setter methods now accept a root parameter with the root on which the change should be enacted. 
* Removed the Get/Set current root methods from the merkletree interface
* Added a field in the state db `state.misc` table to store the current root.

### Reviewers

@arnaubennassar 
@OBrezhniev 
@ToniRamirezM 
@cool-develope 