### PR TITLE
include local config into the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN cd /src && make build
 FROM golang:1.17
 WORKDIR /app
 COPY --from=build /src/dist/hezcore /app/hezcore
+COPY --from=build /src/config/config.local.toml /app/config.local.toml
 EXPOSE 8123
 CMD ["./hezcore", "run"]


### PR DESCRIPTION
### What does this PR do?

This PR copy thelocal configuration file into the docker instance to avoid store this configuration in the bridge service repo

### Reviewers

- @arnaubennassar 
- @tclemos 