### PR TITLE
Fix GetCodeHash

### DIFF
--- a/state/tree/key.go
+++ b/state/tree/key.go
@@ -53,7 +53,10 @@ func keyEthAddr(ethAddr common.Address, leafType leafType, key1 [8]uint64) ([]by
 		return nil, err
 	}
 
-	return h4ToScalar(result[:]).Bytes(), nil
+	resultBi := h4ToScalar(result[:])
+	var k [maxBigIntLen]byte
+
+	return resultBi.FillBytes(k[:]), nil
 }
 
 // KeyEthAddrBalance returns the key of balance leaf:

--- a/state/tree/key_test.go
+++ b/state/tree/key_test.go
@@ -68,6 +68,7 @@ func Test_CommonKeys(t *testing.T) {
 			t.Run(fmt.Sprintf("%s, test vector %d", tc.description, ti), func(t *testing.T) {
 				key, err := tc.keyFunc(common.HexToAddress(testVector.EthAddr))
 				require.NoError(t, err)
+				require.Equal(t, len(key), maxBigIntLen)
 
 				expected, _ := new(big.Int).SetString(testVector.ExpectedKey, 10)
 				assert.Equal(t, hex.EncodeToString(expected.Bytes()), hex.EncodeToString(key))
@@ -90,6 +91,7 @@ func Test_KeyContractStorage(t *testing.T) {
 			require.True(t, ok)
 			key, err := KeyContractStorage(common.HexToAddress(testVector.EthAddr), storagePosition.Bytes())
 			require.NoError(t, err)
+			require.Equal(t, len(key), maxBigIntLen)
 
 			expected, _ := new(big.Int).SetString(testVector.ExpectedKey, 10)
 			assert.Equal(t, hex.EncodeToString(expected.Bytes()), hex.EncodeToString(key))

--- a/state/tree/server.go
+++ b/state/tree/server.go
@@ -134,7 +134,7 @@ func (s *Server) GetCodeHash(ctx context.Context, in *pb.CommonGetRequest) (*pb.
 	}
 
 	return &pb.GetCodeHashResponse{
-		Hash: hex.EncodeToString(hash),
+		Hash: fmt.Sprintf("0x%s", hex.EncodeToString(hash)),
 	}, nil
 }
 

--- a/state/tree/tree.go
+++ b/state/tree/tree.go
@@ -122,7 +122,9 @@ func (tree *StateTree) GetCodeHash(ctx context.Context, address common.Address, 
 		return nil, nil
 	}
 
-	return fea2scalar(proof.Value).Bytes(), nil
+	valueBi := fea2scalar(proof.Value)
+	var valueBuff [maxBigIntLen]byte
+	return valueBi.FillBytes(valueBuff[:]), nil
 }
 
 // GetCode returns code


### PR DESCRIPTION
Closes #582

### What does this PR do?

* Makes sure that the code hash and in general all the MT keys used have the right size, 32 bytes.
* Fixes a MT server test, was using the wrong test vector
* Adds a statetree.GetCodeHash unit test
* Changes the MT server port used in tests to prevent collisions with other services 

### Reviewers

@tclemos
@ToniRamirezM 
@ARR552  