### PR TITLE
Increase MT node cache size

### DIFF
--- a/state/tree/cache.go
+++ b/state/tree/cache.go
@@ -36,7 +36,7 @@ type nodeCache struct {
 }
 
 const (
-	maxMTNodeCacheEntries = 256
+	maxMTNodeCacheEntries = 65536
 )
 
 var (


### PR DESCRIPTION
Closes #589

### What does this PR do?

Besides the errors described in #589 we were getting this in the core logs before the `Error: not found` entry:
```
2022-04-19T08:55:01Z	ERROR	tree/merkletree.go:539	Error setting data in MT node cache: MT node cache is full%!(EXTRA string=
/src/log/log.go:106 github.com/hermeznetwork/hermez-core/log.appendStackTraceMaybeArgs()
/src/log/log.go:164 github.com/hermeznetwork/hermez-core/log.Errorf()
/src/state/tree/merkletree.go:539 github.com/hermeznetwork/hermez-core/state/tree.(*MerkleTree).setNodeData()
/src/state/tree/merkletree.go:525 github.com/hermeznetwork/hermez-core/state/tree.(*MerkleTree).hashSave()
/src/state/tree/merkletree.go:378 github.com/hermeznetwork/hermez-core/state/tree.(*MerkleTree).Set()
/src/state/tree/tree.go:275 github.com/hermeznetwork/hermez-core/state/tree.(*StateTree).SetStorageAt()
/src/state/host.go:56 github.com/hermeznetwork/hermez-core/state.(*Host).SetStorage()
/src/state/runtime/evm/intructions.go:488 github.com/hermeznetwork/hermez-core/state/runtime/evm.opSStore()
/src/state/runtime/evm/state.go:258 github.com/hermeznetwork/hermez-core/state/runtime/evm.(*state).Run()
/src/state/runtime/evm/evm.go:42 github.com/hermeznetwork/hermez-core/state/runtime/evm.(*EVM).Run()
/src/state/host.go:370 github.com/hermeznetwork/hermez-core/state.(*Host).run()
/src/state/host.go:219 github.com/hermeznetwork/hermez-core/state.(*Host).Callx()
/src/state/runtime/evm/intructions.go:1110 github.com/hermeznetwork/hermez-core/state/runtime/evm.opCall.func1()
/src/state/runtime/evm/state.go:258 github.com/hermeznetwork/hermez-core/state/runtime/evm.(*state).Run()
/src/state/runtime/evm/evm.go:42 github.com/hermeznetwork/hermez-core/state/runtime/evm.(*EVM).Run()
/src/state/host.go:370 github.com/hermeznetwork/hermez-core/state.(*Host).run()
/src/state/batchprocessor.go:239 github.com/hermeznetwork/hermez-core/state.(*BatchProcessor).processTransaction()
/src/state/batchprocessor.go:107 github.com/hermeznetwork/hermez-core/state.(*BatchProcessor).ProcessBatch()
/src/synchronizer/synchronizer.go:255 github.com/hermeznetwork/hermez-core/synchronizer.(*ClientSynchronizer).processBlockRange()
/src/synchronizer/synchronizer.go:177 github.com/hermeznetwork/hermez-core/synchronizer.(*ClientSynchronizer).syncBlocks()
/src/synchronizer/synchronizer.go:111 github.com/hermeznetwork/hermez-core/synchronizer.(*ClientSynchronizer).Sync.func1()
)
2022-04-19T08:55:01Z	DEBUG	tree/merkletree.go:402	Set	{"key": "0x9f192b87e954f93671087fb9da5010791ba1a056dbfa7bf1c31330fe1ea9cf2a", "value": [1874919424, 2328306, 0, 0, 2264035265, 35, 0, 1650358501], "mode": "insertNotFound"}
```
So, for some of the db transactions, 256 (max height of the merkle tree) is not enough for the MT node cache size, we can be writing more than one leaf on each db transaction. 

With the max cache size increase done in this PR I no longer get the errors above nor the `Error: not found` error even with failed transactions following the procedure described in #589, @tclemos could you please confirm? 

### Reviewers

@tclemos 
@ARR552 
@ToniRamirezM 
@cool-develope 