### PR TITLE
Enable dependabot for go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Closes #457

### What does this PR do?

Adds dependabot config for updating golang dependencies, set to check for updates daily.

### Reviewers

@arnaubennassar 