### PR TITLE
improve: removing redundant db connections and running of migrations in Approve command.

### DIFF
--- a/cmd/approve.go
+++ b/cmd/approve.go
@@ -37,10 +37,6 @@ func approveTokens(ctx *cli.Context) error {
 
 	setupLog(c.Log)
 
-	runStateMigrations(c.StateDB)
-	runPoolMigrations(c.PoolDB)
-	runRPCMigrations(c.RPC.DB)
-
 	// Check if it is already registered
 	etherman, err := newEtherman(*c)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolai_nedkov@yahoo.com>

Closes #693

### What does this PR do?

Removing init of `DB connections` and running `migrations` in `cmd/approve`.
Note: `register` command seems to be something legacy which doesn't exist now.

### Reviewers
- @KonradIT 
- @kind84 
- @ARR552 
- @tclemos 

Main reviewers:
- @KonradIT 
- @kind84 