### PR TITLE
fix sc log index

### DIFF
--- a/state/host.go
+++ b/state/host.go
@@ -189,7 +189,7 @@ func (h *Host) EmitLog(address common.Address, topics []common.Hash, data []byte
 
 func (h *Host) getLogIndex() uint {
 	nextIndex := 0
-	for l := range h.logs {
+	for _, l := range h.logs {
 		nextIndex += len(l)
 	}
 	return uint(nextIndex)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1509,8 +1509,9 @@ func TestEmitLog(t *testing.T) {
 	logs, err = st.GetLogs(ctx, 0, 5, nil, nil, nil, "")
 	require.NoError(t, err)
 	require.Equal(t, 10, len(logs))
-	for _, l := range logs {
+	for i, l := range logs {
 		assert.Equal(t, scAddress, l.Address)
+		assert.Equal(t, uint(i), l.Index)
 	}
 
 	logs, err = st.GetLogs(ctx, 5, 5, nil, nil, nil, "")


### PR DESCRIPTION
Closes #619.

### What does this PR do?

Fix the way the EVM counts the logs to set the log index properly.
Improve the test to check the log index.

### Reviewers

Main reviewers:

- @ToniRamirezM 
