### PR TITLE
improve: adding commit hash as env var in docker and printing it along with the version on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN cd /src && make build
 
 # CONTAINER FOR RUNNING BINARY
 FROM alpine:3.16.0
+ARG BUILD_COMMIT
+ENV COMMIT_HASH $BUILD_COMMIT
 COPY --from=build /src/dist/zkevm-node /app/zkevm-node
 COPY --from=build /src/config/environments/local/local.node.config.toml /app/example.config.toml
 EXPOSE 8123

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GOBIN := $(GOBASE)/dist
 GOENVVARS := GOBIN=$(GOBIN) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 GOBINARY := zkevm-node
 GOCMD := $(GOBASE)/cmd
+$(eval BUILD_COMMIT:=$(shell git rev-parse --short HEAD))
 
 .PHONY: build
 build: ## Builds the binary locally into ./dist
@@ -15,11 +16,11 @@ build: ## Builds the binary locally into ./dist
 
 .PHONY: build-docker
 build-docker: ## Builds a docker image with the node binary
-	docker build -t zkevm-node -f ./Dockerfile .
+	docker build -t zkevm-node --build-arg BUILD_COMMIT="$(BUILD_COMMIT)" -f ./Dockerfile .
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the node binary - but without build cache
-	docker build --no-cache=true -t zkevm-node -f ./Dockerfile .
+	docker build --no-cache=true -t zkevm-node --build-arg BUILD_COMMIT="$(BUILD_COMMIT)" -f ./Dockerfile .
 
 .PHONY: run-rpc
 run-rpc: ## Runs all the services need to run a local zkEMV RPC node

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc"
 	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/test/testutils"
 	"github.com/urfave/cli/v2"
 )
 
@@ -15,8 +16,6 @@ const (
 	appName = "zkevm-node"
 	// version represents the program based on the git tag
 	version = "v0.1.0"
-	// commit represents the program based on the git commit
-	commit = "dev"
 	// date represents the date of application was built
 	date = ""
 )
@@ -34,7 +33,14 @@ const (
 	BROADCAST = "broadcast-trusted-state"
 )
 
+const (
+	//envCommitHash environment variable name for COMMIT_HASH
+	envCommitHash = "COMMIT_HASH"
+)
+
 var (
+	// commit represents the program based on the git commit
+	commit         = testutils.GetEnv(envCommitHash, "dev")
 	configFileFlag = cli.StringFlag{
 		Name:     config.FlagCfg,
 		Aliases:  []string{"c"},
@@ -79,6 +85,7 @@ func main() {
 		&componentsFlag,
 		&httpAPIFlag,
 	}
+	log.Infof("Starting application [Commit Hash: %s, Version: %s] ...", commit, version)
 	app.Commands = []*cli.Command{
 		{
 			Name:    "version",


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolai_nedkov@yahoo.com>

Closes #1173.

### What does this PR do?

Getting the `COMMIT_HASH`  inside root `Makefile` and passing it to both `docker build` commands as argument `BUILD_COMMIT`. Exporting the commit hash as an environment variable inside the `Dockerfile`. Getting the variable inside `main.go` and printing the  `COMMIT_HASH` along with the `VERSION` at the beginning.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @KonradIT 
- @ARR552 
- @kind84 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @KonradIT
- @tclemos 