### PR TITLE
fix eth_transactionCount for pending block

### DIFF
--- a/jsonrpc/interfaces.go
+++ b/jsonrpc/interfaces.go
@@ -16,9 +16,10 @@ import (
 // jsonRPCTxPool contains the methods required to interact with the tx pool.
 type jsonRPCTxPool interface {
 	AddTx(ctx context.Context, tx types.Transaction) error
-	GetPendingTxs(ctx context.Context, isClaims bool, limit uint64) ([]pool.Transaction, error)
 	GetGasPrice(ctx context.Context) (uint64, error)
+	GetNonce(ctx context.Context, address common.Address) (uint64, error)
 	GetPendingTxHashesSince(ctx context.Context, since time.Time) ([]common.Hash, error)
+	GetPendingTxs(ctx context.Context, isClaims bool, limit uint64) ([]pool.Transaction, error)
 }
 
 // gasPriceEstimator contains the methods required to interact with gas price estimator
@@ -29,39 +30,38 @@ type gasPriceEstimator interface {
 // stateInterface gathers the methods required to interact with the state.
 type stateInterface interface {
 	BeginStateTransaction(ctx context.Context) (pgx.Tx, error)
-
-	GetLastConsolidatedL2BlockNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error)
-	GetTransactionByHash(ctx context.Context, transactionHash common.Hash, dbTx pgx.Tx) (*types.Transaction, error)
-	GetTransactionReceipt(ctx context.Context, transactionHash common.Hash, dbTx pgx.Tx) (*types.Receipt, error)
-	GetLastL2BlockNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error)
-	GetLastL2Block(ctx context.Context, dbTx pgx.Tx) (*types.Block, error)
-	GetLastL2BlockHeader(ctx context.Context, dbTx pgx.Tx) (*types.Header, error)
+	DebugTransaction(ctx context.Context, transactionHash common.Hash, tracer string) (*runtime.ExecutionResult, error)
 	EstimateGas(transaction *types.Transaction, senderAddress common.Address, l2BlockNumber *uint64, dbTx pgx.Tx) (uint64, error)
 	GetBalance(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) (*big.Int, error)
+	GetCode(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) ([]byte, error)
 	GetL2BlockByHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (*types.Block, error)
 	GetL2BlockByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*types.Block, error)
-	GetCode(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) ([]byte, error)
-	GetStorageAt(ctx context.Context, address common.Address, position *big.Int, blockNumber uint64, dbTx pgx.Tx) (*big.Int, error)
-	GetSyncingInfo(ctx context.Context, dbTx pgx.Tx) (state.SyncingInfo, error)
-	GetTransactionByL2BlockHashAndIndex(ctx context.Context, blockHash common.Hash, index uint64, dbTx pgx.Tx) (*types.Transaction, error)
-	GetTransactionByL2BlockNumberAndIndex(ctx context.Context, blockNumber uint64, index uint64, dbTx pgx.Tx) (*types.Transaction, error)
-	GetNonce(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) (uint64, error)
+	GetL2BlockHashesSince(ctx context.Context, since time.Time, dbTx pgx.Tx) ([]common.Hash, error)
 	GetL2BlockHeaderByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*types.Header, error)
 	GetL2BlockTransactionCountByHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (uint64, error)
 	GetL2BlockTransactionCountByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (uint64, error)
+	GetLastConsolidatedL2BlockNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error)
+	GetLastL2Block(ctx context.Context, dbTx pgx.Tx) (*types.Block, error)
+	GetLastL2BlockHeader(ctx context.Context, dbTx pgx.Tx) (*types.Header, error)
+	GetLastL2BlockNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error)
 	GetLogs(ctx context.Context, fromBlock uint64, toBlock uint64, addresses []common.Address, topics [][]common.Hash, blockHash *common.Hash, since *time.Time, dbTx pgx.Tx) ([]*types.Log, error)
-	GetL2BlockHashesSince(ctx context.Context, since time.Time, dbTx pgx.Tx) ([]common.Hash, error)
-	DebugTransaction(ctx context.Context, transactionHash common.Hash, tracer string) (*runtime.ExecutionResult, error)
-	ProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, blockNumber *uint64, dbTx pgx.Tx) *runtime.ExecutionResult
+	GetNonce(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) (uint64, error)
+	GetStorageAt(ctx context.Context, address common.Address, position *big.Int, blockNumber uint64, dbTx pgx.Tx) (*big.Int, error)
+	GetSyncingInfo(ctx context.Context, dbTx pgx.Tx) (state.SyncingInfo, error)
+	GetTransactionByHash(ctx context.Context, transactionHash common.Hash, dbTx pgx.Tx) (*types.Transaction, error)
+	GetTransactionByL2BlockHashAndIndex(ctx context.Context, blockHash common.Hash, index uint64, dbTx pgx.Tx) (*types.Transaction, error)
+	GetTransactionByL2BlockNumberAndIndex(ctx context.Context, blockNumber uint64, index uint64, dbTx pgx.Tx) (*types.Transaction, error)
+	GetTransactionReceipt(ctx context.Context, transactionHash common.Hash, dbTx pgx.Tx) (*types.Receipt, error)
 	IsL2BlockConsolidated(ctx context.Context, blockNumber int, dbTx pgx.Tx) (bool, error)
 	IsL2BlockVirtualized(ctx context.Context, blockNumber int, dbTx pgx.Tx) (bool, error)
