### PR TITLE
Manage errors during MT SQL queries

### DIFF
--- a/state/batchprocessor.go
+++ b/state/batchprocessor.go
@@ -677,6 +677,7 @@ func (b *BasicBatchProcessor) GetStorage(ctx context.Context, address common.Add
 	}
 
 	log.Debugf("GetStorage for address %v", address)
+
 	return common.BytesToHash(storage.Bytes())
 }
 
@@ -838,5 +839,6 @@ func (b *BasicBatchProcessor) GetNonce(ctx context.Context, address common.Addre
 	}
 
 	log.Debugf("GetNonce for address %v", address)
+
 	return nonce.Uint64()
 }


### PR DESCRIPTION
### What does this PR do?

Avoid MT to set transaction status into error so state transactions can work without problems, not being invalidated.

### Reviewers

Main reviewers:

- @arnaubennassar 
- @tclemos 
- @fgimenez 
- @ARR552 
