### PR TITLE
Batchsender script

### DIFF
--- a/test/scripts/batchsender/README.md
+++ b/test/scripts/batchsender/README.md
@@ -1,0 +1,44 @@
+# Batchsender
+
+## Overview
+
+This script allows to send a specified number of (empty) batch transactions to
+L1.  Optionally it can wait for the batch to be verified.  The script interacts
+with L1 only. Basically it acts like a sequencer but without building a real
+rollup.  It can be useful to test the Synchronizer and the Aggregator.
+
+## Usage
+
+The script can be installed running `go install` from this folder.
+
+## Examples
+
+- Send 1 batch:
+
+```sh
+$ batchsender 
+```
+
+- Send 1 batch and wait for its proof:
+
+```sh
+$ batchsender -w send
+```
+
+- Send 42 batches:
+
+```sh
+$ batchsender send 42
+```
+
+- Send 42 batches and wait for the proofs:
+
+```sh
+$ batchsender -w send 42
+```
+
+- Send 42 batches with verbose logs and wait for the proofs:
+
+```sh
+$ batchsender -v -w send 42
+```

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -3,14 +3,16 @@ package main
 import (
 	"bytes"
 	"context"
-	"math/big"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
 	"github.com/0xPolygonHermez/zkevm-node/etherman/types"
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/test/operations"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -19,6 +21,25 @@ import (
 )
 
 func main() {
+	// send 1 batch by default or read the number of batches from args
+	nBatches := 1
+	usage := `Usage: batchsender <nbatches>
+ nbatches	Number of batches to be sent (defaults to 1)`
+	if len(os.Args) > 1 {
+		var err error
+		arg := os.Args[1]
+		if arg == "--help" || arg == "-h" {
+			fmt.Println(usage)
+			os.Exit(0)
+		}
+		nBatches, err = strconv.Atoi(arg)
+		if err != nil {
+			fmt.Println(usage)
+			os.Exit(1)
+		}
+	}
+
+	// retrieve default configuration
 	var cfg config.Config
 	viper.SetConfigType("toml")
 	err := viper.ReadConfig(bytes.NewBuffer([]byte(config.DefaultValues)))
@@ -37,28 +58,35 @@ func main() {
 
 	ctx := context.Background()
 
-	amount := big.NewInt(10000)
-	toAddress := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
-	// toAddress := cfg.Etherman.PoEAddr
+	for i := 0; i < nBatches; i++ {
+		currentBlock, err := client.BlockByNumber(ctx, nil)
+		checkErr(err)
+		log.Debug("currentBlock.Time(): ", currentBlock.Time())
 
-	log.Debug("estimating gas limit")
-	gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{From: auth.From, To: &toAddress, Value: amount})
-	checkErr(err)
+		seqAddr, err := ethMan.GetPublicAddress()
+		checkErr(err)
+		log.Info("Using address: ", seqAddr)
 
-	log.Debug("estimating gas price")
-	gasPrice, err := client.SuggestGasPrice(ctx)
-	checkErr(err)
+		seqs := []types.Sequence{{
+			GlobalExitRoot: common.HexToHash("0x"),
+			Txs:            []ethtypes.Transaction{},
+			Timestamp:      int64(currentBlock.Time() - 1), // fit in latest-sequence < > current-block rage
+		}}
+		tx, err := ethMan.SequenceBatches(ctx, seqs, 0, nil, nil)
+		checkErr(err)
+		log.Info("TxHash: ", tx.Hash())
 
-	log.Debug("getting nonce")
-	nonce, err := client.PendingNonceAt(ctx, auth.From)
-	checkErr(err)
-
-	tx := ethtypes.NewTransaction(nonce+uint64(1), toAddress, amount, gasLimit, gasPrice, nil)
-	seqs := []types.Sequence{{
-		Txs: []ethtypes.Transaction{*tx},
-	}}
-	_, err = ethMan.SequenceBatches(ctx, seqs, gasLimit*2, gasPrice, big.NewInt(int64(nonce)))
-	checkErr(err)
+		var duration time.Duration
+		if nBatches > 1 {
+			duration = 1
+		}
+		time.Sleep(duration * time.Second)
+	}
+	if nBatches > 1 {
+		log.Infof("Successfully sent %d batches", nBatches)
+	} else {
+		log.Info("Successfully sent 1 batch")
+	}
 }
 
 func checkErr(err error) {

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
-	"github.com/0xPolygonHermez/zkevm-node/etherman/types"
 	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/0xPolygonHermez/zkevm-node/test/operations"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -136,10 +136,10 @@ func sendBatches(cliCtx *cli.Context) error {
 		}
 		log.Debug("currentBlock.Time(): ", currentBlock.Time())
 