+	ProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, blockNumber *uint64, dbTx pgx.Tx) *runtime.ExecutionResult
 }
 
 type storageInterface interface {
-	NewLogFilter(filter LogFilter) (uint64, error)
-	NewBlockFilter() (uint64, error)
-	NewPendingTransactionFilter() (uint64, error)
 	GetFilter(filterID uint64) (*Filter, error)
-	UpdateFilterLastPoll(filterID uint64) error
+	NewBlockFilter() (uint64, error)
+	NewLogFilter(filter LogFilter) (uint64, error)
+	NewPendingTransactionFilter() (uint64, error)
 	UninstallFilter(filterID uint64) (bool, error)
+	UpdateFilterLastPoll(filterID uint64) error
 }

--- a/jsonrpc/mock_pool_test.go
+++ b/jsonrpc/mock_pool_test.go
@@ -56,6 +56,27 @@ func (_m *poolMock) GetGasPrice(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
+// GetNonce provides a mock function with given fields: ctx, address
+func (_m *poolMock) GetNonce(ctx context.Context, address common.Address) (uint64, error) {
+	ret := _m.Called(ctx, address)
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(context.Context, common.Address) uint64); ok {
+		r0 = rf(ctx, address)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, common.Address) error); ok {
+		r1 = rf(ctx, address)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetPendingTxHashesSince provides a mock function with given fields: ctx, since
 func (_m *poolMock) GetPendingTxHashesSince(ctx context.Context, since time.Time) ([]common.Hash, error) {
 	ret := _m.Called(ctx, since)

--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -11,22 +11,23 @@ import (
 
 type storage interface {
 	AddTx(ctx context.Context, tx Transaction) error
-	GetTxsByState(ctx context.Context, state TxState, isClaims bool, limit uint64) ([]Transaction, error)
-	UpdateTxState(ctx context.Context, hash common.Hash, newState TxState) error
-	UpdateTxsState(ctx context.Context, hashes []common.Hash, newState TxState) error
-	SetGasPrice(ctx context.Context, gasPrice uint64) error
-	GetGasPrice(ctx context.Context) (uint64, error)
 	CountTransactionsByState(ctx context.Context, state TxState) (uint64, error)
-	GetPendingTxHashesSince(ctx context.Context, since time.Time) ([]common.Hash, error)
-	IsTxPending(ctx context.Context, hash common.Hash) (bool, error)
 	DeleteTxsByHashes(ctx context.Context, hashes []common.Hash) error
-	MarkReorgedTxsAsPending(ctx context.Context) error
+	GetGasPrice(ctx context.Context) (uint64, error)
+	GetNonce(ctx context.Context, address common.Address) (uint64, error)
+	GetPendingTxHashesSince(ctx context.Context, since time.Time) ([]common.Hash, error)
 	GetTopPendingTxByProfitabilityAndZkCounters(ctx context.Context, maxZkCounters ZkCounters) (*Transaction, error)
 	GetTxsByFromAndNonce(ctx context.Context, from common.Address, nonce uint64) ([]Transaction, error)
+	GetTxsByState(ctx context.Context, state TxState, isClaims bool, limit uint64) ([]Transaction, error)
+	IsTxPending(ctx context.Context, hash common.Hash) (bool, error)
+	MarkReorgedTxsAsPending(ctx context.Context) error
+	SetGasPrice(ctx context.Context, gasPrice uint64) error
+	UpdateTxsState(ctx context.Context, hashes []common.Hash, newState TxState) error
+	UpdateTxState(ctx context.Context, hash common.Hash, newState TxState) error
 }
 
 type stateInterface interface {
+	GetBalance(ctx context.Context, address common.Address, batchNumber uint64, dbTx pgx.Tx) (*big.Int, error)
 	GetLastL2BlockNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error)
 	GetNonce(ctx context.Context, address common.Address, batchNumber uint64, dbTx pgx.Tx) (uint64, error)
-	GetBalance(ctx context.Context, address common.Address, batchNumber uint64, dbTx pgx.Tx) (*big.Int, error)
 }


### PR DESCRIPTION
The issue this PR is involved is the #1061

### What does this PR do?

fix the jRPC `eth_getTransactionCount` method to handle `pending` block properly and consider the transactions into the pool.

### Reviewers

Main reviewers:

@arnaubennassar 
@KonradIT 
@Mikelle 