### PR TITLE
Fix receiver address when nil on test-vector

### DIFF
--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1211,8 +1211,12 @@ func TestExecutorTxHashAndRLP(t *testing.T) {
 	require.NoError(t, err)
 
 	for x, testCase := range testCases {
-		var receiverAddress = common.HexToAddress(testCase.To)
 		var stateRoot = state.ZeroHash
+		var receiverAddress = common.HexToAddress(testCase.To)
+		receiver := &receiverAddress
+		if testCase.To == "0x" {
+			receiver = nil
+		}
 
 		v, ok := new(big.Int).SetString(testCase.V, 0)
 		require.Equal(t, true, ok)
@@ -1242,7 +1246,7 @@ func TestExecutorTxHashAndRLP(t *testing.T) {
 		// Create transaction
 		tx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce.Uint64(),
-			To:       &receiverAddress,
+			To:       receiver,
 			Value:    value,
 			Gas:      gasLimit.Uint64(),
 			GasPrice: gasPrice,


### PR DESCRIPTION
### What does this PR do?

Fixes how receiver address is managed during a test when the address is nil in the test-vector.

### Reviewers

Main reviewers:

- @arnaubennassar 
