### PR TITLE
Handle unprocessed transactions in sequencer main loop

### DIFF
--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -263,13 +263,15 @@ func (s *Sequencer) tryToProcessTx(ctx context.Context, ticker *time.Ticker) {
 	s.lastStateRoot = processBatchResp.NewStateRoot
 	s.lastLocalExitRoot = processBatchResp.NewLocalExitRoot
 
-	// TODO: add logic based on this response to decide which txs we include on the DB
 	dbTx, err = s.state.BeginStateTransaction(ctx)
 	if err != nil {
 		log.Errorf("failed to begin state transaction for StoreTransactions, err: %v", err)
 		return
 	}
-	err = s.state.StoreTransactions(ctx, s.lastBatchNum, processBatchResp.Responses, dbTx)
+
+	processedTxs, unprocessedTxs := state.DetermineProcessedTransactions(processBatchResp.Responses)
+	// only save in DB processed transactions.
+	err = s.state.StoreTransactions(ctx, s.lastBatchNum, processedTxs, dbTx)
 	if err != nil {
 		s.sequenceInProgress.Txs = s.sequenceInProgress.Txs[:len(s.sequenceInProgress.Txs)-1]
 		if rollbackErr := dbTx.Rollback(ctx); rollbackErr != nil {
@@ -292,9 +294,18 @@ func (s *Sequencer) tryToProcessTx(ctx context.Context, ticker *time.Ticker) {
 		return
 	}
 
-	log.Infof("Tx %s added into the state. Marking tx as selected in the pool", tx.Hash())
-	// TODO: add correct handling in case update didn't go through
-	if err := s.pool.UpdateTxState(ctx, tx.Hash(), pool.TxStateSelected); err != nil {
+	var txState pool.TxState = pool.TxStateSelected
+	var txUpdateMsg = fmt.Sprintf("Tx %q added into the state. Marking tx as selected in the pool", tx.Hash())
+	// check if the tx was actually processed.
+	for _, unprocessedTx := range unprocessedTxs {
+		if unprocessedTx.TxHash == tx.Hash() {
+			txState = pool.TxStatePending
+			txUpdateMsg = fmt.Sprintf("Tx %q failed to be processed. Marking tx as pending to return the pool", tx.Hash())
+			break
+		}
+	}
+	log.Infof(txUpdateMsg)
+	if err := s.pool.UpdateTxState(ctx, tx.Hash(), txState); err != nil {
 		log.Errorf("failed to update tx status on the pool, err: %v", err)
 		return
 	}

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -295,14 +295,10 @@ func (s *Sequencer) tryToProcessTx(ctx context.Context, ticker *time.Ticker) {
 	}
 
 	var txState pool.TxState = pool.TxStateSelected
-	var txUpdateMsg = fmt.Sprintf("Tx %q added into the state. Marking tx as selected in the pool", tx.Hash())
-	// check if the tx was actually processed.
-	for _, unprocessedTx := range unprocessedTxs {
-		if unprocessedTx.TxHash == tx.Hash() {
-			txState = pool.TxStatePending
-			txUpdateMsg = fmt.Sprintf("Tx %q failed to be processed. Marking tx as pending to return the pool", tx.Hash())
-			break
-		}
+	var txUpdateMsg string = fmt.Sprintf("Tx %q added into the state. Marking tx as selected in the pool", tx.Hash())
+	if _, ok := unprocessedTxs[tx.Hash().String()]; ok {
+		txState = pool.TxStatePending
+		txUpdateMsg = fmt.Sprintf("Tx %q failed to be processed. Marking tx as pending to return the pool", tx.Hash())
 	}
 	log.Infof(txUpdateMsg)
 	if err := s.pool.UpdateTxState(ctx, tx.Hash(), txState); err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -475,6 +475,12 @@ func (s *State) CloseBatch(ctx context.Context, receipt ProcessingReceipt, dbTx 
 	return s.PostgresStorage.closeBatch(ctx, receipt, batchL2Data, dbTx)
 }
 
+// isTransactionProcessed determines if the given process transaction response
+// represents a processed transaction.
+func isTransactionProcessed(unprocessedTransaction uint32) bool {
+	return unprocessedTransaction == cFalse
+}
+
 // ProcessAndStoreClosedBatch is used by the Synchronizer to add a closed batch into the data base
 func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx ProcessingContext, encodedTxs []byte, dbTx pgx.Tx) error {
 	// Open the batch and process the txs
@@ -492,7 +498,7 @@ func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx Pr
 	// Filter unprocessed txs and decode txs to store metadata
 	// note that if the batch is not well encoded it will result in an empty batch (with no txs)
 	for i := 0; i < len(processed.Responses); i++ {
-		if processed.Responses[i].UnprocessedTransaction == cTrue {
+		if !isTransactionProcessed(processed.Responses[i].UnprocessedTransaction) {
 			// Remove unprocessed tx
 			if i == len(processed.Responses)-1 {
 				processed.Responses = processed.Responses[:i]
@@ -826,4 +832,20 @@ func CheckSupersetBatchTransactions(existingTxHashes []common.Hash, processedTxs
 // isContractCreation checks if the tx is a contract creation
 func (s *State) isContractCreation(tx *types.Transaction) bool {
 	return tx.To() == nil && len(tx.Data()) > 0
+}
+
+// DetermineProcessedTransactions splits the given tx process responses
+// returning separated two slices with only processed and unprocessed txs
+// respectively.
+func DetermineProcessedTransactions(responses []*ProcessTransactionResponse) ([]*ProcessTransactionResponse, []*ProcessTransactionResponse) {
+	processedTxResponses := []*ProcessTransactionResponse{}
+	unprocessedTxResponses := []*ProcessTransactionResponse{}
+	for _, response := range responses {
+		if isTransactionProcessed(response.UnprocessedTransaction) {
+			processedTxResponses = append(processedTxResponses, response)
+		} else {
+			unprocessedTxResponses = append(unprocessedTxResponses, response)
+		}
+	}
+	return processedTxResponses, unprocessedTxResponses
 }

--- a/state/state.go
+++ b/state/state.go
@@ -835,16 +835,16 @@ func (s *State) isContractCreation(tx *types.Transaction) bool {
 }
 
 // DetermineProcessedTransactions splits the given tx process responses
-// returning separated two slices with only processed and unprocessed txs
+// returning a slice with only processed and a map unprocessed txs
 // respectively.
-func DetermineProcessedTransactions(responses []*ProcessTransactionResponse) ([]*ProcessTransactionResponse, []*ProcessTransactionResponse) {
+func DetermineProcessedTransactions(responses []*ProcessTransactionResponse) ([]*ProcessTransactionResponse, map[string]*ProcessTransactionResponse) {
 	processedTxResponses := []*ProcessTransactionResponse{}
-	unprocessedTxResponses := []*ProcessTransactionResponse{}
+	unprocessedTxResponses := map[string]*ProcessTransactionResponse{}
 	for _, response := range responses {
 		if isTransactionProcessed(response.UnprocessedTransaction) {
 			processedTxResponses = append(processedTxResponses, response)
 		} else {
-			unprocessedTxResponses = append(unprocessedTxResponses, response)
+			unprocessedTxResponses[response.TxHash.String()] = response
 		}
 	}
 	return processedTxResponses, unprocessedTxResponses

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -765,13 +765,13 @@ func TestDetermineProcessedTransactions(t *testing.T) {
 		description               string
 		input                     []*state.ProcessTransactionResponse
 		expectedProcessedOutput   []*state.ProcessTransactionResponse
-		expectedUnprocessedOutput []*state.ProcessTransactionResponse
+		expectedUnprocessedOutput map[string]*state.ProcessTransactionResponse
 	}{
 		{
 			description:               "empty input returns empty",
 			input:                     []*state.ProcessTransactionResponse{},
 			expectedProcessedOutput:   []*state.ProcessTransactionResponse{},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{},
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{},
 		},
 		{
 			description: "single processed transaction returns itself",
@@ -781,16 +781,22 @@ func TestDetermineProcessedTransactions(t *testing.T) {
 			expectedProcessedOutput: []*state.ProcessTransactionResponse{
 				{UnprocessedTransaction: 0},
 			},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{},
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{},
 		},
 		{
 			description: "single unprocessed transaction returns empty",
 			input: []*state.ProcessTransactionResponse{
-				{UnprocessedTransaction: 1},
+				{
+					TxHash:                 common.HexToHash("a"),
+					UnprocessedTransaction: 1,
+				},
 			},
 			expectedProcessedOutput: []*state.ProcessTransactionResponse{},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{
-				{UnprocessedTransaction: 1},
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{
+				"0x000000000000000000000000000000000000000000000000000000000000000a": {
+					TxHash:                 common.HexToHash("a"),
+					UnprocessedTransaction: 1,
+				},
 			},
 		},
 		{
@@ -823,7 +829,7 @@ func TestDetermineProcessedTransactions(t *testing.T) {
 					UnprocessedTransaction: 0,
 				},
 			},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{},
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{},
 		},
 		{
 			description: "multiple unprocessed transactions",
@@ -842,16 +848,16 @@ func TestDetermineProcessedTransactions(t *testing.T) {
 				},
 			},
 			expectedProcessedOutput: []*state.ProcessTransactionResponse{},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{
-				{
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{
+				"0x000000000000000000000000000000000000000000000000000000000000000a": {
 					TxHash:                 common.HexToHash("a"),
 					UnprocessedTransaction: 1,
 				},
-				{
+				"0x000000000000000000000000000000000000000000000000000000000000000b": {
 					TxHash:                 common.HexToHash("b"),
 					UnprocessedTransaction: 1,
 				},
-				{
+				"0x000000000000000000000000000000000000000000000000000000000000000c": {
 					TxHash:                 common.HexToHash("c"),
 					UnprocessedTransaction: 1,
 				},
@@ -887,12 +893,12 @@ func TestDetermineProcessedTransactions(t *testing.T) {
 					UnprocessedTransaction: 0,
 				},
 			},
-			expectedUnprocessedOutput: []*state.ProcessTransactionResponse{
-				{
+			expectedUnprocessedOutput: map[string]*state.ProcessTransactionResponse{
+				"0x000000000000000000000000000000000000000000000000000000000000000b": {
 					TxHash:                 common.HexToHash("b"),
 					UnprocessedTransaction: 1,
 				},
-				{
+				"0x000000000000000000000000000000000000000000000000000000000000000d": {
 					TxHash:                 common.HexToHash("d"),
 					UnprocessedTransaction: 1,
 				},


### PR DESCRIPTION
Closes #905 

### What does this PR do?
After trying to process a batch with a new tx it:
* only saves to the DB the txs that have been processed
* sets the new tx to pending (sends it back to the pool) if it was not processed 

### Reviewers

@arnaubennassar 
@Mikelle 
@ToniRamirezM 