### PR TITLE
feat: adding new JSON-RPC enpoint 'BatchNumberOfL2Block'.

### DIFF
--- a/jsonrpc/interfaces.go
+++ b/jsonrpc/interfaces.go
@@ -38,6 +38,7 @@ type stateInterface interface {
 	GetCode(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) ([]byte, error)
 	GetL2BlockByHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (*types.Block, error)
 	GetL2BlockByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*types.Block, error)
+	GetBatchNumberOfL2Block(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (uint64, error)
 	GetL2BlockHashesSince(ctx context.Context, since time.Time, dbTx pgx.Tx) ([]common.Hash, error)
 	GetL2BlockHeaderByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*types.Header, error)
 	GetL2BlockTransactionCountByHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (uint64, error)

--- a/jsonrpc/mock_state_test.go
+++ b/jsonrpc/mock_state_test.go
@@ -116,6 +116,27 @@ func (_m *stateMock) GetBalance(ctx context.Context, address common.Address, blo
 	return r0, r1
 }
 
+// GetBatchNumberOfL2Block provides a mock function with given fields: ctx, blockNumber, dbTx
+func (_m *stateMock) GetBatchNumberOfL2Block(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (uint64, error) {
+	ret := _m.Called(ctx, blockNumber, dbTx)
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) uint64); ok {
+		r0 = rf(ctx, blockNumber, dbTx)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, blockNumber, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetCode provides a mock function with given fields: ctx, address, blockNumber, dbTx
 func (_m *stateMock) GetCode(ctx context.Context, address common.Address, blockNumber uint64, dbTx pgx.Tx) ([]byte, error) {
 	ret := _m.Called(ctx, address, blockNumber, dbTx)

--- a/jsonrpc/zkevm.go
+++ b/jsonrpc/zkevm.go
@@ -57,6 +57,20 @@ func (h *ZKEVM) IsL2BlockVirtualized(blockNumber int) (interface{}, rpcError) {
 	})
 }
 
