### PR TITLE
Fixes for MT node cache.

### DIFF
--- a/state/tree/cache.go
+++ b/state/tree/cache.go
@@ -2,11 +2,9 @@ package tree
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/dgraph-io/ristretto"
-	poseidon "github.com/iden3/go-iden3-crypto/goldenposeidon"
 )
 
 const (
@@ -55,9 +53,6 @@ func newNodeCache() *nodeCache {
 
 // get reads a MT node cache entry.
 func (nc *nodeCache) get(key []uint64) ([]uint64, error) {
-	if len(key) != poseidon.CAPLEN {
-		return nil, fmt.Errorf("Invalid key length should be %d", poseidon.CAPLEN)
-	}
 	keyStr := h4ToString(key)
 
 	item, ok := nc.data[keyStr]
@@ -71,9 +66,6 @@ func (nc *nodeCache) get(key []uint64) ([]uint64, error) {
 func (nc *nodeCache) set(key []uint64, value []uint64) error {
 	if len(nc.data) >= maxMTNodeCacheEntries {
 		return errors.New("MT node cache is full")
-	}
-	if len(key) != poseidon.CAPLEN {
-		return fmt.Errorf("Invalid key length, should be %d", poseidon.CAPLEN)
 	}
 	keyStr := h4ToString(key)
 

--- a/state/tree/cache_test.go
+++ b/state/tree/cache_test.go
@@ -102,13 +102,6 @@ func TestMTNodeCacheSet(t *testing.T) {
 				"0x0000000000000002000000000000000100000000000000010000000000000001": {16},
 			},
 		},
-		{
-			description:    "key length != 4 causes error",
-			key:            [][]uint64{{1, 1, 1}},
-			value:          [][]uint64{{15}},
-			expectedErr:    true,
-			expectedErrMsg: "Invalid key length, should be 4",
-		},
 	}
 
 	for _, tc := range tcs {

--- a/state/tree/tree.go
+++ b/state/tree/tree.go
@@ -48,7 +48,7 @@ func (tree *StateTree) BeginDBTransaction(ctx context.Context) error {
 
 // Commit commits a db transaction
 func (tree *StateTree) Commit(ctx context.Context) error {
-	err := tree.mt.store.Commit(ctx)
+	err := tree.mt.Commit(ctx)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (tree *StateTree) Commit(ctx context.Context) error {
 
 // Rollback rollbacks a db transaction
 func (tree *StateTree) Rollback(ctx context.Context) error {
-	err := tree.mt.store.Rollback(ctx)
+	err := tree.mt.Rollback(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

* Fixes a bug in state tree, it was calling `Commit` method directly on the MT store, circumventing the node cache setup.
* Allows keys with more than 4 items in node cache, for leaves they are greater. Only the first 4 elements will be taken into account to generate the key index (same as in MT store).

### Reviewers

@ARR552 
@ToniRamirezM 