### PR TITLE
Allow batches without txs to be stored by the synchronizer

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -524,9 +524,13 @@ func (s *State) closeSynchronizedBatch(ctx context.Context, receipt ProcessingRe
 		return err
 	}
 
-	if len(txs) == 0 {
-		return ErrClosingBatchWithoutTxs
-	}
+	// TODO: Modification done to bypass situation detected during testnet testing
+	// 		 Further analysis of this is needed
+	/*
+		if len(txs) == 0 {
+			return ErrClosingBatchWithoutTxs
+		}
+	*/
 
 	batchL2Data, err := EncodeTransactions(txs)
 	if err != nil {


### PR DESCRIPTION
Closes #1167 

### What does this PR do?

Allows the synchronizer to store empty batches.

### Reviewers

Main reviewers:

- @Mikelle 