-		seqs := []types.Sequence{{
+		seqs := []state.Sequence{{
 			GlobalExitRoot: common.HexToHash("0x"),
 			Txs:            []ethtypes.Transaction{},
-			Timestamp:      int64(currentBlock.Time() - 1), // fit in latest-sequence < > current-block rage
+			Timestamp:      time.Unix(int64(currentBlock.Time()-1), 0), // fit in latest-sequence < > current-block rage
 		}}
 
 		// send empty rollup to L1

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+
+	"github.com/0xPolygonHermez/zkevm-node/config"
+	"github.com/0xPolygonHermez/zkevm-node/etherman"
+	"github.com/0xPolygonHermez/zkevm-node/etherman/types"
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/test/operations"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
+func main() {
+	var cfg config.Config
+	viper.SetConfigType("toml")
+	err := viper.ReadConfig(bytes.NewBuffer([]byte(config.DefaultValues)))
+	checkErr(err)
+	err = viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
+	checkErr(err)
+
+	client, err := ethclient.Dial(operations.DefaultL1NetworkURL)
+	checkErr(err)
+
+	auth, err := operations.GetAuth(operations.DefaultSequencerPrivateKey, operations.DefaultL1ChainID)
+	checkErr(err)
+
+	ethMan, err := etherman.NewClient(cfg.Etherman, auth)
+	checkErr(err)
+
+	ctx := context.Background()
+
+	amount := big.NewInt(10000)
+	toAddress := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	// toAddress := cfg.Etherman.PoEAddr
+
+	log.Debug("estimating gas limit")
+	gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{From: auth.From, To: &toAddress, Value: amount})
+	checkErr(err)
+
+	log.Debug("estimating gas price")
+	gasPrice, err := client.SuggestGasPrice(ctx)
+	checkErr(err)
+
+	log.Debug("getting nonce")
+	nonce, err := client.PendingNonceAt(ctx, auth.From)
+	checkErr(err)
+
+	tx := ethtypes.NewTransaction(nonce+uint64(1), toAddress, amount, gasLimit, gasPrice, nil)
+	seqs := []types.Sequence{{
+		Txs: []ethtypes.Transaction{*tx},
+	}}
+	_, err = ethMan.SequenceBatches(ctx, seqs, gasLimit*2, gasPrice, big.NewInt(int64(nonce)))
+	checkErr(err)
+}
+
+func checkErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -56,16 +56,16 @@ func main() {
 	ethMan, err := etherman.NewClient(cfg.Etherman, auth)
 	checkErr(err)
 
+	seqAddr, err := ethMan.GetPublicAddress()
+	checkErr(err)
+	log.Info("Using address: ", seqAddr)
+
 	ctx := context.Background()
 
 	for i := 0; i < nBatches; i++ {
 		currentBlock, err := client.BlockByNumber(ctx, nil)
 		checkErr(err)
 		log.Debug("currentBlock.Time(): ", currentBlock.Time())
-
-		seqAddr, err := ethMan.GetPublicAddress()
-		checkErr(err)
-		log.Info("Using address: ", seqAddr)
 
 		seqs := []types.Sequence{{
 			GlobalExitRoot: common.HexToHash("0x"),


### PR DESCRIPTION
### Background

While developing the new aggregator, we would like to have a convenient way to issue batch transactions on layer 1 for testing purposes.
This means bypassing the sequencer and directly interact with L1.

### What does this PR do?

This PR proposes to add a `batchsender` script in `test/scripts` that accepts as argument the number of batches (one L1 transaction per batch) to be sent (it defaults to 1 batch when no arguments are passed).

It can be easily installed with `go install` to be used later or included in shell scripts.

You can wait for the batches to be verified on L1, by using the `--wait` flag.

Examples:
- Send 1 batch without waiting:
```sh
$  batchsender
```

- Send 1 batch and wait for the proof:
```sh
$  batchsender -w send
```

- Send 42 batches without waiting:
```sh
$ batchsender send 42
```

- Send 42 batches and wait for the proofs:
```sh
$ batchsender -w send 42
```

- Send 42 batches with verbose log and wait for the proofs:
```sh
$ batchsender -v -w send 42
```

### Reviewers

Main reviewers:

@ARR552 
@arnaubennassar 
