### PR TITLE
Refactor FillBytes

### DIFF
--- a/state/batchprocessor.go
+++ b/state/batchprocessor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hermeznetwork/hermez-core/log"
 	"github.com/hermeznetwork/hermez-core/state/helper"
 	"github.com/hermeznetwork/hermez-core/state/runtime"
+	"github.com/hermeznetwork/hermez-core/state/tree"
 )
 
 const (
@@ -83,9 +84,8 @@ func (b *BatchProcessor) ProcessBatch(ctx context.Context, batch *Batch) error {
 	b.Host.logs = map[common.Hash][]*types.Log{}
 
 	// Set Global Exit Root storage position
-	var batchNumberBuf, storagePositionBuf [32]byte
-	batchNumber := batch.Number().FillBytes(batchNumberBuf[:])
-	storagePosition := new(big.Int).SetUint64(b.Host.State.cfg.GlobalExitRootStoragePosition).FillBytes(storagePositionBuf[:])
+	batchNumber := tree.ScalarToFilledByteSlice(batch.Number())
+	storagePosition := tree.ScalarToFilledByteSlice(new(big.Int).SetUint64(b.Host.State.cfg.GlobalExitRootStoragePosition))
 	globalExitRootPos := helper.Keccak256(batchNumber, storagePosition)
 
 	root, _, err := b.Host.State.tree.SetStorageAt(ctx, b.Host.State.cfg.L2GlobalExitRootManagerAddr, new(big.Int).SetBytes(globalExitRootPos), new(big.Int).SetBytes(batch.GlobalExitRoot.Bytes()), b.Host.stateRoot, b.TxBundleID)

--- a/state/tree/key.go
+++ b/state/tree/key.go
@@ -53,10 +53,7 @@ func keyEthAddr(ethAddr common.Address, leafType leafType, key1 [8]uint64) ([]by
 		return nil, err
 	}
 
-	resultBi := h4ToScalar(result[:])
-	var k [maxBigIntLen]byte
-
-	return resultBi.FillBytes(k[:]), nil
+	return h4ToFilledByteSlice(result[:]), nil
 }
 
 // KeyEthAddrBalance returns the key of balance leaf:

--- a/state/tree/merkletree.go
+++ b/state/tree/merkletree.go
@@ -568,7 +568,7 @@ func (mt *MerkleTree) setStoreNodeData(ctx context.Context, key []uint64, data [
 		return err
 	}
 
-	return mt.store.Set(ctx, h4ToScalar(key).Bytes(), dataByte, txBundleID)
+	return mt.store.Set(ctx, h4ToFilledByteSlice(key), dataByte, txBundleID)
 }
 
 func (mt *MerkleTree) getNodeData(ctx context.Context, key []uint64, txBundleID string) ([]uint64, error) {
@@ -589,7 +589,7 @@ func (mt *MerkleTree) getNodeData(ctx context.Context, key []uint64, txBundleID 
 		}
 	}
 	if len(dataByte) == 0 {
-		dataByte, err = mt.store.Get(ctx, h4ToScalar(key).Bytes(), txBundleID)
+		dataByte, err = mt.store.Get(ctx, h4ToFilledByteSlice(key), txBundleID)
 		if err != nil {
 			return nil, err
 		}

--- a/state/tree/split.go
+++ b/state/tree/split.go
@@ -84,8 +84,7 @@ func stringToh4(str string) ([]uint64, error) {
 
 // scalarToh4 converts a *big.Int into an array of 4 uint64
 func scalarToh4(s *big.Int) []uint64 {
-	buf := make([]byte, maxBigIntLen)
-	b := s.FillBytes(buf)
+	b := ScalarToFilledByteSlice(s)
 
 	r := make([]uint64, 4)
 
@@ -98,4 +97,17 @@ func scalarToh4(s *big.Int) []uint64 {
 	r[0] = binary.BigEndian.Uint64(b[24:]) & fbe
 
 	return r
+}
+
+// ScalarToFilledByteSlice converts a *big.Int into an array of maxBigIntLen
+// bytes.
+func ScalarToFilledByteSlice(s *big.Int) []byte {
+	buf := make([]byte, maxBigIntLen)
+	return s.FillBytes(buf)
+}
+
+// h4ToFilledByteSlice converts an array of 4 uint64 into an array of
+// maxBigIntLen bytes.
+func h4ToFilledByteSlice(h4 []uint64) []byte {
+	return ScalarToFilledByteSlice(h4ToScalar(h4))
 }

--- a/state/tree/split_test.go
+++ b/state/tree/split_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/hermeznetwork/hermez-core/hex"
 	"github.com/hermeznetwork/hermez-core/test/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -218,6 +219,83 @@ func Test_stringToh4(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			actual, err := stringToh4(tc.input)
 			require.NoError(t, testutils.CheckError(err, tc.expectedErr, tc.expectedErrMsg))
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func Test_ScalarToFilledByteSlice(t *testing.T) {
+	tcs := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "0",
+			expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			input:    "256",
+			expected: "0x0000000000000000000000000000000000000000000000000000000000000100",
+		},
+		{
+			input:    "235938498573495379548793890390932048239042839490238",
+			expected: "0x0000000000000000000000a16f882ee8972432c0a71c5e309ad5f7215690aebe",
+		},
+		{
+			input:    "4309593458485959083095843905390485089430985490434080439904305093450934509490",
+			expected: "0x098724b9a1bc97eee674cf5b6b56b8fafd83ac49c3da1f2c87c822548bbfdfb2",
+		},
+		{
+			input:    "98999023430240239049320492430858334093493024832984092384902398409234090932489",
+			expected: "0xdadf762a31e865f150a1456d7db7963c91361b771c8381a3fb879cf5bf91b909",
+		},
+	}
+
+	for i, tc := range tcs {
+		tc := tc
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			input, ok := big.NewInt(0).SetString(tc.input, 10)
+			require.True(t, ok)
+
+			actualSlice := ScalarToFilledByteSlice(input)
+
+			actual := hex.EncodeToHex(actualSlice)
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func Test_h4ToFilledByteSlice(t *testing.T) {
+	tcs := []struct {
+		input    []uint64
+		expected string
+	}{
+		{
+			input:    []uint64{0, 0, 0, 0},
+			expected: "0x0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			input:    []uint64{0, 1, 2, 3},
+			expected: "0x0000000000000003000000000000000200000000000000010000000000000000",
+		},
+		{
+			input:    []uint64{55345354959, 991992992929, 2, 3},
+			expected: "0x00000000000000030000000000000002000000e6f763d4a10000000ce2d718cf",
+		},
+		{
+			input:    []uint64{8398349845894398543, 3485942349435495945, 734034022234249459, 5490434584389534589},
+			expected: "0x4c31f12a390ec37d0a2fd00ddc52d8f330608e18f597e609748ceeb03ffe024f",
+		},
+	}
+
+	for i, tc := range tcs {
+		tc := tc
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			actualSlice := h4ToFilledByteSlice(tc.input)
+
+			actual := hex.EncodeToHex(actualSlice)
 
 			require.Equal(t, tc.expected, actual)
 		})

--- a/state/tree/tree.go
+++ b/state/tree/tree.go
@@ -120,8 +120,7 @@ func (tree *StateTree) GetCodeHash(ctx context.Context, address common.Address, 
 	}
 
 	valueBi := fea2scalar(proof.Value)
-	var valueBuff [maxBigIntLen]byte
-	return valueBi.FillBytes(valueBuff[:]), nil
+	return ScalarToFilledByteSlice(valueBi), nil
 }
 
 // GetCode returns code
@@ -196,8 +195,7 @@ func (tree *StateTree) SetBalance(ctx context.Context, address common.Address, b
 		return nil, nil, err
 	}
 
-	rootBI := h4ToScalar(updateProof.NewRoot)
-	return rootBI.Bytes(), updateProof, nil
+	return h4ToFilledByteSlice(updateProof.NewRoot), updateProof, nil
 }
 
 // SetNonce sets nonce
@@ -221,7 +219,7 @@ func (tree *StateTree) SetNonce(ctx context.Context, address common.Address, non
 		return nil, nil, err
 	}
 
-	return h4ToScalar(updateProof.NewRoot).Bytes(), updateProof, nil
+	return h4ToFilledByteSlice(updateProof.NewRoot), updateProof, nil
 }
 
 // SetCode sets smart contract code
@@ -258,7 +256,7 @@ func (tree *StateTree) SetCode(ctx context.Context, address common.Address, code
 		return nil, nil, err
 	}
 
-	return h4ToScalar(updateProof.NewRoot).Bytes(), updateProof, nil
+	return h4ToFilledByteSlice(updateProof.NewRoot), updateProof, nil
 }
 
 // SetStorageAt sets storage value at specified position
