### PR TITLE
Initial consumer interfaces for sequencer v2

### DIFF
--- a/sequencerv2/interfaces.go
+++ b/sequencerv2/interfaces.go
@@ -4,11 +4,13 @@ package sequencerv2
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hermeznetwork/hermez-core/pool"
 	"github.com/hermeznetwork/hermez-core/state"
+	"github.com/hermeznetwork/hermez-core/state/runtime"
 )
 
 // Consumer interfaces required by the package.
@@ -35,14 +37,23 @@ type etherman interface {
 	GetTx(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)
 	GetTxReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 
-	SequenceBatches(sequences []*sequence) error
+	SequenceBatches(sequences []*Sequence) error
 }
 
 // stateInterface gathers the methods required to interact with the state.
 type stateInterface interface {
-	GetLastBatch(ctx context.Context, isVirtual bool, txBundleID string) (*state.Batch, error)
+	GetLastBatch(ctx context.Context, txBundleID string) (*state.Batch, error)
 	GetLastBatchNumber(ctx context.Context, txBundleID string) (uint64, error)
 	GetLastBatchNumberSeenOnEthereum(ctx context.Context, txBundleID string) (uint64, error)
 	GetLastBatchByStateRoot(ctx context.Context, stateRoot []byte, txBundleID string) (*state.Batch, error)
-	NewBatchProcessor(ctx context.Context, sequencerAddress common.Address, stateRoot []byte, txBundleID string) (*state.BatchProcessor, error)
+
+	SetGenesis(ctx context.Context, genesis state.Genesis, txBundleID string) error
+	SetLastBatchNumberSeenOnEthereum(ctx context.Context, batchNumber uint64, txBundleID string) error
+	SetLastBatchNumberConsolidatedOnEthereum(ctx context.Context, batchNumber uint64, txBundleID string) error
+	SetInitSyncBatch(ctx context.Context, batchNumber uint64, txBundleID string) error
+
+	AddBlock(ctx context.Context, block *state.Block, txBundleID string) error
+	ConsolidateBatch(ctx context.Context, batchNumber uint64, globalExitRoot common.Hash, timestamp time.Time, txBundleID string) error
+
+	ProcessSequence(ctx context.Context, sequence Sequence) *runtime.ExecutionResult
 }

--- a/sequencerv2/sequencer.go
+++ b/sequencerv2/sequencer.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// sequence represents an operation sent to the PoE smart contract to be
+// Sequence represents an operation sent to the PoE smart contract to be
 // processed.
-type sequence struct {
+type Sequence struct {
 	globalExitRoot  common.Hash
 	timestamp       uint64
 	forceBatchesNum uint64


### PR DESCRIPTION
Closes #708

* Added:
  * `txPool`
    * `IsTxPending(ctx context.Context, hash common.Hash) (bool, error)` from #723
  * `etherman`
    * `GetSequencerAddress() common.Address` to query https://github.com/hermeznetwork/contracts-zkEVM/blob/feature/poeV2/contracts/ProofOfEfficiency.sol#L75
  * `state`
    * `SetGenesis(ctx context.Context, genesis state.Genesis, txBundleID string) error`
    * `SetLastBatchNumberSeenOnEthereum(ctx context.Context, batchNumber uint64, txBundleID string) error`
    * `SetLastBatchNumberConsolidatedOnEthereum(ctx context.Context, batchNumber uint64, txBundleID string) error`
    * `SetInitSyncBatch(ctx context.Context, batchNumber uint64, txBundleID string) error`
    * `AddBlock(ctx context.Context, block *state.Block, txBundleID string) error`
    * `ConsolidateBatch(ctx context.Context, batchNumber uint64, globalExitRoot common.Hash, timestamp time.Time, txBundleID string) error`
    * `ProcessSequence(ctx context.Context, sequence Sequence) *runtime.ExecutionResult`
* Renamed:
  * `etherman`
    * `SendBatch(ctx context.Context, gasLimit uint64, txs []*types.Transaction, maticAmount *big.Int) (*types.Transaction, error)` -> `SequenceBatches(sequences []*sequence) error`
    * `GetCurrentSequencerCollateral() (*big.Int, error)` -> `GetSequencerCollateral() (*big.Int, error)` to query https://github.com/hermeznetwork/contracts-zkEVM/blob/feature/poeV2/contracts/ProofOfEfficiency.sol#L45
* Removed:
  * `etherman`
    * `GetCustomChainID() (*big.Int, error)`
  * `txProfitabilityChecker` complete
  * `stateInterface`
    * `GetSequencer(ctx context.Context, address common.Address, txundleID string) (*state.Sequencer, error)` probably we can have a local reference?
### Reviewers

@Mikelle 
@arnaubennassar 