### PR TITLE
fix: making 'tryParseError' to check if contains when no exact match.

### DIFF
--- a/etherman/errors.go
+++ b/etherman/errors.go
@@ -1,6 +1,9 @@
 package etherman
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	//ErrGasRequiredExceedsAllowance gas required exceeds the allowance
@@ -31,5 +34,12 @@ var (
 
 func tryParseError(err error) (error, bool) {
 	parsedError, exists := errorsCache[err.Error()]
+	if !exists {
+		for errStr, actualErr := range errorsCache {
+			if strings.Contains(err.Error(), errStr) {
+				return actualErr, true
+			}
+		}
+	}
 	return parsedError, exists
 }

--- a/etherman/errors_test.go
+++ b/etherman/errors_test.go
@@ -1,0 +1,37 @@
+package etherman
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTryParseWithExactMatch(t *testing.T) {
+	expected := ErrTimestampMustBeInsideRange
+	smartContractErr := expected
+
+	actualErr, ok := tryParseError(smartContractErr)
+
+	assert.ErrorIs(t, actualErr, expected)
+	assert.True(t, ok)
+}
+
+func TestTryParseWithContains(t *testing.T) {
+	expected := ErrTimestampMustBeInsideRange
+	smartContractErr := fmt.Errorf(" execution reverted: ProofOfEfficiency::sequenceBatches: %s", expected)
+
+	actualErr, ok := tryParseError(smartContractErr)
+
+	assert.ErrorIs(t, actualErr, expected)
+	assert.True(t, ok)
+}
+
+func TestTryParseWithNonExistingErr(t *testing.T) {
+	smartContractErr := fmt.Errorf("some non-existing err")
+
+	actualErr, ok := tryParseError(smartContractErr)
+
+	assert.Nil(t, actualErr)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolai_nedkov@yahoo.com>

Closes #1059.

### What does this PR do?

Making 'tryParseError' to check if it contains any string error key from the supported ones when there is no exact match.

### Reviewers
- @ARR552 
- @cool-develope 

Main reviewers:
- @ARR552 
- @cool-develope 