### PR TITLE
Remove state.storage interface

### DIFF
--- a/cmd/register.go
+++ b/cmd/register.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/db"
 	"github.com/hermeznetwork/hermez-core/log"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/iden3/go-iden3-crypto/poseidon"
 	"github.com/urfave/cli/v2"
@@ -62,7 +61,7 @@ func registerSequencer(ctx *cli.Context) error {
 		L2GlobalExitRootManagerPosition: c.NetworkConfig.L2GlobalExitRootManagerPosition,
 	}
 
-	stateDb := pgstatestorage.NewPostgresStorage(sqlDB)
+	stateDb := state.NewPostgresStorage(sqlDB)
 	st := state.NewState(stateCfg, stateDb, tr)
 
 	_, err = st.GetSequencer(ctx.Context, etherman.GetAddress())

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/proverclient"
 	"github.com/hermeznetwork/hermez-core/sequencer"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/state/tree/pb"
 	"github.com/hermeznetwork/hermez-core/synchronizer"
@@ -77,7 +76,7 @@ func start(ctx *cli.Context) error {
 		L2GlobalExitRootManagerPosition: c.NetworkConfig.L2GlobalExitRootManagerPosition,
 	}
 
-	stateDb := pgstatestorage.NewPostgresStorage(sqlDB)
+	stateDb := state.NewPostgresStorage(sqlDB)
 
 	var (
 		st              *state.State

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/pool"
 	"github.com/hermeznetwork/hermez-core/pool/pgpoolstorage"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/test/dbutils"
 	"github.com/iden3/go-iden3-crypto/poseidon"
@@ -436,7 +435,7 @@ func newState(sqlDB *pgxpool.Pool) *state.State {
 		MaxCumulativeGasUsed: 800000,
 	}
 
-	stateDB := pgstatestorage.NewPostgresStorage(sqlDB)
+	stateDB := state.NewPostgresStorage(sqlDB)
 	st := state.NewState(stateCfg, stateDB, tr)
 
 	return st

--- a/sequencer/sequencer_internal_test.go
+++ b/sequencer/sequencer_internal_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/sequencer/strategy/txprofitabilitychecker"
 	"github.com/hermeznetwork/hermez-core/sequencer/strategy/txselector"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/test/dbutils"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -138,7 +137,7 @@ func TestMain(m *testing.M) {
 	store := tree.NewPostgresStore(stateDB)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDB)
-	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore))
+	testState = state.NewState(stateCfg, state.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore))
 
 	intervalToProposeBatch := new(Duration)
 	_ = intervalToProposeBatch.UnmarshalText([]byte("5s"))

--- a/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
+++ b/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/log"
 	"github.com/hermeznetwork/hermez-core/sequencer/strategy/txprofitabilitychecker"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/test/dbutils"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -64,7 +63,7 @@ func TestMain(m *testing.M) {
 	store := tree.NewPostgresStore(stateDB)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDB)
-	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore))
+	testState = state.NewState(stateCfg, state.NewPostgresStorage(stateDB), tree.NewStateTree(mt, scCodeStore))
 	tx := types.NewTransaction(uint64(0), common.Address{}, big.NewInt(10), uint64(1), big.NewInt(10), []byte{})
 	txs = []*types.Transaction{tx}
 

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -3,10 +3,8 @@ package state
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 )
 
