### PR TITLE
Increment nonce during SC execution

### DIFF
--- a/state/batchprocessor.go
+++ b/state/batchprocessor.go
@@ -584,30 +584,28 @@ func (b *BatchProcessor) execute(ctx context.Context, tx *types.Transaction, sen
 	log.Debugf("Transaction Data %v", tx.Data())
 	log.Debugf("Returned value from execution: %v", "0x"+hex.EncodeToString(result.ReturnValue))
 
-	if result.Succeeded() {
-		// Increment sender nonce
-		senderNonce, err := b.Host.State.tree.GetNonce(ctx, senderAddress, b.Host.stateRoot)
-		if err != nil {
-			result.Err = err
-			result.StateRoot = b.Host.stateRoot
-			return result
-		}
-
-		// Increment nonce of the sender
-		senderNonce.Add(senderNonce, big.NewInt(1))
-
-		// Store new nonce
-		root, _, err := b.Host.State.tree.SetNonce(ctx, senderAddress, senderNonce, b.Host.stateRoot)
-		if err != nil {
-			result.Err = err
-			result.StateRoot = b.Host.stateRoot
-			return result
-		}
-
-		b.Host.stateRoot = root
+	// Increment sender nonce
+	senderNonce, err := b.Host.State.tree.GetNonce(ctx, senderAddress, b.Host.stateRoot)
+	if err != nil {
+		result.Err = err
+		result.StateRoot = b.Host.stateRoot
+		return result
 	}
 
+	// Increment nonce of the sender
+	senderNonce.Add(senderNonce, big.NewInt(1))
+
+	// Store new nonce
+	root, _, err := b.Host.State.tree.SetNonce(ctx, senderAddress, senderNonce, b.Host.stateRoot)
+	if err != nil {
+		result.Err = err
+		result.StateRoot = b.Host.stateRoot
+		return result
+	}
+
+	b.Host.stateRoot = root
 	result.StateRoot = b.Host.stateRoot
+
 	return result
 }
 


### PR DESCRIPTION
Closes #590 

### What does this PR do?

Nonce of the sender was not being incremented when a SC execution transaction was processed. This PR fixes it.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @ARR552 
- @tclemos 
- @arnaubennassar 
