### PR TITLE
Fix wrong vector folder in docker compose file

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -258,7 +258,7 @@ services:
       - 43061:43061 # MT
       - 43071:43071 # Executor
     volumes:
-      - ./test/vectors/src:/app/testvectors
+      - ./vectors/src:/app/testvectors
     command: >
       /app/zkprover-mock server --statedb-port 43061 --executor-port 43071 --test-vector-path /app/testvectors
 


### PR DESCRIPTION
Closes #1390.

### What does this PR do?

Fixes the path for vector files in zkprover mocked server

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @arnaubennassar 

Codeowner reviewers:
