### PR TITLE
replace the docker container to use alpine as image instead of golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # CONTAINER FOR BUILDING BINARY
 FROM golang:1.17 AS build
 
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 
 # INSTALL DEPENDENCIES
 RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
@@ -14,9 +14,8 @@ RUN cd /src/db && packr2
 RUN cd /src && make build
 
 # CONTAINER FOR RUNNING BINARY
-FROM golang:1.17
-WORKDIR /app
+FROM alpine:3.16.0
 COPY --from=build /src/dist/hezcore /app/hezcore
 COPY --from=build /src/config/config.local.toml /app/config.local.toml
 EXPOSE 8123
-CMD ["./hezcore", "run"]
+CMD ["/bin/sh", "-c", "/app/hezcore run"]

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,13 @@ stop-prover: ## Stops the zk prover
 
 .PHONY: run-explorer
 run-explorer: ## Runs the explorer
+	$(RUNEXPLORERRPC)
 	$(RUNEXPLORER)
 
 .PHONY: stop-explorer
 stop-explorer: ## Stops the explorer
 	$(STOPEXPLORER)
+	$(STOPEXPLORERRPC)
 
 .PHONY: run-explorer-db
 run-explorer-db: ## Runs the explorer database
@@ -171,7 +173,6 @@ stop-explorer-db: ## Stops the explorer database
 run: compile-scs ## Runs all the services
 	$(RUNDB)
 	$(RUNEXPLORERDB)
-	$(RUNEXPLORERRPC)
 	$(RUNNETWORK)
 	sleep 5
 	$(RUNPROVER)
@@ -179,6 +180,7 @@ run: compile-scs ## Runs all the services
 	$(RUNCORESEQ)
 	$(RUNCOREAGG)
 	$(RUNCORERPC)
+	$(RUNEXPLORERRPC)
 	$(RUNCORESYNC)
 	$(RUNEXPLORER)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,9 @@ services:
       - ./test/test.keystore:/pk/keystore
       - ./config/config.local.toml:/app/config.toml
     command:
-      - "./hezcore"
-      - "run"
-      - "--network"
-      - "local"
-      - "--cfg"
-      - "/app/config.toml"
-      - "--components"
-      - "sequencer"
-    
+      - "/bin/sh"
+      - "-c"
+      - "/app/hezcore run --network local --cfg /app/config.toml --components sequencer"    
 
   hez-core-rpc:
     container_name: hez-core-rpc
@@ -39,14 +33,9 @@ services:
     volumes:
       - ./config/config.local.toml:/app/config.toml
     command:
-      - "./hezcore"
-      - "run"
-      - "--network"
-      - "local"
-      - "--cfg"
-      - "/app/config.toml"
-      - "--components"
-      - "rpc"
+      - "/bin/sh"
+      - "-c"
+      - "/app/hezcore run --network local --cfg /app/config.toml --components rpc"
       
   hez-core-agg:
     container_name: hez-core-agg
@@ -61,14 +50,9 @@ services:
       - ./test/test.keystore:/pk/keystore
       - ./config/config.local.toml:/app/config.toml
     command:
-      - "./hezcore"
-      - "run"
-      - "--network"
-      - "local"
-      - "--cfg"
-      - "/app/config.toml"
-      - "--components"
-      - "aggregator"
+      - "/bin/sh"
+      - "-c"
+      - "/app/hezcore run --network local --cfg /app/config.toml --components aggregator"
       
   hez-core-sync:
     container_name: hez-core-sync
@@ -83,14 +67,9 @@ services:
       - ./test/test.keystore:/pk/keystore
       - ./config/config.local.toml:/app/config.toml
     command:
-      - "./hezcore"
-      - "run"
-      - "--network"
-      - "local"
-      - "--cfg"
-      - "/app/config.toml"
-      - "--components"
-      - "synchronizer"
+      - "/bin/sh"
+      - "-c"
+      - "/app/hezcore run --network local --cfg /app/config.toml --components synchronizer"
       
   hez-postgres:
     container_name: hez-postgres
@@ -143,16 +122,9 @@ services:
     volumes:
       - ./config/config.local.toml:/app/config.toml
     command:
-      [
-        "./hezcore",
-        "run",
-        "--network",
-        "local",
-        "--cfg",
-        "/app/config.toml",
-        "--components",
-        "rpc",
-      ]
+      - "/bin/sh"
+      - "-c"
+      - "/app/hezcore run --network local --cfg /app/config.toml --components rpc --http.api eth,net,debug,hez,txpool,web3"
 
   hez-explorer-postgres:
     container_name: hez-explorer-postgres


### PR DESCRIPTION
Closes #769.

### What does this PR do?

Replaces the base image from golang to alpine for the container that runs the node
It also organizes the docker-compose file to deal with the new image.

### Reviewers

Main reviewers:

@arnaubennassar 
@ToniRamirezM 