@@ -276,7 +274,7 @@ func (tree *StateTree) SetStorageAt(ctx context.Context, address common.Address,
 		return nil, nil, err
 	}
 
-	return h4ToScalar(updateProof.NewRoot).Bytes(), updateProof, nil
+	return h4ToFilledByteSlice(updateProof.NewRoot), updateProof, nil
 }
 
 // SetHashValue sets value for an specific key.
@@ -289,22 +287,17 @@ func (tree *StateTree) SetHashValue(ctx context.Context, key common.Hash, value 
 		return nil, nil, err
 	}
 
-	return h4ToScalar(updateProof.NewRoot).Bytes(), updateProof, nil
+	return h4ToFilledByteSlice(updateProof.NewRoot), updateProof, nil
 }
 
 // SetNodeData sets data for a specific node.
 func (tree *StateTree) SetNodeData(ctx context.Context, key *big.Int, value *big.Int) (err error) {
-	var k [maxBigIntLen]byte
-	key.FillBytes(k[:])
-
-	return tree.mt.store.Set(ctx, k[:], value.Bytes(), "")
+	return tree.mt.store.Set(ctx, ScalarToFilledByteSlice(key), value.Bytes(), "")
 }
 
 // GetNodeData sets data for a specific node.
 func (tree *StateTree) GetNodeData(ctx context.Context, key *big.Int) (*big.Int, error) {
-	var k [maxBigIntLen]byte
-	key.FillBytes(k[:])
-	data, err := tree.mt.store.Get(ctx, k[:], "")
+	data, err := tree.mt.store.Get(ctx, ScalarToFilledByteSlice(key), "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Creates functions to properly set the padding of merkletree keys to 32 bytes and reactors to use them, 

### Reviewers

@arnaubennassar 
@ToniRamirezM 
@ARR552 