### PR TITLE
reorg channel notification implemented

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -140,14 +140,14 @@ func newEtherman(c config.Config) (*etherman.Client, error) {
 	return etherman, nil
 }
 
-func runSynchronizer(networkConfig config.NetworkConfig, etherman *etherman.Client, st *state.State, cfg synchronizer.Config, reorgBlockNumChan chan struct{}) {
+func runSynchronizer(networkConfig config.NetworkConfig, etherman *etherman.Client, st *state.State, cfg synchronizer.Config, reorgTrustedStateChan chan struct{}) {
 	genesis := state.Genesis{
 		Balances:       networkConfig.Genesis.Balances,
 		SmartContracts: networkConfig.Genesis.SmartContracts,
 		Storage:        networkConfig.Genesis.Storage,
 		Nonces:         networkConfig.Genesis.Nonces,
 	}
-	sy, err := synchronizer.NewSynchronizer(etherman, st, networkConfig.GenBlockNumber, genesis, reorgBlockNumChan, cfg)
+	sy, err := synchronizer.NewSynchronizer(etherman, st, networkConfig.GenBlockNumber, genesis, reorgTrustedStateChan, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -168,13 +168,13 @@ func runJSONRPCServer(c config.Config, pool *pool.Pool, st *state.State, gpe gas
 }
 
 func createSequencer(c config.Config, pool *pool.Pool, state *state.State, etherman *etherman.Client,
-	ethTxManager *ethtxmanager.Client, reorgBlockNumChan chan struct{}) *sequencer.Sequencer {
+	ethTxManager *ethtxmanager.Client, reorgTrustedStateChan chan struct{}) *sequencer.Sequencer {
 	pg, err := pricegetter.NewClient(c.PriceGetter)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	seq, err := sequencer.New(c.Sequencer, pool, state, etherman, pg, reorgBlockNumChan, ethTxManager)
+	seq, err := sequencer.New(c.Sequencer, pool, state, etherman, pg, reorgTrustedStateChan, ethTxManager)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -23,14 +23,14 @@ type Synchronizer interface {
 
 // ClientSynchronizer connects L1 and L2
 type ClientSynchronizer struct {
-	etherMan          ethermanInterface
-	state             stateInterface
-	ctx               context.Context
-	cancelCtx         context.CancelFunc
-	genBlockNumber    uint64
-	genesis           state.Genesis
-	reorgBlockNumChan chan struct{}
-	cfg               Config
+	etherMan              ethermanInterface
+	state                 stateInterface
+	ctx                   context.Context
+	cancelCtx             context.CancelFunc
+	genBlockNumber        uint64
+	genesis               state.Genesis
+	reorgTrustedStateChan chan struct{}
+	cfg                   Config
 }
 
 // NewSynchronizer creates and initializes an instance of Synchronizer
@@ -39,19 +39,19 @@ func NewSynchronizer(
 	st stateInterface,
 	genBlockNumber uint64,
 	genesis state.Genesis,
-	reorgBlockNumChan chan struct{},
+	reorgTrustedStateChan chan struct{},
 	cfg Config) (Synchronizer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &ClientSynchronizer{
-		state:             st,
-		etherMan:          ethMan,
-		ctx:               ctx,
-		cancelCtx:         cancel,
-		genBlockNumber:    genBlockNumber,
-		genesis:           genesis,
-		reorgBlockNumChan: reorgBlockNumChan,
-		cfg:               cfg,
+		state:                 st,
+		etherMan:              ethMan,
+		ctx:                   ctx,
+		cancelCtx:             cancel,
+		genBlockNumber:        genBlockNumber,
+		genesis:               genesis,
+		reorgTrustedStateChan: reorgTrustedStateChan,
+		cfg:                   cfg,
 	}, nil
 }
 
@@ -532,6 +532,8 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 					}
 					log.Fatalf("error storing batch. BatchNumber: %d, BlockNumber: %d, error: %s", batch.BatchNumber, blockNumber, err.Error())
 				}
+				// Add info into the channel to inform the sequencer
+				s.reorgTrustedStateChan <- struct{}{}
 			}
 			// Store virtualBatch
 			err = s.state.AddVirtualBatch(s.ctx, &virtualBatches[i], dbTx)
@@ -621,6 +623,8 @@ func (s *ClientSynchronizer) processSequenceForceBatch(sequenceForceBatch etherm
 			log.Fatalf("error adding the batchNumber to forcedBatch in processSequenceForceBatch. BlockNumber: %d, error: %s", blockNumber, err.Error())
 		}
 	}
+	// Add info into the channel to inform the sequencer
+	s.reorgTrustedStateChan <- struct{}{}
 }
 
 func (s *ClientSynchronizer) processForcedBatch(forcedBatch etherman.ForcedBatch, dbTx pgx.Tx) {

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -35,8 +35,8 @@ func TestTrustedStateReorg(t *testing.T) {
 			SyncInterval:  cfgTypes.Duration{Duration: 1 * time.Second},
 			SyncChunkSize: 10,
 		}
-		reorgBlockNumChan := make(chan struct{})
-		sync, err := NewSynchronizer(m.Etherman, m.State, genBlockNumber, genesis, reorgBlockNumChan, cfg)
+		reorgTrustedStateChan := make(chan struct{})
+		sync, err := NewSynchronizer(m.Etherman, m.State, genBlockNumber, genesis, reorgTrustedStateChan, cfg)
 		require.NoError(t, err)
 
 		// state preparation

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -39,6 +39,17 @@ func TestTrustedStateReorg(t *testing.T) {
 		sync, err := NewSynchronizer(m.Etherman, m.State, genBlockNumber, genesis, reorgTrustedStateChan, cfg)
 		require.NoError(t, err)
 
+		go func() {
+			for {
+				select {
+				case <-reorgTrustedStateChan:
+					t.Log("Trusted reorg receive in the channel")
+					return
+				case <-context.Background().Done():
+					return
+				}
+			}
+		}()
 		// state preparation
 		ctxMatchBy := mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })
 		m.State.


### PR DESCRIPTION
Closes #927

### What does this PR do?

This PR implements the reorg channel in the synchronizer to notify the ts that there is a trusted reorg.

### Reviewers

- @Mikelle 
- @cool-develope 
- @tclemos 