### PR TITLE
add support for pending block for GetBlockTransactionCountByNumber jRPC method

### DIFF
--- a/jsonrpc/eth.go
+++ b/jsonrpc/eth.go
@@ -496,6 +496,14 @@ func (e *Eth) GetBlockTransactionCountByHash(hash common.Hash) (interface{}, rpc
 // block from a block mlocking the given block number.
 func (e *Eth) GetBlockTransactionCountByNumber(number *BlockNumber) (interface{}, rpcError) {
 	return e.txMan.NewDbTxScope(e.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, rpcError) {
+		if number != nil && *number == PendingBlockNumber {
+			c, err := e.pool.CountPendingTransactions(ctx)
+			if err != nil {
+				return rpcErrorResponse(defaultErrorCode, "failed to count pending transactions", err)
+			}
+			return argUint64(c), nil
+		}
+
 		var err error
 		blockNumber, rpcErr := number.getNumericBlockNumber(ctx, e.state, dbTx)
 		if rpcErr != nil {

--- a/jsonrpc/interfaces.go
+++ b/jsonrpc/interfaces.go
@@ -20,6 +20,7 @@ type jsonRPCTxPool interface {
 	GetNonce(ctx context.Context, address common.Address) (uint64, error)
 	GetPendingTxHashesSince(ctx context.Context, since time.Time) ([]common.Hash, error)
 	GetPendingTxs(ctx context.Context, isClaims bool, limit uint64) ([]pool.Transaction, error)
+	CountPendingTransactions(ctx context.Context) (uint64, error)
 }
 
 // gasPriceEstimator contains the methods required to interact with gas price estimator

--- a/jsonrpc/mock_pool_test.go
+++ b/jsonrpc/mock_pool_test.go
@@ -35,6 +35,27 @@ func (_m *poolMock) AddTx(ctx context.Context, tx types.Transaction) error {
 	return r0
 }
 
+// CountPendingTransactions provides a mock function with given fields: ctx
+func (_m *poolMock) CountPendingTransactions(ctx context.Context) (uint64, error) {
+	ret := _m.Called(ctx)
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(context.Context) uint64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetGasPrice provides a mock function with given fields: ctx
 func (_m *poolMock) GetGasPrice(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
The PR is related to this issue: #1061

### What does this PR do?

Fix the GetBlockTransactionCountByNumber method to handle `pending` block properly consuming the information from the pool.

### Reviewers

Main reviewers:

@arnaubennassar 
@KonradIT 
@Mikelle 