### PR TITLE
fix low end gas estimation to consider data

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/state/runtime/instrumentation"
 	"github.com/0xPolygonHermez/zkevm-node/state/runtime/instrumentation/tracers"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/trie"
@@ -137,10 +138,9 @@ func (s *State) EstimateGas(transaction *types.Transaction, senderAddress common
 		previousBatch = lastBatches[1]
 	}
 
-	if s.isContractCreation(transaction) {
-		lowEnd = TxSmartContractCreationGas
-	} else {
-		lowEnd = TxTransferGas
+	lowEnd, err = core.IntrinsicGas(transaction.Data(), transaction.AccessList(), s.isContractCreation(transaction), true, false)
+	if err != nil {
+		return 0, err
 	}
 
 	if transaction.Gas() != 0 && transaction.Gas() > lowEnd {


### PR DESCRIPTION
Closes #1055.

### What does this PR do?

Uses `Geth - IntrinsicGas()` function to define the minimum gas required by a transaction before using the Executor to estimate its gas

### Reviewers

Main reviewers:

@arnaubennassar 