+// BatchNumberOfL2Block returns the batch number from which the passed block number is created
+func (h *ZKEVM) BatchNumberOfL2Block(blockNumber uint64) (interface{}, rpcError) {
+	return h.txMan.NewDbTxScope(h.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, rpcError) {
+		batchNum, err := h.state.GetBatchNumberOfL2Block(ctx, blockNumber, dbTx)
+		if err != nil {
+			const errorMessage = "failed to get batch number of l2 batchNum"
+			log.Errorf("%v:%v", errorMessage, err)
+			return nil, newRPCError(defaultErrorCode, errorMessage)
+		}
+
+		return batchNum, nil
+	})
+}
+
 // GetBroadcastURI returns the IP:PORT of the broadcast service provided
 // by the Trusted Sequencer JSON RPC server
 func (h *ZKEVM) GetBroadcastURI() (interface{}, rpcError) {

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -80,11 +80,12 @@ const (
 		 INNER JOIN state.l2block consolidated_blocks
 			ON consolidated_blocks.batch_num = sy.last_batch_num_consolidated;
 	`
-	addTransactionSQL          = "INSERT INTO state.transaction (hash, encoded, decoded, l2_block_num) VALUES($1, $2, $3, $4)"
-	getBatchNumByBlockNum      = "SELECT batch_num FROM state.virtual_batch WHERE block_num <= $1 ORDER BY batch_num DESC LIMIT 1"
-	getTxsHashesBeforeBatchNum = "SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num <= $1"
-	isL2BlockVirtualized       = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.virtual_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
-	isL2BlockConsolidated      = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.verified_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
+	addTransactionSQL                     = "INSERT INTO state.transaction (hash, encoded, decoded, l2_block_num) VALUES($1, $2, $3, $4)"
+	getBatchNumByBlockNumFromVirtualBatch = "SELECT batch_num FROM state.virtual_batch WHERE block_num <= $1 ORDER BY batch_num DESC LIMIT 1"
+	getBatchNumByBlockNum                 = "SELECT batch_num FROM state.l2block WHERE block_num = $1"
+	getTxsHashesBeforeBatchNum            = "SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num <= $1"
+	isL2BlockVirtualized                  = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.virtual_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
+	isL2BlockConsolidated                 = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.verified_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
 )
 
 // PostgresStorage implements the Storage interface
@@ -152,7 +153,7 @@ func (p *PostgresStorage) GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Block
 		return nil, errors.New("blockNumDiff is too big, there are no txs to delete")
 	}
 
-	err = e.QueryRow(ctx, getBatchNumByBlockNum, blockNum).Scan(&batchNum)
+	err = e.QueryRow(ctx, getBatchNumByBlockNumFromVirtualBatch, blockNum).Scan(&batchNum)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	} else if err != nil {
@@ -947,6 +948,21 @@ func (p *PostgresStorage) AddBatchNumberInForcedBatch(ctx context.Context, force
 	e := p.getExecQuerier(dbTx)
 	_, err := e.Exec(ctx, addBatchNumberInForcedBatchSQL, forceBatchNumber, batchNumber)
 	return err
+}
+
+// GetBatchNumberOfL2Block gets a batch number for l2 block by its number
+func (p *PostgresStorage) GetBatchNumberOfL2Block(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (uint64, error) {
+	batchNumber := uint64(0)
+	q := p.getExecQuerier(dbTx)
+	err := q.QueryRow(ctx, getBatchNumByBlockNum, blockNumber).
+		Scan(&batchNumber)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return batchNumber, ErrNotFound
+	} else if err != nil {
+		return batchNumber, err
+	}
+	return batchNumber, nil
 }
 
 // GetL2BlockByNumber gets a l2 block by its number

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -82,7 +82,6 @@ const (
 	`
 	addTransactionSQL                     = "INSERT INTO state.transaction (hash, encoded, decoded, l2_block_num) VALUES($1, $2, $3, $4)"
 	getBatchNumByBlockNumFromVirtualBatch = "SELECT batch_num FROM state.virtual_batch WHERE block_num <= $1 ORDER BY batch_num DESC LIMIT 1"
-	getBatchNumByBlockNum                 = "SELECT batch_num FROM state.l2block WHERE block_num = $1"
 	getTxsHashesBeforeBatchNum            = "SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num <= $1"
 	isL2BlockVirtualized                  = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.virtual_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
 	isL2BlockConsolidated                 = "SELECT l2b.block_num FROM state.l2block l2b INNER JOIN state.verified_batch vb ON vb.batch_num = l2b.batch_num WHERE l2b.block_num = $1"
@@ -952,6 +951,7 @@ func (p *PostgresStorage) AddBatchNumberInForcedBatch(ctx context.Context, force
 
 // GetBatchNumberOfL2Block gets a batch number for l2 block by its number
 func (p *PostgresStorage) GetBatchNumberOfL2Block(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (uint64, error) {
+	getBatchNumByBlockNum := "SELECT batch_num FROM state.l2block WHERE block_num = $1"
 	batchNumber := uint64(0)
 	q := p.getExecQuerier(dbTx)
 	err := q.QueryRow(ctx, getBatchNumByBlockNum, blockNumber).

--- a/state/pgstatestorage_test.go
+++ b/state/pgstatestorage_test.go
@@ -1,0 +1,88 @@
+package state_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	pgStateStorage *state.PostgresStorage
+	block          = &state.Block{
+		BlockNumber: 1,
+		BlockHash:   common.HexToHash("0x29e885edaf8e4b51e1d2e05f9da28161d2fb4f6b1d53827d9b80a23cf2d7d9f1"),
+		ParentHash:  common.HexToHash("0x29e885edaf8e4b51e1d2e05f9da28161d2fb4f6b1d53827d9b80a23cf2d7d9f1"),
+		ReceivedAt:  time.Now(),
+	}
+)
+
+func setup() {
+	pgStateStorage = state.NewPostgresStorage(stateDb)
+}
+
+func TestGetBatchByL2BlockNumber(t *testing.T) {
+	setup()
+	ctx := context.Background()
+	dbTx, err := testState.BeginStateTransaction(ctx)
+	require.NoError(t, err)
+	err = testState.AddBlock(ctx, block, dbTx)
+	assert.NoError(t, err)
+
+	batchNumber := uint64(1)
+	_, err = testState.PostgresStorage.Exec(ctx, "INSERT INTO state.batch (batch_num) VALUES ($1)", batchNumber)
+	assert.NoError(t, err)
+
+	time := time.Now()
+	blockNumber := big.NewInt(1)
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		To:       nil,
+		Value:    new(big.Int),
+		Gas:      0,
+		GasPrice: big.NewInt(0),
+	})
+
+	receipt := &types.Receipt{
+		Type:              uint8(tx.Type()),
+		PostState:         state.ZeroHash.Bytes(),
+		CumulativeGasUsed: 0,
+		BlockNumber:       blockNumber,
+		GasUsed:           tx.Gas(),
+		TxHash:            tx.Hash(),
+		TransactionIndex:  0,
+		Status:            types.ReceiptStatusSuccessful,
+	}
+
+	header := &types.Header{
+		Number:     big.NewInt(1),
+		ParentHash: state.ZeroHash,
+		Coinbase:   state.ZeroAddress,
+		Root:       state.ZeroHash,
+		GasUsed:    1,
+		GasLimit:   10,
+		Time:       uint64(time.Unix()),
+	}
+	transactions := []*types.Transaction{tx}
+
+	receipts := []*types.Receipt{receipt}
+
+	// Create block to be able to calculate its hash
+	l2Block := types.NewBlock(header, transactions, []*types.Header{}, receipts, &trie.StackTrie{})
+	receipt.BlockHash = l2Block.Hash()
+
+	err = pgStateStorage.AddL2Block(ctx, batchNumber, l2Block, receipts, dbTx)
+	require.NoError(t, err)
+	result, err := pgStateStorage.GetBatchNumberOfL2Block(ctx, l2Block.Number().Uint64(), dbTx)
+	require.NoError(t, err)
+	assert.Equal(t, batchNumber, result)
+	require.NoError(t, dbTx.Commit(ctx))
+}


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolai_nedkov@yahoo.com>

Closes #1281.

### What does this PR do?

The `JSON-RPC` component exposes a new endpoint for getting the `batch number` of `L2 Block` by its number.

### Reviewers

Main reviewers:
- @tclemos 
- @KonradIT
- @arnaubennassar 

Codeowner reviewers:
- @tclemos
- @arnaubennassar 