### PR TITLE
improve: making the timeout of the RPC server to be configurable and fixing deprecated func for creating temp file.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"flag"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -212,6 +211,14 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: int(8123),
 		},
 		{
+			path:          "RPC.ReadTimeoutInSec",
+			expectedValue: time.Duration(1),
+		},
+		{
+			path:          "RPC.WriteTimeoutInSec",
+			expectedValue: time.Duration(1),
+		},
+		{
 			path:          "RPC.SequencerNodeURI",
 			expectedValue: "",
 		},
@@ -268,7 +275,7 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: 61090,
 		},
 	}
-	file, err := ioutil.TempFile("", "genesisConfig")
+	file, err := os.CreateTemp("", "genesisConfig")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.Remove(file.Name()))

--- a/config/default.go
+++ b/config/default.go
@@ -47,6 +47,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
+ReadTimeoutInSec = 1
+WriteTimeoutInSec = 1
 MaxRequestsPerIPAndSecond = 50
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"

--- a/config/default.go
+++ b/config/default.go
@@ -47,8 +47,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
-ReadTimeoutInSec = 1
-WriteTimeoutInSec = 1
+ReadTimeoutInSec = 60
+WriteTimeoutInSec = 60
 MaxRequestsPerIPAndSecond = 50
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"

--- a/config/environments/local/debug.node.config.toml
+++ b/config/environments/local/debug.node.config.toml
@@ -43,8 +43,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
-ReadTimeoutInSec = 1
-WriteTimeoutInSec = 1
+ReadTimeoutInSec = 60
+WriteTimeoutInSec = 60
 MaxRequestsPerIPAndSecond = 10000
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"

--- a/config/environments/local/debug.node.config.toml
+++ b/config/environments/local/debug.node.config.toml
@@ -43,6 +43,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
+ReadTimeoutInSec = 1
+WriteTimeoutInSec = 1
 MaxRequestsPerIPAndSecond = 10000
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -43,6 +43,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8545
+ReadTimeoutInSec = 1
+WriteTimeoutInSec = 1
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://internal.zkevm-test.net:2083/"
 BroadcastURI = "internal.zkevm-test.net:61090"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -43,8 +43,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8545
-ReadTimeoutInSec = 1
-WriteTimeoutInSec = 1
+ReadTimeoutInSec = 60
+WriteTimeoutInSec = 60
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://internal.zkevm-test.net:2083/"
 BroadcastURI = "internal.zkevm-test.net:61090"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -31,8 +31,8 @@ GlobalExitRootManagerAddr = "0x762d09Ed110ace4EaC94acbb67b1C35D16C3297b"
 [RPC]
 Host = "0.0.0.0"
 Port = 8545
-ReadTimeoutInSec = 1
-WriteTimeoutInSec = 1
+ReadTimeoutInSec = 60
+WriteTimeoutInSec = 60
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://public.zkevm-test.net:2083"
 BroadcastURI = "public-grpc.zkevm-test.net:61090"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -31,6 +31,8 @@ GlobalExitRootManagerAddr = "0x762d09Ed110ace4EaC94acbb67b1C35D16C3297b"
 [RPC]
 Host = "0.0.0.0"
 Port = 8545
+ReadTimeoutInSec = 1
+WriteTimeoutInSec = 1
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://public.zkevm-test.net:2083"
 BroadcastURI = "public-grpc.zkevm-test.net:61090"

--- a/jsonrpc/config.go
+++ b/jsonrpc/config.go
@@ -1,11 +1,17 @@
 package jsonrpc
 
-import "github.com/0xPolygonHermez/zkevm-node/db"
+import (
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/db"
+)
 
 // Config represents the configuration of the json rpc
 type Config struct {
-	Host string `mapstructure:"Host"`
-	Port int    `mapstructure:"Port"`
+	Host              string        `mapstructure:"Host"`
+	Port              int           `mapstructure:"Port"`
+	ReadTimeoutInSec  time.Duration `mapstructure:"ReadTimeoutInSec"`
+	WriteTimeoutInSec time.Duration `mapstructure:"WriteTimeoutInSec"`
 
 	MaxRequestsPerIPAndSecond float64 `mapstructure:"MaxRequestsPerIPAndSecond"`
 

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/didip/tollbooth/v6"
@@ -99,7 +100,9 @@ func (s *Server) Start() error {
 	mux.Handle("/", tollbooth.LimitFuncHandler(lmt, s.handle))
 
 	s.srv = &http.Server{
-		Handler: mux,
+		Handler:      mux,
+		ReadTimeout:  s.config.ReadTimeoutInSec * time.Second,
+		WriteTimeout: s.config.WriteTimeoutInSec * time.Second,
 	}
 	if err := s.srv.Serve(lis); err != nil {
 		if err == http.ErrServerClosed {

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -39,8 +39,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
-ReadTimeoutInSec = 1
-WriteTimeoutInSec = 1
+ReadTimeoutInSec = 60
+WriteTimeoutInSec = 60
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -39,6 +39,8 @@ PercentageToIncreaseGasLimit = 10
 [RPC]
 Host = "0.0.0.0"
 Port = 8123
+ReadTimeoutInSec = 1
+WriteTimeoutInSec = 1
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
 BroadcastURI = "127.0.0.1:61090"


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolai_nedkov@yahoo.com>

Closes #614 .

### What does this PR do?

Making the `ReadTimeout` and `WriteTimeout` of the `RPC HTTP Server` to be configurable by expecting values in the `config file` in seconds with the following names:
`ReadTimeoutInSec`
`WriteTimeoutInSec`

And fixing deprecated function use in `config.go` for creating temp file.

### Reviewers

- @KonradIT 
- @kind84 
- @tclemos 
- @ARR552 

Main reviewers:

- @KonradIT 
- @kind84 