### PR TITLE
Add get batch num since it was missing

### DIFF
--- a/sequencerv2/sequencer.go
+++ b/sequencerv2/sequencer.go
@@ -130,6 +130,11 @@ func (s *Sequencer) tryToProcessTx(ctx context.Context, ticker *time.Ticker) {
 
 	log.Infof("processing tx")
 	s.sequenceInProgress.Txs = append(s.sequenceInProgress.Txs, tx.Transaction)
+	batchNumber, err := s.state.GetLastBatchNumber(ctx, nil)
+	if err != nil {
+		log.Debug("failed to get last batch number")
+		return
+	}
 	processBatchResp, err := s.state.ProcessBatch(ctx, batchNumber, s.sequenceInProgress.Txs, nil)
 	if err != nil {
 		s.sequenceInProgress.Txs = s.sequenceInProgress.Txs[:len(s.sequenceInProgress.Txs)-1]


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

Based on my brief time with the code I ran the tests, a test failed due to the variable `batchNumber` not being defined. This defined said variable.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @tclemos 
- @arnaubennassar 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @Alice
- @Bob