### PR TITLE
Fix updatedeps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
       - main
       - master
       - develop
-      - update-external-dependencies
   pull_request:
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
       - main
       - master
       - develop
-      - update-external-dependencies
   pull_request:
 jobs:
   test:

--- a/scripts/cmd/dependencies/files.go
+++ b/scripts/cmd/dependencies/files.go
@@ -37,7 +37,7 @@ func updateFiles(fs afero.Fs, sourceDir, targetDir string) error {
 				log.Errorf("Could not close %s: %v", sourceFile.Name(), err)
 			}
 		}()
-		targetFile, err := fs.OpenFile(wpath, os.O_RDWR, 0644)
+		targetFile, err := fs.OpenFile(wpath, os.O_RDWR|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Towards #480

### What does this PR do?

* Fixes the copy of new remote files by truncating the existing ones on open, it will prevent the resulting files from keeping old data like in https://github.com/hermeznetwork/hermez-core/pull/505/files#diff-8c5161b3d08bee59a0c411fddc470033afb9117a4dd2e5f3c9187be3e5ffcbdaR152  
* Removes the execution of tests on pushes to `update-external-dependencies` branch, now that the PR is created with commits from int-bot we are getting 2 executions per push like in https://github.com/hermeznetwork/hermez-core/pull/505 where we have one execution per push and another per pull_request.

Main reviewers:

@arnaubennassar 
@tclemos 
@cool-develope 