@@ -28,44 +26,4 @@ type merkletree interface {
 	SetNonce(ctx context.Context, address common.Address, nonce *big.Int, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
 	SetCode(ctx context.Context, address common.Address, code []byte, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
 	SetStorageAt(ctx context.Context, address common.Address, key *big.Int, value *big.Int, root []byte) (newRoot []byte, proof *tree.UpdateProof, err error)
-}
-
-// storage is the interface of the Hermez state methods that access database.
-type storage interface {
-	BeginDBTransaction(ctx context.Context) error
-	Commit(ctx context.Context) error
-	Rollback(ctx context.Context) error
-	GetLastBlock(ctx context.Context) (*Block, error)
-	GetPreviousBlock(ctx context.Context, offset uint64) (*Block, error)
-	GetBlockByHash(ctx context.Context, hash common.Hash) (*Block, error)
-	GetBlockByNumber(ctx context.Context, blockNumber uint64) (*Block, error)
-	GetLastBlockNumber(ctx context.Context) (uint64, error)
-	GetLastBatch(ctx context.Context, isVirtual bool) (*Batch, error)
-	GetPreviousBatch(ctx context.Context, isVirtual bool, offset uint64) (*Batch, error)
-	GetBatchByHash(ctx context.Context, hash common.Hash) (*Batch, error)
-	GetBatchByNumber(ctx context.Context, batchNumber uint64) (*Batch, error)
-	GetLastBatchByStateRoot(ctx context.Context, stateRoot []byte) (*Batch, error)
-	GetBatchHeader(ctx context.Context, batchNumber uint64) (*types.Header, error)
-	GetLastBatchNumber(ctx context.Context) (uint64, error)
-	GetLastConsolidatedBatchNumber(ctx context.Context) (uint64, error)
-	GetTransactionByBatchHashAndIndex(ctx context.Context, batchHash common.Hash, index uint64) (*types.Transaction, error)
-	GetTransactionByBatchNumberAndIndex(ctx context.Context, batchNumber uint64, index uint64) (*types.Transaction, error)
-	GetTransactionByHash(ctx context.Context, transactionHash common.Hash) (*types.Transaction, error)
-	GetTransactionCount(ctx context.Context, address common.Address) (uint64, error)
-	GetTransactionReceipt(ctx context.Context, transactionHash common.Hash) (*Receipt, error)
-	Reset(ctx context.Context, block *Block) error
-	ConsolidateBatch(ctx context.Context, batchNumber uint64, consolidatedTxHash common.Hash, consolidatedAt time.Time, aggregator common.Address) error
-	GetTxsByBatchNum(ctx context.Context, batchNum uint64) ([]*types.Transaction, error)
-	AddSequencer(ctx context.Context, seq Sequencer) error
-	GetSequencer(ctx context.Context, address common.Address) (*Sequencer, error)
-	AddBlock(ctx context.Context, block *Block) error
-	SetLastBatchNumberSeenOnEthereum(ctx context.Context, batchNumber uint64) error
-	GetLastBatchNumberSeenOnEthereum(ctx context.Context) (uint64, error)
-	AddBatch(ctx context.Context, batch *Batch) error
-	AddTransaction(ctx context.Context, tx *types.Transaction, batchNumber uint64, index uint) error
-	AddReceipt(ctx context.Context, receipt *Receipt) error
-	AddLog(ctx context.Context, log types.Log) error
-	GetLogs(ctx context.Context, fromBatch uint64, toBatch uint64, addresses []common.Address, topics [][]common.Hash, batchHash *common.Hash) ([]*types.Log, error)
-	SetLastBatchNumberConsolidatedOnEthereum(ctx context.Context, batchNumber uint64) error
-	GetLastBatchNumberConsolidatedOnEthereum(ctx context.Context) (uint64, error)
 }

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -1,4 +1,4 @@
-package pgstatestorage
+package state
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hermeznetwork/hermez-core/encoding"
 	"github.com/hermeznetwork/hermez-core/hex"
-	"github.com/hermeznetwork/hermez-core/state"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
@@ -80,7 +79,7 @@ func NewPostgresStorage(db *pgxpool.Pool) *PostgresStorage {
 // BeginDBTransaction starts a transaction block
 func (s *PostgresStorage) BeginDBTransaction(ctx context.Context) error {
 	if s.dbTx != nil {
-		return state.ErrAlreadyInitializedDBTransaction
+		return ErrAlreadyInitializedDBTransaction
 	}
 
 	dbTx, err := s.db.Begin(ctx)
@@ -99,7 +98,7 @@ func (s *PostgresStorage) Commit(ctx context.Context) error {
 		return err
 	}
 
-	return state.ErrNilDBTransaction
+	return ErrNilDBTransaction
 }
 
 // Rollback rollbacks a db transaction
@@ -110,7 +109,7 @@ func (s *PostgresStorage) Rollback(ctx context.Context) error {
 		return err
 	}
 
-	return state.ErrNilDBTransaction
+	return ErrNilDBTransaction
 }
 
 func (s *PostgresStorage) exec(ctx context.Context, sql string, arguments ...interface{}) (commandTag pgconn.CommandTag, err error) {
@@ -135,12 +134,12 @@ func (s *PostgresStorage) query(ctx context.Context, sql string, args ...interfa
 }
 
 // GetLastBlock gets the latest block
-func (s *PostgresStorage) GetLastBlock(ctx context.Context) (*state.Block, error) {
-	var block state.Block
+func (s *PostgresStorage) GetLastBlock(ctx context.Context) (*Block, error) {
+	var block Block
 	err := s.queryRow(ctx, getLastBlockSQL).Scan(&block.BlockNumber, &block.BlockHash, &block.ParentHash, &block.ReceivedAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrStateNotSynchronized
+		return nil, ErrStateNotSynchronized
 	} else if err != nil {
 		return nil, err
 	}
@@ -149,12 +148,12 @@ func (s *PostgresStorage) GetLastBlock(ctx context.Context) (*state.Block, error
 }
 
 // GetPreviousBlock gets the offset previous block respect to latest
-func (s *PostgresStorage) GetPreviousBlock(ctx context.Context, offset uint64) (*state.Block, error) {
-	var block state.Block
+func (s *PostgresStorage) GetPreviousBlock(ctx context.Context, offset uint64) (*Block, error) {
+	var block Block
 	err := s.queryRow(ctx, getPreviousBlockSQL, offset).Scan(&block.BlockNumber, &block.BlockHash, &block.ParentHash, &block.ReceivedAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -163,12 +162,12 @@ func (s *PostgresStorage) GetPreviousBlock(ctx context.Context, offset uint64) (
 }
 
 // GetBlockByHash gets the block with the required hash
-func (s *PostgresStorage) GetBlockByHash(ctx context.Context, hash common.Hash) (*state.Block, error) {
-	var block state.Block
+func (s *PostgresStorage) GetBlockByHash(ctx context.Context, hash common.Hash) (*Block, error) {
+	var block Block
 	err := s.queryRow(ctx, getBlockByHashSQL, hash).Scan(&block.BlockNumber, &block.BlockHash, &block.ParentHash, &block.ReceivedAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -177,12 +176,12 @@ func (s *PostgresStorage) GetBlockByHash(ctx context.Context, hash common.Hash) 
 }
 
 // GetBlockByNumber gets the block with the required number
-func (s *PostgresStorage) GetBlockByNumber(ctx context.Context, blockNumber uint64) (*state.Block, error) {
-	var block state.Block
+func (s *PostgresStorage) GetBlockByNumber(ctx context.Context, blockNumber uint64) (*Block, error) {
+	var block Block
 	err := s.queryRow(ctx, getBlockByNumberSQL, blockNumber).Scan(&block.BlockNumber, &block.BlockHash, &block.ParentHash, &block.ReceivedAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -196,7 +195,7 @@ func (s *PostgresStorage) GetLastBlockNumber(ctx context.Context) (uint64, error
 	err := s.queryRow(ctx, getLastBlockNumberSQL).Scan(&lastBlockNum)
 
 	if reflect.TypeOf(err) == reflect.TypeOf(pgx.ScanArgError{}) {
-		return 0, state.ErrStateNotSynchronized
+		return 0, ErrStateNotSynchronized
 	} else if err != nil {
 		return 0, err
 	}
@@ -205,9 +204,9 @@ func (s *PostgresStorage) GetLastBlockNumber(ctx context.Context) (uint64, error
 }
 
 // GetLastBatch gets the latest batch
-func (s *PostgresStorage) GetLastBatch(ctx context.Context, isVirtual bool) (*state.Batch, error) {
+func (s *PostgresStorage) GetLastBatch(ctx context.Context, isVirtual bool) (*Batch, error) {
 	var (
-		batch           state.Batch
+		batch           Batch
 		maticCollateral pgtype.Numeric
 
 		chain uint64
@@ -228,7 +227,7 @@ func (s *PostgresStorage) GetLastBatch(ctx context.Context, isVirtual bool) (*st
 	batch.ChainID = new(big.Int).SetUint64(chain)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrStateNotSynchronized
+		return nil, ErrStateNotSynchronized
 	} else if err != nil {
 		return nil, err
 	}
@@ -239,9 +238,9 @@ func (s *PostgresStorage) GetLastBatch(ctx context.Context, isVirtual bool) (*st
 }
 
 // GetPreviousBatch gets the offset previous batch respect to latest
-func (s *PostgresStorage) GetPreviousBatch(ctx context.Context, isVirtual bool, offset uint64) (*state.Batch, error) {
+func (s *PostgresStorage) GetPreviousBatch(ctx context.Context, isVirtual bool, offset uint64) (*Batch, error) {
 	var (
-		batch           state.Batch
+		batch           Batch
 		maticCollateral pgtype.Numeric
 
 		chain uint64
@@ -262,7 +261,7 @@ func (s *PostgresStorage) GetPreviousBatch(ctx context.Context, isVirtual bool, 
 	batch.ChainID = new(big.Int).SetUint64(chain)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -272,9 +271,9 @@ func (s *PostgresStorage) GetPreviousBatch(ctx context.Context, isVirtual bool, 
 }
 
 // GetBatchByHash gets the batch with the required hash
-func (s *PostgresStorage) GetBatchByHash(ctx context.Context, hash common.Hash) (*state.Batch, error) {
+func (s *PostgresStorage) GetBatchByHash(ctx context.Context, hash common.Hash) (*Batch, error) {
 	var (
-		batch           state.Batch
+		batch           Batch
 		maticCollateral pgtype.Numeric
 		chain           uint64
 	)
@@ -283,7 +282,7 @@ func (s *PostgresStorage) GetBatchByHash(ctx context.Context, hash common.Hash) 
 		&batch.Header, &batch.Uncles, &batch.RawTxsData, &maticCollateral,
 		&batch.ReceivedAt, &batch.ConsolidatedAt, &chain, &batch.GlobalExitRoot, &batch.GlobalExitRoot)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -299,7 +298,7 @@ func (s *PostgresStorage) GetBatchByHash(ctx context.Context, hash common.Hash) 
 }
 
 // GetBatchByNumber gets the batch with the required number
-func (s *PostgresStorage) GetBatchByNumber(ctx context.Context, batchNumber uint64) (*state.Batch, error) {
+func (s *PostgresStorage) GetBatchByNumber(ctx context.Context, batchNumber uint64) (*Batch, error) {
 	batch, err := s.getBatchWithoutTxsByNumber(ctx, batchNumber)
 	if err != nil {
 		return nil, err
@@ -314,7 +313,7 @@ func (s *PostgresStorage) GetBatchByNumber(ctx context.Context, batchNumber uint
 }
 
 // GetLastBatchByStateRoot gets the last batch with the required state root
-func (s *PostgresStorage) GetLastBatchByStateRoot(ctx context.Context, stateRoot []byte) (*state.Batch, error) {
+func (s *PostgresStorage) GetLastBatchByStateRoot(ctx context.Context, stateRoot []byte) (*Batch, error) {
 	batch, err := s.getLastBatchWithoutTxsByStateRoot(ctx, stateRoot)
 	if err != nil {
 		return nil, err
@@ -367,7 +366,7 @@ func (s *PostgresStorage) GetTransactionByBatchHashAndIndex(ctx context.Context,
 	err := s.queryRow(ctx, getTransactionByBatchHashAndIndexSQL, batchHash.Bytes(), index).Scan(&encoded)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -391,7 +390,7 @@ func (s *PostgresStorage) GetTransactionByBatchNumberAndIndex(ctx context.Contex
 	err := s.queryRow(ctx, getTransactionByBatchNumberAndIndexSQL, batchNumber, index).Scan(&encoded)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -415,7 +414,7 @@ func (s *PostgresStorage) GetTransactionByHash(ctx context.Context, transactionH
 	err := s.queryRow(ctx, getTransactionByHashSQL, transactionHash).Scan(&encoded)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -444,8 +443,8 @@ func (s *PostgresStorage) GetTransactionCount(ctx context.Context, fromAddress c
 }
 
 // GetTransactionReceipt returns the receipt of a transaction by transaction hash
-func (s *PostgresStorage) GetTransactionReceipt(ctx context.Context, transactionHash common.Hash) (*state.Receipt, error) {
-	var receipt state.Receipt
+func (s *PostgresStorage) GetTransactionReceipt(ctx context.Context, transactionHash common.Hash) (*Receipt, error) {
+	var receipt Receipt
 	var batchNumber uint64
 	var to *[]byte
 
@@ -453,7 +452,7 @@ func (s *PostgresStorage) GetTransactionReceipt(ctx context.Context, transaction
 		&receipt.CumulativeGasUsed, &receipt.GasUsed, &batchNumber, &receipt.BlockHash, &receipt.TxHash, &receipt.TransactionIndex, &receipt.From, &to, &receipt.ContractAddress)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -586,7 +585,7 @@ func (s *PostgresStorage) GetLogs(ctx context.Context, fromBatch uint64, toBatch
 }
 
 // Reset resets the state to a block
-func (s *PostgresStorage) Reset(ctx context.Context, block *state.Block) error {
+func (s *PostgresStorage) Reset(ctx context.Context, block *Block) error {
 	if _, err := s.exec(ctx, resetSQL, block.BlockNumber); err != nil {
 		return err
 	}
@@ -611,7 +610,7 @@ func (s *PostgresStorage) GetTxsByBatchNum(ctx context.Context, batchNum uint64)
 	rows, err := s.query(ctx, getTxsByBatchNumSQL, batchNum)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -646,19 +645,19 @@ func (s *PostgresStorage) GetTxsByBatchNum(ctx context.Context, batchNum uint64)
 }
 
 // AddSequencer stores a new sequencer
-func (s *PostgresStorage) AddSequencer(ctx context.Context, seq state.Sequencer) error {
+func (s *PostgresStorage) AddSequencer(ctx context.Context, seq Sequencer) error {
 	_, err := s.exec(ctx, addSequencerSQL, seq.Address, seq.URL, seq.ChainID.Uint64(), seq.BlockNumber)
 	return err
 }
 
 // GetSequencer gets a sequencer
-func (s *PostgresStorage) GetSequencer(ctx context.Context, address common.Address) (*state.Sequencer, error) {
-	var seq state.Sequencer
+func (s *PostgresStorage) GetSequencer(ctx context.Context, address common.Address) (*Sequencer, error) {
+	var seq Sequencer
 	var cID uint64
 	err := s.queryRow(ctx, getSequencerSQL, address.Bytes()).Scan(&seq.Address, &seq.URL, &cID, &seq.BlockNumber)
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -669,7 +668,7 @@ func (s *PostgresStorage) GetSequencer(ctx context.Context, address common.Addre
 }
 
 // AddBlock adds a new block to the State Store
-func (s *PostgresStorage) AddBlock(ctx context.Context, block *state.Block) error {
+func (s *PostgresStorage) AddBlock(ctx context.Context, block *Block) error {
 	_, err := s.exec(ctx, addBlockSQL, block.BlockNumber, block.BlockHash.Bytes(), block.ParentHash.Bytes(), block.ReceivedAt)
 	return err
 }
@@ -715,7 +714,7 @@ func (s *PostgresStorage) GetLastBatchNumberConsolidatedOnEthereum(ctx context.C
 }
 
 // AddBatch adds a new batch to the State Store
-func (s *PostgresStorage) AddBatch(ctx context.Context, batch *state.Batch) error {
+func (s *PostgresStorage) AddBatch(ctx context.Context, batch *Batch) error {
 	_, err := s.exec(ctx, addBatchSQL, batch.Number().Uint64(), batch.Hash(), batch.BlockNumber, batch.Sequencer, batch.Aggregator,
 		batch.ConsolidatedTxHash, batch.Header, batch.Uncles, batch.RawTxsData, batch.MaticCollateral.String(), batch.ReceivedAt, batch.ChainID.String(), batch.GlobalExitRoot, batch.RollupExitRoot)
 	return err
@@ -740,7 +739,7 @@ func (s *PostgresStorage) AddTransaction(ctx context.Context, tx *types.Transact
 }
 
 // AddReceipt adds a new receipt to the State Store
-func (s *PostgresStorage) AddReceipt(ctx context.Context, receipt *state.Receipt) error {
+func (s *PostgresStorage) AddReceipt(ctx context.Context, receipt *Receipt) error {
 	var to *[]byte = nil
 	if receipt.To != nil {
 		b := receipt.To.Bytes()
@@ -765,7 +764,7 @@ func (s *PostgresStorage) AddLog(ctx context.Context, l types.Log) error {
 	return err
 }
 
-func (s *PostgresStorage) getBatchTransactions(ctx context.Context, batch state.Batch) ([]*types.Transaction, error) {
+func (s *PostgresStorage) getBatchTransactions(ctx context.Context, batch Batch) ([]*types.Transaction, error) {
 	transactions, err := s.GetTxsByBatchNum(ctx, batch.Number().Uint64())
 	if errors.Is(err, pgx.ErrNoRows) {
 		transactions = []*types.Transaction{}
@@ -776,9 +775,9 @@ func (s *PostgresStorage) getBatchTransactions(ctx context.Context, batch state.
 	return transactions, nil
 }
 
-func (s *PostgresStorage) getBatchWithoutTxsByNumber(ctx context.Context, batchNumber uint64) (*state.Batch, error) {
+func (s *PostgresStorage) getBatchWithoutTxsByNumber(ctx context.Context, batchNumber uint64) (*Batch, error) {
 	var (
-		batch           state.Batch
+		batch           Batch
 		maticCollateral pgtype.Numeric
 		chain           uint64
 	)
@@ -787,7 +786,7 @@ func (s *PostgresStorage) getBatchWithoutTxsByNumber(ctx context.Context, batchN
 		&batch.Header, &batch.Uncles, &batch.RawTxsData, &maticCollateral,
 		&batch.ReceivedAt, &batch.ConsolidatedAt, &chain, &batch.GlobalExitRoot, &batch.RollupExitRoot)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -798,9 +797,9 @@ func (s *PostgresStorage) getBatchWithoutTxsByNumber(ctx context.Context, batchN
 	return &batch, nil
 }
 
-func (s *PostgresStorage) getLastBatchWithoutTxsByStateRoot(ctx context.Context, stateRoot []byte) (*state.Batch, error) {
+func (s *PostgresStorage) getLastBatchWithoutTxsByStateRoot(ctx context.Context, stateRoot []byte) (*Batch, error) {
 	var (
-		batch           state.Batch
+		batch           Batch
 		maticCollateral pgtype.Numeric
 		chain           uint64
 	)
@@ -809,7 +808,7 @@ func (s *PostgresStorage) getLastBatchWithoutTxsByStateRoot(ctx context.Context,
 		&batch.Header, &batch.Uncles, &batch.RawTxsData, &maticCollateral,
 		&batch.ReceivedAt, &batch.ConsolidatedAt, &chain, &batch.GlobalExitRoot, &batch.RollupExitRoot)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, state.ErrNotFound
+		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -38,17 +38,17 @@ var (
 type State struct {
 	cfg  Config
 	tree merkletree
-	storage
+	*PostgresStorage
 }
 
 // NewState creates a new State
-func NewState(cfg Config, storage storage, tree merkletree) *State {
-	return &State{cfg: cfg, tree: tree, storage: storage}
+func NewState(cfg Config, storage *PostgresStorage, tree merkletree) *State {
+	return &State{cfg: cfg, tree: tree, PostgresStorage: storage}
 }
 
 // BeginStateTransaction starts a transaction block
 func (s *State) BeginStateTransaction(ctx context.Context) error {
-	err := s.storage.BeginDBTransaction(ctx)
+	err := s.PostgresStorage.BeginDBTransaction(ctx)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (s *State) BeginStateTransaction(ctx context.Context) error {
 
 // CommitState commits a state into db
 func (s *State) CommitState(ctx context.Context) error {
-	err := s.storage.Commit(ctx)
+	err := s.PostgresStorage.Commit(ctx)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (s *State) CommitState(ctx context.Context) error {
 
 // RollbackState rollbacks a db state transaction
 func (s *State) RollbackState(ctx context.Context) error {
-	err := s.storage.Rollback(ctx)
+	err := s.PostgresStorage.Rollback(ctx)
 	if err != nil {
 		return err
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/log"
 	"github.com/hermeznetwork/hermez-core/scripts/cmd/compilesc"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/test/dbutils"
 	"github.com/hermeznetwork/hermez-core/test/vectors"
@@ -76,7 +75,7 @@ func TestMain(m *testing.M) {
 	store := tree.NewPostgresStore(stateDb)
 	mt := tree.NewMerkleTree(store, tree.DefaultMerkleTreeArity, nil)
 	scCodeStore := tree.NewPostgresSCCodeStore(stateDb)
-	testState = state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
+	testState = state.NewState(stateCfg, state.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 
 	setUpBlocks()
 	setUpBatches()
@@ -460,7 +459,7 @@ func TestStateTransition(t *testing.T) {
 			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
-			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+			st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 			genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 			genesisBlock.ReceivedAt = time.Now()
 			genesis := state.Genesis{
@@ -605,7 +604,7 @@ func TestStateTransitionSC(t *testing.T) {
 			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
-			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+			st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 			genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 			genesisBlock.ReceivedAt = time.Now()
 			genesis := state.Genesis{
@@ -635,7 +634,7 @@ func TestLastSeenBatch(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -680,7 +679,7 @@ func TestReceipts(t *testing.T) {
 			stateTree := tree.NewStateTree(mt, scCodeStore)
 
 			// Create state
-			st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+			st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 			genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 			genesisBlock.ReceivedAt = time.Now()
@@ -840,7 +839,7 @@ func TestLastConsolidatedBatch(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -874,7 +873,7 @@ func TestStateErrors(t *testing.T) {
 
 	// Create state
 	scCodeStore := tree.NewPostgresSCCodeStore(mtDb)
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), tree.NewStateTree(mt, scCodeStore))
 	ctx := context.Background()
 
 	// Clean Up to reset Genesis
@@ -974,7 +973,7 @@ func TestSCExecution(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1102,7 +1101,7 @@ func TestSCCall(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1238,7 +1237,7 @@ func TestGenesisStorage(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1288,7 +1287,7 @@ func TestSCSelfDestruct(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1394,7 +1393,7 @@ func TestEmitLog(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1743,7 +1742,7 @@ func TestEstimateGas(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()
@@ -1870,7 +1869,7 @@ func TestStorageOnDeploy(t *testing.T) {
 	stateTree := tree.NewStateTree(mt, scCodeStore)
 
 	// Create state
-	st := state.NewState(stateCfg, pgstatestorage.NewPostgresStorage(stateDb), stateTree)
+	st := state.NewState(stateCfg, state.NewPostgresStorage(stateDb), stateTree)
 
 	genesisBlock := types.NewBlock(&types.Header{Number: big.NewInt(0)}, []*types.Transaction{}, []*types.Header{}, []*types.Receipt{}, &trie.StackTrie{})
 	genesisBlock.ReceivedAt = time.Now()

--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hermeznetwork/hermez-core/etherman"
 	"github.com/hermeznetwork/hermez-core/hex"
 	"github.com/hermeznetwork/hermez-core/state"
-	"github.com/hermeznetwork/hermez-core/state/pgstatestorage"
 	"github.com/hermeznetwork/hermez-core/state/tree"
 	"github.com/hermeznetwork/hermez-core/test/dbutils"
 	"github.com/hermeznetwork/hermez-core/test/vectors"
@@ -277,7 +276,7 @@ func initState(arity uint8, defaultChainID uint64, maxCumulativeGasUsed uint64) 
 		MaxCumulativeGasUsed: maxCumulativeGasUsed,
 	}
 
-	stateDB := pgstatestorage.NewPostgresStorage(sqlDB)
+	stateDB := state.NewPostgresStorage(sqlDB)
 	return state.NewState(stateCfg, stateDB, tr), nil
 }
 


### PR DESCRIPTION
Closes #533

### What does this PR do?

Removes `state.storage` interface by moving `PostgresStorage` to the state package.

### Reviewers

@ToniRamirezM 
@arnaubennassar 
@cool-develope 