### PR TITLE
Txsender script

### DIFF
--- a/test/e2e/ethtransfer_test.go
+++ b/test/e2e/ethtransfer_test.go
@@ -68,6 +68,6 @@ func TestEthTransfer(t *testing.T) {
 		txs = append(txs, tx)
 	}
 
-	err = operations.ApplyTxs(ctx, txs)
+	err = operations.ApplyL2Txs(ctx, txs, auth, client)
 	require.NoError(t, err)
 }

--- a/test/e2e/state_test.go
+++ b/test/e2e/state_test.go
@@ -69,7 +69,7 @@ func TestStateTransition(t *testing.T) {
 			}
 
 			// send transactions
-			require.NoError(t, operations.ApplyTxs(ctx, txs))
+			require.NoError(t, operations.ApplyL2Txs(ctx, txs, nil, nil))
 
 			st := opsman.State()
 

--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -200,7 +200,7 @@ func ApplyTxs(ctx context.Context, txs []*types.Transaction) error {
 	}
 
 	// wait for TX to be mined
-	timeout := 180 * time.Second
+	timeout := 180 * time.Second //nolint:gomnd
 	for _, tx := range sentTxs {
 		log.Infof("Waiting Tx %s to be mined", tx.Hash())
 		err = WaitTxToBeMined(ctx, client, tx, timeout)
@@ -237,14 +237,14 @@ func ApplyTxs(ctx context.Context, txs []*types.Transaction) error {
 
 	// wait for l2 block to be virtualized
 	log.Infof("waiting for the block number %v to be virtualized", l2BlockNumber.String())
-	err = WaitL2BlockToBeVirtualized(l2BlockNumber, 4*time.Minute)
+	err = WaitL2BlockToBeVirtualized(l2BlockNumber, 4*time.Minute) //nolint:gomnd
 	if err != nil {
 		return err
 	}
 
 	// wait for l2 block number to be consolidated
 	log.Infof("waiting for the block number %v to be consolidated", l2BlockNumber.String())
-	err = WaitL2BlockToBeConsolidated(l2BlockNumber, 4*time.Minute)
+	err = WaitL2BlockToBeConsolidated(l2BlockNumber, 4*time.Minute) //nolint:gomnd
 	if err != nil {
 		return err
 	}

--- a/test/scripts/txsender/README.md
+++ b/test/scripts/txsender/README.md
@@ -1,0 +1,36 @@
+# Txsender
+
+## Overview
+
+This script allows to send a specified number of transactions to either L1 or
+L2 (or both).  Optionally it can wait for the transactions to be verified.
+
+## Usage
+
+The script can be installed running `go install` from this folder.
+
+## Examples
+
+- Send 1 transaction on L2:
+
+```sh
+$ txsender 
+```
+
+- Send 1 transaction on L2 and wait for it to be validated:
+
+```sh
+$ txsender -w send
+```
+
+- Send 42 transactions on L1:
+
+```sh
+$ txsender -n l1 send 42
+```
+
+- Send 42 transactions both on L1 and L2 with verbose logs and wait for the validations:
+
+```sh
+$ txsender -v -w -n l1 -n l2 send 42
+```

--- a/test/scripts/txsender/main.go
+++ b/test/scripts/txsender/main.go
@@ -76,6 +76,7 @@ Optionally it can wait for the transactions to be validated.`
 	txsender.Commands = []*cli.Command{
 		{
 			Name:    "send",
+			Before:  setLogLevel,
 			Aliases: []string{},
 			Usage:   "Sends the specified number of transactions",
 			Description: `This command sends the specified number of transactions.
@@ -92,15 +93,18 @@ If --wait flag is used, it waits for the corresponding validation transaction.`,
 	}
 }
 
-func sendTxs(cliCtx *cli.Context) error {
-	ctx := cliCtx.Context
-
+func setLogLevel(ctx *cli.Context) error {
 	logLevel := "info"
-	if cliCtx.Bool(flagVerboseName) {
+	if ctx.Bool(flagVerboseName) {
 		logLevel = "debug"
 	}
 
 	log.Init(log.Config{Level: logLevel, Outputs: []string{"stdout"}})
+	return nil
+}
+
+func sendTxs(cliCtx *cli.Context) error {
+	ctx := cliCtx.Context
 
 	nTxs := 1 // send 1 tx by default
 	if cliCtx.NArg() > 0 {

--- a/test/scripts/txsender/main.go
+++ b/test/scripts/txsender/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	// Send txs
-	amount := big.NewInt(10000)
+	amount := big.NewInt(10000) //nolint:gomnd
 	toAddress := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 	senderBalance, err := client.BalanceAt(ctx, auth.From, nil)
 	if err != nil {

--- a/test/scripts/txsender/main.go
+++ b/test/scripts/txsender/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -13,75 +12,199 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/urfave/cli/v2"
 )
 
-const maxTxs int = 1e6
+const (
+	flagNetworkName       = "network"
+	flagWaitName          = "wait"
+	flagVerboseName       = "verbose"
+	flagNetworkLocalL1Key = "l1"
+	flagNetworkLocalL2Key = "l2"
+	defaultNetwork        = flagNetworkLocalL2Key
+
+	receiverAddr = "0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D"
+)
+
+type networkLayer int
+
+const (
+	networkLayer1 networkLayer = iota
+	networkLayer2
+)
+
+var networks = map[string]struct {
+	Name       string
+	URL        string
+	ChainID    uint64
+	PrivateKey string
+	networkLayer
+}{
+	flagNetworkLocalL1Key: {Name: "Local L1", URL: operations.DefaultL1NetworkURL, ChainID: operations.DefaultL1ChainID, PrivateKey: operations.DefaultSequencerPrivateKey, networkLayer: networkLayer1},
+	flagNetworkLocalL2Key: {Name: "Local L2", URL: operations.DefaultL2NetworkURL, ChainID: operations.DefaultL2ChainID, PrivateKey: operations.DefaultSequencerPrivateKey, networkLayer: networkLayer2},
+}
+
+var (
+	flagNetwork = cli.StringSliceFlag{
+		Name:     flagNetworkName,
+		Aliases:  []string{"n"},
+		Usage:    "list of networks on which to send transactions",
+		Required: false,
+	}
+	flagWait = cli.BoolFlag{
+		Name:     flagWaitName,
+		Aliases:  []string{"w"},
+		Usage:    "wait transactions to be confirmed",
+		Required: false,
+	}
+	flagVerbose = cli.BoolFlag{
+		Name:     flagVerboseName,
+		Aliases:  []string{"v"},
+		Usage:    "output verbose logs",
+		Required: false,
+	}
+)
 
 func main() {
-	// Send 1 tx by default or read the number of txs from args
-	nTxs := 1
-	if len(os.Args) > 1 {
-		nTxs, _ = strconv.Atoi(os.Args[1])
-		if nTxs > maxTxs {
-			fmt.Printf("too many transactions, please input a number between 1 (default) and %d\n", maxTxs)
-			os.Exit(1)
+	txsender := cli.NewApp()
+	txsender.Name = "txsender"
+	txsender.Flags = []cli.Flag{&flagNetwork, &flagWait, &flagVerbose}
+	txsender.Usage = "send transactions"
+	txsender.Description = `This tool allows to send a specified number of transactions.
+Optionally it can wait for the transactions to be validated.`
+	txsender.DefaultCommand = "send"
+	txsender.Commands = []*cli.Command{
+		{
+			Name:    "send",
+			Aliases: []string{},
+			Usage:   "Sends the specified number of transactions",
+			Description: `This command sends the specified number of transactions.
+If --wait flag is used, it waits for the corresponding validation transaction.`,
+			ArgsUsage: "number of transactions to be sent (default: 1)",
+			Action:    sendTxs,
+		},
+	}
+
+	err := txsender.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+}
+
+func sendTxs(cliCtx *cli.Context) error {
+	ctx := cliCtx.Context
+
+	logLevel := "info"
+	if cliCtx.Bool(flagVerboseName) {
+		logLevel = "debug"
+	}
+
+	log.Init(log.Config{Level: logLevel, Outputs: []string{"stdout"}})
+
+	nTxs := 1 // send 1 tx by default
+	if cliCtx.NArg() > 0 {
+		nTxsArgStr := cliCtx.Args().Get(0)
+		nTxsArg, err := strconv.Atoi(nTxsArgStr)
+		if err == nil {
+			nTxs = nTxsArg
 		}
 	}
 
-	ctx := context.Background()
+	selNetworks := cliCtx.StringSlice(flagNetworkName)
 
-	// Load account with balance on local genesis
-	auth, err := operations.GetAuth(operations.DefaultSequencerPrivateKey, operations.DefaultL2ChainID)
-	if err != nil {
-		log.Fatal(err)
+	// if no network selected, pick the default one
+	if selNetworks == nil {
+		selNetworks = []string{defaultNetwork}
 	}
 
-	// Load eth client
-	client, err := ethclient.Dial(operations.DefaultL2NetworkURL)
-	if err != nil {
-		log.Fatal(err)
+	for _, selNetwork := range selNetworks {
+		network, ok := networks[selNetwork]
+		if !ok {
+			netKeys := make([]string, 0, len(networks))
+			for net := range networks {
+				netKeys = append(netKeys, net)
+			}
+			return fmt.Errorf("Please specify one or more of these networks: %v", netKeys)
+		}
+		log.Infof("connecting to %v: %v", network.Name, network.URL)
+		client, err := ethclient.Dial(network.URL)
+		if err != nil {
+			return err
+		}
+		log.Infof("connected")
+
+		auth, err := operations.GetAuth(network.PrivateKey, network.ChainID)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Sender Addr: %v", auth.From.String())
+
+		senderBalance, err := client.BalanceAt(ctx, auth.From, nil)
+		if err != nil {
+			return err
+		}
+		log.Debugf("ETH Balance for %v: %v", auth.From, senderBalance)
+
+		amount := big.NewInt(10) //nolint:gomnd
+		log.Debugf("Transfer Amount: %v", amount)
+
+		senderNonce, err := client.PendingNonceAt(ctx, auth.From)
+		if err != nil {
+			return err
+		}
+		log.Debugf("Sender Nonce: %v", senderNonce)
+
+		to := common.HexToAddress(receiverAddr)
+		log.Infof("Receiver Addr: %v", to.String())
+
+		gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{From: auth.From, To: &to, Value: amount})
+		if err != nil {
+			return err
+		}
+
+		gasPrice, err := client.SuggestGasPrice(ctx)
+		if err != nil {
+			return err
+		}
+
+		txs := make([]*types.Transaction, 0, nTxs)
+		for i := 0; i < nTxs; i++ {
+			tx := types.NewTransaction(senderNonce+uint64(i), to, amount, gasLimit, gasPrice, nil)
+			txs = append(txs, tx)
+		}
+
+		if cliCtx.Bool(flagWaitName) {
+			var err error
+			if network.networkLayer == networkLayer1 {
+				err = operations.ApplyL1Txs(ctx, txs, auth, client)
+			} else if network.networkLayer == networkLayer2 {
+				err = operations.ApplyL2Txs(ctx, txs, auth, client)
+			}
+			if err != nil {
+				return err
+			}
+		} else {
+			for i := 0; i < nTxs; i++ {
+				signedTx, err := auth.Signer(auth.From, txs[i])
+				if err != nil {
+					return err
+				}
+				log.Infof("Sending Tx %v Nonce %v", signedTx.Hash(), signedTx.Nonce())
+				err = client.SendTransaction(ctx, signedTx)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if nTxs > 1 {
+			log.Infof("%d transactions successfully sent", nTxs)
+		} else {
+			log.Info("transaction successfully sent")
+		}
 	}
 
-	// Send txs
-	amount := big.NewInt(10000) //nolint:gomnd
-	toAddress := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
-	senderBalance, err := client.BalanceAt(ctx, auth.From, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	senderNonce, err := client.PendingNonceAt(ctx, auth.From)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Infof("Receiver Addr: %v", toAddress.String())
-	log.Infof("Sender Addr: %v", auth.From.String())
-	log.Infof("Sender Balance: %v", senderBalance.String())
-	log.Infof("Sender Nonce: %v", senderNonce)
-
-	gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{From: auth.From, To: &toAddress, Value: amount})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	gasPrice, err := client.SuggestGasPrice(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	nonce, err := client.PendingNonceAt(ctx, auth.From)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	txs := make([]*types.Transaction, 0, nTxs)
-	for i := 0; i < nTxs; i++ {
-		tx := types.NewTransaction(nonce+uint64(i), toAddress, amount, gasLimit, gasPrice, nil)
-		txs = append(txs, tx)
-	}
-
-	err = operations.ApplyTxs(ctx, txs)
-	if err != nil {
-		log.Fatal(err)
-	}
+	return nil
 }

--- a/test/scripts/txsender/main.go
+++ b/test/scripts/txsender/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"os"
 	"strconv"
@@ -14,7 +15,19 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+const maxTxs int = 1e6
+
 func main() {
+	// Send 1 tx by default or read the number of txs from args
+	nTxs := 1
+	if len(os.Args) > 1 {
+		nTxs, _ = strconv.Atoi(os.Args[1])
+		if nTxs > maxTxs {
+			fmt.Printf("too many transactions, please input a number between 1 (default) and %d\n", maxTxs)
+			os.Exit(1)
+		}
+	}
+
 	ctx := context.Background()
 
 	// Load account with balance on local genesis
@@ -27,12 +40,6 @@ func main() {
 	client, err := ethclient.Dial(operations.DefaultL2NetworkURL)
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	// Send 1 tx by default or read the number of txs from args
-	nTxs := 1
-	if len(os.Args) > 1 {
-		nTxs, _ = strconv.Atoi(os.Args[1])
 	}
 
 	// Send txs


### PR DESCRIPTION
### Background

For development purposes, it would be nice to have a script to send an arbitrary number of transactions.

Basically the behavior should be the same of the `TestEthTransfer` e2e test, but without dealing with creating/destroying the node local stack, which is assumed to be already running.

### What does this PR do?

This PR proposes to add a `txsender` script in `test/scripts` that accepts as argument the number of transactions to be sent (it defaults to 1 transaction).

- Can send either on layer 1, layer 2 or both, specifying the `--network` flag.
- Can wait for transactions to be validated using the `--wait flag`.

Please refer to the `README.md` file in the script folder to see some examples.

This PR also removes the `send_transfer` script as the one proposed here is a more flexible solution of that script.
In the future we may think about a full fledged CLI development application to include this and other useful script.

In order avoid duplication, the code shared between `TestEthTransfer` and the new script has been moved to `operations.ApplyL1Txs` and `operations.ApplyL2Txs`.

### Reviewers

Main reviewers:

@ARR552 
@KonradIT 
@arnaubennassar 
@ToniRamirezM 