### PR TITLE
Remove basic naming

### DIFF
--- a/jsonrpc/interfaces.go
+++ b/jsonrpc/interfaces.go
@@ -31,7 +31,7 @@ type stateInterface interface {
 	GetTransactionReceipt(ctx context.Context, transactionHash common.Hash) (*state.Receipt, error)
 	GetLastBatchNumber(ctx context.Context) (uint64, error)
 	GetLastBatch(ctx context.Context, isVirtual bool) (*state.Batch, error)
-	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BasicBatchProcessor, error)
+	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BatchProcessor, error)
 	EstimateGas(transaction *types.Transaction) (uint64, error)
 	GetBalance(ctx context.Context, address common.Address, batchNumber uint64) (*big.Int, error)
 	GetBatchByHash(ctx context.Context, hash common.Hash) (*state.Batch, error)

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -41,5 +41,5 @@ type stateInterface interface {
 	GetLastBatchNumber(ctx context.Context) (uint64, error)
 	GetLastBatchNumberSeenOnEthereum(ctx context.Context) (uint64, error)
 	GetLastBatchByStateRoot(ctx context.Context, stateRoot []byte) (*state.Batch, error)
-	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BasicBatchProcessor, error)
+	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BatchProcessor, error)
 }

--- a/sequencer/sequencer_internal_test.go
+++ b/sequencer/sequencer_internal_test.go
@@ -31,7 +31,7 @@ import (
 type stateTestInterface interface {
 	stateInterface
 	// following methods used for tests
-	NewGenesisBatchProcessor(genesisStateRoot []byte) (*state.BasicBatchProcessor, error)
+	NewGenesisBatchProcessor(genesisStateRoot []byte) (*state.BatchProcessor, error)
 	GetNonce(ctx context.Context, address common.Address, batchNumber uint64) (uint64, error)
 	GetBalance(ctx context.Context, address common.Address, batchNumber uint64) (*big.Int, error)
 	SetLastBatchNumberSeenOnEthereum(ctx context.Context, batchNumber uint64) error

--- a/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
+++ b/sequencer/strategy/txprofitabilitychecker/txprofitabilitychecker_test.go
@@ -24,7 +24,7 @@ import (
 // stateInterface gathers the methods required to interact with the state.
 type stateInterface interface {
 	GetLastBatch(ctx context.Context, isVirtual bool) (*state.Batch, error)
-	NewGenesisBatchProcessor(genesisStateRoot []byte) (*state.BasicBatchProcessor, error)
+	NewGenesisBatchProcessor(genesisStateRoot []byte) (*state.BatchProcessor, error)
 }
 
 var (

--- a/state/state.go
+++ b/state/state.go
@@ -74,7 +74,7 @@ func (s *State) RollbackState(ctx context.Context) error {
 }
 
 // NewBatchProcessor creates a new batch processor
-func (s *State) NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*BasicBatchProcessor, error) {
+func (s *State) NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*BatchProcessor, error) {
 	// Get Sequencer's Chain ID
 	chainID := s.cfg.DefaultChainID
 	sq, err := s.GetSequencer(ctx, sequencerAddress)
@@ -95,18 +95,18 @@ func (s *State) NewBatchProcessor(ctx context.Context, sequencerAddress common.A
 	}
 	host.forks = runtime.AllForksEnabled.At(blockNumber)
 
-	batchProcessor := &BasicBatchProcessor{SequencerAddress: sequencerAddress, SequencerChainID: chainID, LastBatch: lastBatch, MaxCumulativeGasUsed: s.cfg.MaxCumulativeGasUsed, Host: host}
+	batchProcessor := &BatchProcessor{SequencerAddress: sequencerAddress, SequencerChainID: chainID, LastBatch: lastBatch, MaxCumulativeGasUsed: s.cfg.MaxCumulativeGasUsed, Host: host}
 	batchProcessor.Host.setRuntime(evm.NewEVM())
 
 	return batchProcessor, nil
 }
 
 // NewGenesisBatchProcessor creates a new batch processor
-func (s *State) NewGenesisBatchProcessor(genesisStateRoot []byte) (*BasicBatchProcessor, error) {
+func (s *State) NewGenesisBatchProcessor(genesisStateRoot []byte) (*BatchProcessor, error) {
 	host := Host{State: s, stateRoot: genesisStateRoot, transactionContext: transactionContext{difficulty: new(big.Int)}}
 	host.setRuntime(evm.NewEVM())
 	host.forks = runtime.AllForksEnabled.At(0)
-	return &BasicBatchProcessor{Host: host}, nil
+	return &BatchProcessor{Host: host}, nil
 }
 
 // GetStateRoot returns the root of the state tree

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -39,7 +39,7 @@ type stateInterface interface {
 	RollbackState(ctx context.Context) error
 	AddBlock(ctx context.Context, block *state.Block) error
 	ConsolidateBatch(ctx context.Context, batchNumber uint64, consolidatedTxHash common.Hash, consolidatedAt time.Time, aggregator common.Address) error
-	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BasicBatchProcessor, error)
+	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte) (*state.BatchProcessor, error)
 	AddSequencer(ctx context.Context, seq state.Sequencer) error
 	CommitState(ctx context.Context) error
 	Reset(ctx context.Context, block *state.Block) error


### PR DESCRIPTION
Closes #507

### What does this PR do?

Rename `BasicBatchProcessor` to `BatchProcessor`