### PR TITLE
fix trusted state reorg to reset the correct batch number

### DIFF
--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -598,7 +598,8 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 			if !status {
 				// Reset trusted state
 				log.Infof("reorg detected, discarding batches until batchNum %d", batch.BatchNumber)
-				err := s.state.ResetTrustedState(s.ctx, batch.BatchNumber, dbTx) // This method has to reset the forced batches deleting the batchNumber for higher batchNumbers
+				previousBatchNumber := batch.BatchNumber - 1
+				err := s.state.ResetTrustedState(s.ctx, previousBatchNumber, dbTx) // This method has to reset the forced batches deleting the batchNumber for higher batchNumbers
 				if err != nil {
 					log.Errorf("error resetting trusted state. BatchNumber: %d, BlockNumber: %d, error: %s", batch.BatchNumber, blockNumber, err.Error())
 					rollbackErr := dbTx.Rollback(s.ctx)
@@ -813,7 +814,8 @@ func (s *ClientSynchronizer) processTrustedBatch(trustedBatch *pb.GetBatchRespon
 	}
 
 	log.Debugf("resetting trusted state from batch %v", trustedBatch.BatchNumber)
-	if err := s.state.ResetTrustedState(s.ctx, trustedBatch.BatchNumber-1, dbTx); err != nil {
+	previousBatchNumber := trustedBatch.BatchNumber - 1
+	if err := s.state.ResetTrustedState(s.ctx, previousBatchNumber, dbTx); err != nil {
 		log.Errorf("failed to reset trusted state", trustedBatch.BatchNumber)
 		return err
 	}

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -142,7 +142,7 @@ func TestTrustedStateReorg(t *testing.T) {
 					Once()
 
 				m.State.
-					On("ResetTrustedState", ctx, sequencedBatch.BatchNumber, m.DbTx).
+					On("ResetTrustedState", ctx, sequencedBatch.BatchNumber-1, m.DbTx).
 					Return(nil).
 					Once()
 


### PR DESCRIPTION
### What does this PR do?

Solves the trusted state reorg failing due to the error when trying to add a duplicated batch mentioned in this issue #945.

### Reviewers

Main reviewers:

- @ARR552 
- @cool-develope 
- @arnaubennassar 
- @Mikelle 