### PR TITLE
Check sequences timestamp against POE SC lastTimestamp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,13 +157,13 @@ services:
 
   zkevm-mock-l1-network:
     container_name: zkevm-local-l1-network
-    image: hermeznetwork/geth-zkevm-contracts@sha256:419cf8c488d5cd099d1ffb5722613375c5392bdcda7a3c5ae2801d498fe49af8
+    image: hermeznetwork/geth-zkevm-contracts@sha256:7ac654f8b06baaca030f0022398dca1ffaa872be07dcf03c6bbc3ff6011adb88
     ports:
       - 8545:8545
 
   zkevm-mock-prover:
     container_name: zkevm-mock-prover
-    image: hermeznetwork/zkevm-mock-prover@sha256:3a86d0c65f0428decb7f1f3843b753bf6846bf43f6c628ab0b4d298fe7f918f2
+    image: hermeznetwork/zkevm-mock-prover@sha256:5a702c225c89f1dc9b54efc779541b7dc8d181eecad3320a918f1dc5a6521b18
     ports:
       - 50051:50051
       - 50052:50052

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -553,6 +553,11 @@ func (etherMan *Client) EthBlockByNumber(ctx context.Context, blockNumber uint64
 	return block, nil
 }
 
+// GetLastTimestamp function allows to retrieve the lastTimestamp value in the smc
+func (etherMan *Client) GetLastTimestamp() (uint64, error) {
+	return etherMan.PoE.LastTimestamp(&bind.CallOpts{Pending: false})
+}
+
 // GetLatestBatchNumber function allows to retrieve the latest proposed batch in the smc
 func (etherMan *Client) GetLatestBatchNumber() (uint64, error) {
 	return etherMan.PoE.LastBatchSequenced(&bind.CallOpts{Pending: false})

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -34,6 +34,7 @@ type etherman interface {
 	GetSendSequenceFee() (*big.Int, error)
 	TrustedSequencer() (common.Address, error)
 	GetLatestBatchNumber() (uint64, error)
+	GetLastTimestamp() (uint64, error)
 }
 
 // stateInterface gathers the methods required to interact with the state.

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -373,6 +373,7 @@ func (s *Sequencer) shouldSendSequences(ctx context.Context) (bool, bool) {
 				if seq.Timestamp < int64(lastTimestamp) {
 					panic("sequence timestamp is < POE SC lastTimestamp")
 				}
+				lastTimestamp = uint64(seq.Timestamp)
 			}
 
 			log.Debug("block.timestamp is greater than seq.Timestamp. A new block must be mined before the gas can be estimated.")

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -371,7 +371,7 @@ func (s *Sequencer) shouldSendSequences(ctx context.Context) (bool, bool) {
 			// check POE SC lastTimestamp against sequences' one
 			for _, seq := range s.closedSequences {
 				if seq.Timestamp < int64(lastTimestamp) {
-					panic("sequence timestamp is < POE SC lastTimestamp")
+					log.Fatalf("sequence timestamp %d is < POE SC lastTimestamp %d", seq.Timestamp, lastTimestamp)
 				}
 				lastTimestamp = uint64(seq.Timestamp)
 			}

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -360,12 +360,12 @@ func (s *Sequencer) shouldSendSequences(ctx context.Context) (bool, bool) {
 
 	if err != nil {
 		// while estimating gas a new block is not created and the POE SC may return
-		// an error regarding timestamp verification, this must handled
+		// an error regarding timestamp verification, this must be handled
 		if strings.Contains(err.Error(), errTimestampMustBeInsideRange) {
 			// query the sc about the value of its lastTimestamp variable
 			lastTimestamp, err := s.etherman.GetLastTimestamp()
 			if err != nil {
-				log.Errorf("failed to estimate gas for sequence batches, err: %v", err)
+				log.Errorf("failed to query last timestamp from SC, err: %v", err)
 				return false, false
 			}
 			// check POE SC lastTimestamp against sequences' one
@@ -375,7 +375,7 @@ func (s *Sequencer) shouldSendSequences(ctx context.Context) (bool, bool) {
 				}
 			}
 
-			log.Debug("block.timestamp is greater than seq.Timestamp. A new block must be forged.")
+			log.Debug("block.timestamp is greater than seq.Timestamp. A new block must be mined before the gas can be estimated.")
 			return false, false
 		}
 

--- a/test/e2e/ethtransfer_test.go
+++ b/test/e2e/ethtransfer_test.go
@@ -50,7 +50,7 @@ func Test1000EthTransfer(t *testing.T) {
 		}
 	}
 	log.Infof("%d transactions sent without error. Waiting for all the transactions to be mined", nTxs)
-	timeout := 2 * time.Minute
+	timeout := 3 * time.Minute
 	err = operations.WaitTxToBeMined(client, lastTxHash, timeout)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Closes #936 

### What does this PR do?

Checks sequences timestamp against POE SC lastTimestamp variable to ensure it is valid.
Also updates the L1 container in the docker-compose file to a new images that forges blocks every second.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @arnaubennassar 
- @Mikelle 
- @fgimenez 
