### PR TITLE
allow 'pending' block to be used as filter for JSON RPC methods

### DIFF
--- a/jsonrpc/eth.go
+++ b/jsonrpc/eth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -163,6 +164,22 @@ func (e *Eth) GetBlockByHash(hash common.Hash, fullTx bool) (interface{}, error)
 // GetBlockByNumber returns information about a block by block number
 func (e *Eth) GetBlockByNumber(number BlockNumber, fullTx bool) (interface{}, error) {
 	ctx := context.Background()
+
+	if number == PendingBlockNumber {
+		lastBatch, err := e.state.GetLastBatch(context.Background(), true)
+		if err != nil {
+			return nil, err
+		}
+		header := &types.Header{
+			ParentHash: lastBatch.Hash(),
+			Number:     big.NewInt(0).SetUint64(lastBatch.Number().Uint64() + 1),
+			Difficulty: big.NewInt(0),
+		}
+		batch := &state.Batch{Header: header}
+		block := batchToRPCBlock(batch, fullTx)
+
+		return block, nil
+	}
 
 	batchNumber, err := e.getNumericBlockNumber(ctx, number)
 	if err != nil {
@@ -368,18 +385,16 @@ func (e *Eth) SendRawTransaction(input string) (interface{}, error) {
 
 func (e *Eth) getNumericBlockNumber(ctx context.Context, number BlockNumber) (uint64, error) {
 	switch number {
-	case LatestBlockNumber:
+	case LatestBlockNumber, PendingBlockNumber:
 		lastBatchNumber, err := e.state.GetLastBatchNumber(ctx)
 		if err != nil {
 			return 0, err
 		}
 
 		return lastBatchNumber, nil
-	case EarliestBlockNumber:
-		return 0, fmt.Errorf("fetching the earliest header is not supported")
 
-	case PendingBlockNumber:
-		return 0, fmt.Errorf("fetching the pending header is not supported")
+	case EarliestBlockNumber:
+		return 0, nil
 
 	default:
 		if number < 0 {
@@ -440,7 +455,16 @@ func (e *Eth) getBatchHeader(number BlockNumber) (*types.Header, error) {
 		return e.state.GetBatchHeader(context.Background(), uint64(0))
 
 	case PendingBlockNumber:
-		return nil, fmt.Errorf("fetching the pending header is not supported")
+		lastBatch, err := e.state.GetLastBatch(context.Background(), true)
+		if err != nil {
+			return nil, err
+		}
+		header := &types.Header{
+			ParentHash: lastBatch.Hash(),
+			Number:     big.NewInt(0).SetUint64(lastBatch.Number().Uint64() + 1),
+			Difficulty: big.NewInt(0),
+		}
+		return header, nil
 
 	default:
 		return e.state.GetBatchHeader(context.Background(), uint64(number))


### PR DESCRIPTION
Closes #543.

### What does this PR do?

As required by the code generated by `abigen`, this PR adds support to filter by `pending` for all the methods in the `JSON RPC` that allows the block number to be filtered.

It also adds support to the `earliest` block, which in our case is always `zero`.

### Reviewers

Main reviewers:

- @ARR552 
- @ToniRamirezM 