### PR TITLE
Init `logs` map in host

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -146,7 +146,8 @@ func (s *State) NewBatchProcessor(ctx context.Context, sequencerAddress common.A
 		return nil, err
 	}
 
-	host := Host{State: s, stateRoot: stateRoot, transactionContext: transactionContext{difficulty: new(big.Int)}, txBundleID: txBundleID}
+	logs := make(map[common.Hash][]*types.Log)
+	host := Host{State: s, stateRoot: stateRoot, transactionContext: transactionContext{difficulty: new(big.Int)}, txBundleID: txBundleID, logs: logs}
 	host.setRuntime(evm.NewEVM())
 	blockNumber, err := s.GetLastBlockNumber(ctx, txBundleID)
 	if err != nil {


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

Init `logs` map in host, otherwise it panics on a nil resource

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @arnaubennassar 
- @fgimenez 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @ToniRamirezM 
- @OBrezhniev 