### PR TITLE
Revert batch data size to 30K

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -204,14 +204,14 @@ func (p *Pool) validateTx(ctx context.Context, tx types.Transaction) error {
 // GasLimit: 256 bits
 // GasPrice: 256 bits
 // Value: 256 bits
-// Data: 60000 bytes
+// Data: 30000 bytes
 // Nonce: 64 bits
 // To: 160 bits
 // ChainId: 64 bits
 func (p *Pool) checkTxFieldCompatibilityWithExecutor(ctx context.Context, tx types.Transaction) error {
 	maxUint64BigInt := big.NewInt(0).SetUint64(math.MaxUint64)
 
-	const maxDataSize = 60000
+	const maxDataSize = 30000
 
 	// GasLimit, Nonce and To fields are limited by their types, no need to check
 	// Gas Price and Value are checked against the balance, and the max balance allowed

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -821,9 +821,9 @@ func Test_TryAddIncompatibleTxs(t *testing.T) {
 			expectedError: pool.ErrInsufficientFunds,
 		},
 		{
-			name: "data over 60k bytes",
+			name: "data over 30k bytes",
 			createIncompatibleTx: func() types.Transaction {
-				data := [60001]byte{}
+				data := [30001]byte{}
 				tx := types.NewTransaction(uint64(0),
 					common.HexToAddress("0x1"),
 					big.NewInt(1), uint64(1), big.NewInt(1), data[:])
@@ -831,7 +831,7 @@ func Test_TryAddIncompatibleTxs(t *testing.T) {
 				require.NoError(t, err)
 				return *signedTx
 			},
-			expectedError: fmt.Errorf("data size bigger than allowed, current size is %v bytes and max allowed is %v bytes", 60001, 60000),
+			expectedError: fmt.Errorf("data size bigger than allowed, current size is %v bytes and max allowed is %v bytes", 30001, 30000),
 		},
 		{
 			name: "chain id over 64 bits",

--- a/sequencer/batchbuilder.go
+++ b/sequencer/batchbuilder.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	maxTxsPerBatch    uint64 = 150
-	maxBatchBytesSize int    = 60000
+	maxBatchBytesSize int    = 30000
 )
 
 type processTxResponse struct {


### PR DESCRIPTION
Closes #1216

### What does this PR do?

Revert batch data size checks to 30K

### Reviewers

Main reviewers:

- @arnaubennassar 
- @Mikelle 