### PR TITLE
allow sc creation txs to be estimated

### DIFF
--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -136,7 +136,14 @@ func (arg *txnArgs) ToTransaction() *types.Transaction {
 		data = *arg.Data
 	}
 
-	tx := types.NewTransaction(nonce, *arg.To, value, gas, gasPrice, data)
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    nonce,
+		To:       arg.To,
+		Value:    value,
+		Gas:      gas,
+		GasPrice: gasPrice,
+		Data:     data,
+	})
 
 	return tx
 }


### PR DESCRIPTION
Closes #541.

### What does this PR do?

Change the way the JSON RPC works with the eth_estimateGas parameters to allow the field `To` to be set as `null`

### Reviewers

Main reviewers:

- @Toni