### PR TITLE
Add multiplatform docker build workflow and tag images for integration

### DIFF
--- a/.github/workflows/push-docker-develop.yml
+++ b/.github/workflows/push-docker-develop.yml
@@ -9,21 +9,36 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: hermeznetwork/hermez-node-zkevm:develop
+          tags: |
+            hermeznetwork/hermez-node-zkevm:develop
+            hermeznetwork/hermez-core:1.5-integration
+
       - name: Build and push prover mock
         id: docker_build_prover_mock
         uses: docker/build-push-action@v2
         with:
           context: ./proverservice
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: hermeznetwork/hez-mock-prover
+          tags: |
+            hermeznetwork/hez-mock-prover:latest
+            hermeznetwork/hez-mock-prover:1.5-integration

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -9,21 +9,36 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: hermeznetwork/hermez-node-zkevm
+          tags: |
+            hermeznetwork/hermez-node-zkevm:latest
+            hermeznetwork/hermez-core:1.5-itestnet
+
       - name: Build and push prover mock
         id: docker_build_prover_mock
         uses: docker/build-push-action@v2
         with:
           context: ./proverservice
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: hermeznetwork/hez-mock-prover
+          tags: |
+            hermeznetwork/hez-mock-prover:latest
+            hermeznetwork/hez-mock-prover:1.5-itestnet


### PR DESCRIPTION
### What does this PR do?

Small changes to GitHub workflows to build multi platform docker images that can be directly run also in ARM MacBook computers. Also set new tags for integration and internal-testnet purposes: **1.5-integration** and **1.5-itestnet**

### Reviewers

Main reviewers:

- @fgimenez 
- @tclemos 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @fgimenez 
- @tclemos 