### PR TITLE
Allow synchronizer to store empty batches

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -525,7 +525,7 @@ func (s *State) closeSynchronizedBatch(ctx context.Context, receipt ProcessingRe
 	}
 
 	// TODO: Modification done to bypass situation detected during testnet testing
-	// 		 Further analysis fo this is needed
+	// Further analysis is needed
 	/*
 		if len(txs) == 0 {
 			return ErrClosingBatchWithoutTxs

--- a/state/state.go
+++ b/state/state.go
@@ -524,9 +524,13 @@ func (s *State) closeSynchronizedBatch(ctx context.Context, receipt ProcessingRe
 		return err
 	}
 
-	if len(txs) == 0 {
-		return ErrClosingBatchWithoutTxs
-	}
+	// TODO: Modification done to bypass situation detected during testnet testing
+	// 		 Further analysis fo this is needed
+	/*
+		if len(txs) == 0 {
+			return ErrClosingBatchWithoutTxs
+		}
+	*/
 
 	batchL2Data, err := EncodeTransactions(txs)
 	if err != nil {


### PR DESCRIPTION
Closes #1167 

### What does this PR do?

Allows synchronizer to store empty batches.

### Reviewers

Main reviewers:

- @Mikelle 