### PR TITLE
adding ooc handling

### DIFF
--- a/sequencer/batchbuilder.go
+++ b/sequencer/batchbuilder.go
@@ -135,7 +135,7 @@ func (s *Sequencer) tryToProcessTx(ctx context.Context, ticker *time.Ticker) {
 
 		// in that case executor meets OOC error, try to reprocess only tx with OOC after this error
 		// len(s.sequenceInProgress.Txs) == 0 - so it means, there is no valid txs and before OOC there are only
-		// instric invalid txs
+		// intrinsic invalid txs
 		var isOOCError bool
 		if len(s.sequenceInProgress.Txs) == 0 && !processResponse.isBatchProcessed {
 			lastUnprocessedTxHash := processResponse.unprocessedTxsHashes[len(processResponse.unprocessedTxsHashes)-1]


### PR DESCRIPTION
Adding handling of the case, when batch consists of the failed intrinsic value transaction and meets OOC error. Here batchbuilder is trying to reprocess only tx with OOC error. If it fails to be processed again, tx is marked as invalid.
### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @arnaubennassar 