### PR TITLE
Revamp logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN cd /src && make build
 
 # CONTAINER FOR RUNNING BINARY
 FROM alpine:3.16.0
-ARG BUILD_COMMIT
-ENV COMMIT_HASH $BUILD_COMMIT
 COPY --from=build /src/dist/zkevm-node /app/zkevm-node
 COPY --from=build /src/config/environments/local/local.node.config.toml /app/example.config.toml
 EXPOSE 8123

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-VERSION := $(shell git describe --tags --always)
-COMMIT := $(shell git rev-parse --short HEAD)
-DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
-LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+include version.mk
+
 ARCH := $(shell arch)
 
 ifeq ($(ARCH),x86_64)
@@ -11,25 +9,28 @@ else
 		ARCH = arm64
 	endif
 endif
-
 GOBASE := $(shell pwd)
 GOBIN := $(GOBASE)/dist
 GOENVVARS := GOBIN=$(GOBIN) CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH)
 GOBINARY := zkevm-node
 GOCMD := $(GOBASE)/cmd
-$(eval BUILD_COMMIT:=$(shell git rev-parse --short HEAD))
+
+LDFLAGS += -X 'github.com/0xPolygonHermez/zkevm-node.Version=$(VERSION)'
+LDFLAGS += -X 'github.com/0xPolygonHermez/zkevm-node.GitRev=$(GITREV)'
+LDFLAGS += -X 'github.com/0xPolygonHermez/zkevm-node.GitBranch=$(GITBRANCH)'
+LDFLAGS += -X 'github.com/0xPolygonHermez/zkevm-node.BuildDate=$(DATE)'
 
 .PHONY: build
 build: ## Builds the binary locally into ./dist
-	$(GOENVVARS) go build $(LDFLAGS) -o $(GOBIN)/$(GOBINARY) $(GOCMD)
+	$(GOENVVARS) go build -ldflags "all=$(LDFLAGS)" -o $(GOBIN)/$(GOBINARY) $(GOCMD)
 
 .PHONY: build-docker
 build-docker: ## Builds a docker image with the node binary
-	docker build -t zkevm-node --build-arg BUILD_COMMIT="$(BUILD_COMMIT)" -f ./Dockerfile .
+	docker build -t zkevm-node -f ./Dockerfile .
 
 .PHONY: build-docker-nc
 build-docker-nc: ## Builds a docker image with the node binary - but without build cache
-	docker build --no-cache=true -t zkevm-node --build-arg BUILD_COMMIT="$(BUILD_COMMIT)" -f ./Dockerfile .
+	docker build --no-cache=true -t zkevm-node -f ./Dockerfile .
 
 .PHONY: run-rpc
 run-rpc: ## Runs all the services need to run a local zkEMV RPC node

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,21 +4,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/0xPolygonHermez/zkevm-node"
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc"
 	"github.com/0xPolygonHermez/zkevm-node/log"
-	"github.com/0xPolygonHermez/zkevm-node/test/testutils"
 	"github.com/urfave/cli/v2"
 )
 
-const (
-	// App name
-	appName = "zkevm-node"
-	// version represents the program based on the git tag
-	version = "v0.1.0"
-	// date represents the date of application was built
-	date = ""
-)
+const appName = "zkevm-node"
 
 const (
 	// AGGREGATOR is the aggregator component identifier.
@@ -33,14 +26,7 @@ const (
 	BROADCAST = "broadcast-trusted-state"
 )
 
-const (
-	//envCommitHash environment variable name for COMMIT_HASH
-	envCommitHash = "COMMIT_HASH"
-)
-
 var (
-	// commit represents the program based on the git commit
-	commit         = testutils.GetEnv(envCommitHash, "dev")
 	configFileFlag = cli.StringFlag{
 		Name:     config.FlagCfg,
 		Aliases:  []string{"c"},
@@ -78,14 +64,13 @@ var (
 func main() {
 	app := cli.NewApp()
 	app.Name = appName
-	app.Version = version
+	app.Version = zkevm.Version
 	flags := []cli.Flag{
 		&configFileFlag,
 		&yesFlag,
 		&componentsFlag,
 		&httpAPIFlag,
 	}
-	log.Infof("Starting application [Commit Hash: %s, Version: %s] ...", commit, version)
 	app.Commands = []*cli.Command{
 		{
 			Name:    "version",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 
+	"github.com/0xPolygonHermez/zkevm-node"
 	"github.com/0xPolygonHermez/zkevm-node/aggregator"
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/db"
@@ -40,6 +41,8 @@ import (
 )
 
 func start(cliCtx *cli.Context) error {
+	zkevm.PrintVersion(os.Stdout)
+
 	c, err := config.Load(cliCtx)
 	if err != nil {
 		return err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
+	"github.com/0xPolygonHermez/zkevm-node"
 	"github.com/urfave/cli/v2"
 )
 
 func versionCmd(*cli.Context) error {
-	fmt.Printf("Version = \"%v\"\n", version)
-	fmt.Printf("Build = \"%v\"\n", commit)
-	fmt.Printf("Date = \"%v\"\n", date)
+	zkevm.PrintVersion(os.Stdout)
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -62,8 +62,8 @@ type Config struct {
 	Metrics            metrics.Config
 }
 
-// Load loads the configuration
-func Load(ctx *cli.Context) (*Config, error) {
+// Default parses the default configuration values.
+func Default() (*Config, error) {
 	var cfg Config
 	viper.SetConfigType("toml")
 
@@ -72,6 +72,15 @@ func Load(ctx *cli.Context) (*Config, error) {
 		return nil, err
 	}
 	err = viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Load loads the configuration
+func Load(ctx *cli.Context) (*Config, error) {
+	cfg, err := Default()
 	if err != nil {
 		return nil, err
 	}
@@ -114,5 +123,5 @@ func Load(ctx *cli.Context) (*Config, error) {
 		}
 		log.Debugf("Configuration loaded: \n%s\n", string(cfgJSON))
 	*/
-	return &cfg, nil
+	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,18 @@ func Test_Defaults(t *testing.T) {
 		expectedValue interface{}
 	}{
 		{
+			path:          "Log.Level",
+			expectedValue: "debug",
+		},
+		{
+			path:          "Log.Encoding",
+			expectedValue: "console",
+		},
+		{
+			path:          "Log.Outputs",
+			expectedValue: []string{"stdout"},
+		},
+		{
 			path:          "Synchronizer.SyncChunkSize",
 			expectedValue: uint64(100),
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/config"
 	"github.com/0xPolygonHermez/zkevm-node/config/types"
+	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/pricegetter"
 	"github.com/0xPolygonHermez/zkevm-node/sequencer"
 	"github.com/ethereum/go-ethereum/common"
@@ -24,16 +25,16 @@ func Test_Defaults(t *testing.T) {
 		expectedValue interface{}
 	}{
 		{
+			path:          "Log.Environment",
+			expectedValue: log.LogEnvironment("development"),
+		},
+		{
 			path:          "Log.Level",
 			expectedValue: "debug",
 		},
 		{
-			path:          "Log.Encoding",
-			expectedValue: "console",
-		},
-		{
 			path:          "Log.Outputs",
-			expectedValue: []string{"stdout"},
+			expectedValue: []string{"stderr"},
 		},
 		{
 			path:          "Synchronizer.SyncChunkSize",

--- a/config/default.go
+++ b/config/default.go
@@ -5,9 +5,9 @@ const DefaultValues = `
 IsTrustedSequencer = false
 
 [Log]
+Environment = "development" # "production" or "development"
 Level = "debug"
-Encoding = "console" # valid values are "console" or "json"
-Outputs = ["stdout"]
+Outputs = ["stderr"]
 
 [StateDB]
 User = "state_user"

--- a/config/default.go
+++ b/config/default.go
@@ -6,6 +6,7 @@ IsTrustedSequencer = false
 
 [Log]
 Level = "debug"
+Encoding = "console" # valid values are "console" or "json"
 Outputs = ["stdout"]
 
 [StateDB]

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -2,6 +2,7 @@ IsTrustedSequencer = false
 
 [Log]
 Level = "debug"
+Encoding = "console" # valid values are "console" or "json"
 Outputs = ["stdout"]
 
 [StateDB]

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -1,9 +1,9 @@
 IsTrustedSequencer = false
 
 [Log]
+Environment = "development" # "production" or "development"
 Level = "debug"
-Encoding = "console" # valid values are "console" or "json"
-Outputs = ["stdout"]
+Outputs = ["stderr"]
 
 [StateDB]
 User = "state_user"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -1,5 +1,6 @@
 [Log]
 Level = "debug"
+Encoding = "console" # valid values are "console" or "json"
 Outputs = ["stdout"]
 
 [StateDB]

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -1,7 +1,7 @@
 [Log]
-Level = "debug"
-Encoding = "console" # valid values are "console" or "json"
-Outputs = ["stdout"]
+Environment = "development" # "production" or "development"
+Level = "info"
+Outputs = ["stderr"]
 
 [StateDB]
 User = "state_user"

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -104,6 +104,8 @@ type Client struct {
 	GasProviders externalGasProviders
 
 	auth *bind.TransactOpts // nil in case of read-only client
+
+	cfg Config
 }
 
 // NewClient creates a new etherman.
@@ -152,6 +154,7 @@ func NewClient(cfg Config, auth *bind.TransactOpts) (*Client, error) {
 			Providers:        gProviders,
 		},
 		auth: auth,
+		cfg:  cfg,
 	}, nil
 }
 
@@ -457,7 +460,6 @@ func (etherMan *Client) forcedBatchEvent(ctx context.Context, vLog types.Log, bl
 	}
 	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	if fb.Sequencer == msg.From() {
@@ -526,7 +528,6 @@ func (etherMan *Client) sequencedBatchesEvent(ctx context.Context, vLog types.Lo
 	}
 	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	sequences, err := decodeSequences(tx.Data(), sb.NumBatch, msg.From(), vLog.TxHash, msg.Nonce())
@@ -651,7 +652,6 @@ func (etherMan *Client) forceSequencedBatchesEvent(ctx context.Context, vLog typ
 	}
 	msg, err := tx.AsMessage(types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 	fullBlock, err := etherMan.EtherClient.BlockByHash(ctx, vLog.BlockHash)

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -104,8 +104,6 @@ type Client struct {
 	GasProviders externalGasProviders
 
 	auth *bind.TransactOpts // nil in case of read-only client
-
-	cfg Config
 }
 
 // NewClient creates a new etherman.
@@ -154,7 +152,6 @@ func NewClient(cfg Config, auth *bind.TransactOpts) (*Client, error) {
 			Providers:        gProviders,
 		},
 		auth: auth,
-		cfg:  cfg,
 	}, nil
 }
 

--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -24,9 +24,8 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:    "debug",
-		Encoding: "console",
-		Outputs:  []string{"stdout"},
+		Level:   "debug",
+		Outputs: []string{"stderr"},
 	})
 }
 

--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -24,8 +24,9 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:   "debug",
-		Outputs: []string{"stdout"},
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
 	})
 }
 

--- a/etherman/etherscan/etherscan_test.go
+++ b/etherman/etherscan/etherscan_test.go
@@ -15,8 +15,9 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:   "debug",
-		Outputs: []string{"stdout"},
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
 	})
 }
 

--- a/etherman/etherscan/etherscan_test.go
+++ b/etherman/etherscan/etherscan_test.go
@@ -15,9 +15,8 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:    "debug",
-		Encoding: "console",
-		Outputs:  []string{"stdout"},
+		Level:   "debug",
+		Outputs: []string{"stderr"},
 	})
 }
 

--- a/etherman/ethgasstation/ethgasstation_test.go
+++ b/etherman/ethgasstation/ethgasstation_test.go
@@ -15,8 +15,9 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:   "debug",
-		Outputs: []string{"stdout"},
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
 	})
 }
 

--- a/etherman/ethgasstation/ethgasstation_test.go
+++ b/etherman/ethgasstation/ethgasstation_test.go
@@ -15,9 +15,8 @@ import (
 
 func init() {
 	log.Init(log.Config{
-		Level:    "debug",
-		Encoding: "console",
-		Outputs:  []string{"stdout"},
+		Level:   "debug",
+		Outputs: []string{"stderr"},
 	})
 }
 

--- a/jsonrpc/handler.go
+++ b/jsonrpc/handler.go
@@ -49,6 +49,7 @@ var connectionCounterMutex sync.Mutex
 // Handle is the function that knows which and how a function should
 // be executed when a JSON RPC request is received
 func (d *Handler) Handle(req Request) Response {
+	log := log.WithFields("method", req.Method, "requestId", req.ID)
 	connectionCounterMutex.Lock()
 	connectionCounter++
 	connectionCounterMutex.Unlock()
@@ -59,7 +60,7 @@ func (d *Handler) Handle(req Request) Response {
 		log.Debugf("Current open connections %d", connectionCounter)
 	}()
 	log.Debugf("Current open connections %d", connectionCounter)
-	log.Debugf("request method %s id %v params %v", req.Method, req.ID, string(req.Params))
+	log.Debugf("request params %v", string(req.Params))
 
 	service, fd, err := d.getFnHandler(req)
 	if err != nil {
@@ -90,7 +91,7 @@ func (d *Handler) Handle(req Request) Response {
 
 	output := fd.fv.Call(inArgs)
 	if err := getError(output[1]); err != nil {
-		log.Infof("failed to call method %s: [%v]%v. Params: %v", req.Method, err.ErrorCode(), err.Error(), string(req.Params))
+		log.Infof("failed call: [%v]%v. Params: %v", err.ErrorCode(), err.Error(), string(req.Params))
 		return NewResponse(req, nil, err)
 	}
 

--- a/log/config.go
+++ b/log/config.go
@@ -4,6 +4,8 @@ package log
 type Config struct {
 	// Level of log, e.g. INFO, WARN, ...
 	Level string `mapstructure:"Level"`
+	// Encoding of the logs ("json" or "console")
+	Encoding string `mapstructure:"Encoding"`
 	// Outputs
 	Outputs []string `mapstructure:"Outputs"`
 }

--- a/log/config.go
+++ b/log/config.go
@@ -2,10 +2,10 @@ package log
 
 // Config for log
 type Config struct {
+	// Environment defining the log format ("production" or "development").
+	Environment LogEnvironment `mapstructure:"Environment"`
 	// Level of log, e.g. INFO, WARN, ...
 	Level string `mapstructure:"Level"`
-	// Encoding of the logs ("json" or "console")
-	Encoding string `mapstructure:"Encoding"`
 	// Outputs
 	Outputs []string `mapstructure:"Outputs"`
 }

--- a/log/log.go
+++ b/log/log.go
@@ -110,7 +110,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 // WithFields returns a new Logger (derived from the root one) with additional
 // fields as per keyValuePairs.  The root Logger instance is not affected.
 func WithFields(keyValuePairs ...interface{}) *Logger {
-	l := log.WithFields(keyValuePairs...)
+	l := getDefaultLog().WithFields(keyValuePairs...)
 
 	// since we are returning a new instance, remove one caller from the
 	// stack, because we'll be calling the retruned Logger methods

--- a/log/log.go
+++ b/log/log.go
@@ -25,7 +25,11 @@ func getDefaultLog() *Logger {
 		return log
 	}
 	// default level: debug
-	zapLogger, _, err := NewLogger(Config{"debug", []string{"stdout"}})
+	zapLogger, _, err := NewLogger(Config{
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +64,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 
 	zapCfg := zap.Config{
 		Level:            level,
-		Encoding:         "json",
+		Encoding:         cfg.Encoding,
 		OutputPaths:      cfg.Outputs,
 		ErrorOutputPaths: []string{"stderr"},
 		EncoderConfig: zapcore.EncoderConfig{

--- a/log/log.go
+++ b/log/log.go
@@ -60,14 +60,14 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 
 	zapCfg := zap.Config{
 		Level:            level,
-		Encoding:         "console",
+		Encoding:         "json",
 		OutputPaths:      cfg.Outputs,
 		ErrorOutputPaths: []string{"stderr"},
 		EncoderConfig: zapcore.EncoderConfig{
 			MessageKey: "message",
 
 			LevelKey:    "level",
-			EncodeLevel: zapcore.CapitalColorLevelEncoder,
+			EncodeLevel: zapcore.CapitalLevelEncoder,
 
 			TimeKey: "timestamp",
 			EncodeTime: func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {

--- a/log/log.go
+++ b/log/log.go
@@ -99,7 +99,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 	defer logger.Sync() //nolint:gosec,errcheck
 
 	// skip 2 callers: one for our wrapper methods and one for the package functions
-	withOptions := logger.WithOptions(zap.AddCallerSkip(2))
+	withOptions := logger.WithOptions(zap.AddCallerSkip(2)) //nolint:gomnd
 	return withOptions.Sugar(), &level, nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -62,6 +62,10 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 		return nil, nil, fmt.Errorf("error on setting log level: %s", err)
 	}
 
+	encodeLevel := zapcore.CapitalColorLevelEncoder
+	if cfg.Encoding == "json" {
+		encodeLevel = zapcore.CapitalLevelEncoder
+	}
 	zapCfg := zap.Config{
 		Level:            level,
 		Encoding:         cfg.Encoding,
@@ -71,7 +75,7 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 			MessageKey: "message",
 
 			LevelKey:    "level",
-			EncodeLevel: zapcore.CapitalLevelEncoder,
+			EncodeLevel: encodeLevel,
 
 			TimeKey: "timestamp",
 			EncodeTime: func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {

--- a/log/log.go
+++ b/log/log.go
@@ -2,26 +2,34 @@ package log
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/0xPolygonHermez/zkevm-node"
 	"github.com/hermeznetwork/tracerr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-var log *zap.SugaredLogger
+// Logger is a wrapper providing logging facilities.
+type Logger struct {
+	x *zap.SugaredLogger
+}
 
-func getDefaultLog() *zap.SugaredLogger {
-	var err error
+// root logger
+var log *Logger
+
+func getDefaultLog() *Logger {
 	if log != nil {
 		return log
 	}
 	// default level: debug
-	log, _, err = NewLogger(Config{"debug", []string{"stdout"}})
+	zapLogger, _, err := NewLogger(Config{"debug", []string{"stdout"}})
 	if err != nil {
 		panic(err)
 	}
+	log = &Logger{x: zapLogger}
 	return log
 }
 
@@ -31,11 +39,11 @@ func getDefaultLog() *zap.SugaredLogger {
 // should be added at the outputs array. To avoid printing the logs but storing
 // them on a file, can use []string{"pathtofile.log"}
 func Init(cfg Config) {
-	var err error
-	log, _, err = NewLogger(cfg)
+	zapLogger, _, err := NewLogger(cfg)
 	if err != nil {
 		panic(err)
 	}
+	log = &Logger{x: zapLogger}
 }
 
 // NewLogger creates the logger with defined level. outputs defines the outputs where the
@@ -74,6 +82,10 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 			StacktraceKey: "",
 			LineEnding:    zapcore.DefaultLineEnding,
 		},
+		InitialFields: map[string]interface{}{
+			"version": zkevm.Version,
+			"pid":     os.Getpid(),
+		},
 	}
 
 	logger, err := zapCfg.Build()
@@ -81,8 +93,31 @@ func NewLogger(cfg Config) (*zap.SugaredLogger, *zap.AtomicLevel, error) {
 		return nil, nil, err
 	}
 	defer logger.Sync() //nolint:gosec,errcheck
-	withOptions := logger.WithOptions(zap.AddCallerSkip(1))
+
+	// skip 2 callers: one for our wrapper methods and one for the package functions
+	withOptions := logger.WithOptions(zap.AddCallerSkip(2))
 	return withOptions.Sugar(), &level, nil
+}
+
+// WithFields returns a new Logger (derived from the root one) with additional
+// fields as per keyValuePairs.  The root Logger instance is not affected.
+func WithFields(keyValuePairs ...interface{}) *Logger {
+	l := log.WithFields(keyValuePairs...)
+
+	// since we are returning a new instance, remove one caller from the
+	// stack, because we'll be calling the retruned Logger methods
+	// directly, not the package functions.
+	x := l.x.WithOptions(zap.AddCallerSkip(-1))
+	l.x = x
+	return l
+}
+
+// WithFields returns a new Logger with additional fields as per keyValuePairs.
+// The original Logger instance is not affected.
+func (l *Logger) WithFields(keyValuePairs ...interface{}) *Logger {
+	return &Logger{
+		x: l.x.With(keyValuePairs...),
+	}
 }
 
 func sprintStackTrace(st []tracerr.Frame) string {
@@ -112,54 +147,105 @@ func appendStackTraceMaybeArgs(args []interface{}) []interface{} {
 }
 
 // Debug calls log.Debug
+func (l *Logger) Debug(args ...interface{}) {
+	l.x.Debug(args...)
+}
+
+// Info calls log.Info
+func (l *Logger) Info(args ...interface{}) {
+	l.x.Info(args...)
+}
+
+// Warn calls log.Warn
+func (l *Logger) Warn(args ...interface{}) {
+	l.x.Warn(args...)
+}
+
+// Error calls log.Error
+func (l *Logger) Error(args ...interface{}) {
+	l.x.Error(args...)
+}
+
+// Fatal calls log.Fatal
+func (l *Logger) Fatal(args ...interface{}) {
+	l.x.Fatal(args...)
+}
+
+// Debugf calls log.Debugf
+func (l *Logger) Debugf(template string, args ...interface{}) {
+	l.x.Debugf(template, args...)
+}
+
+// Infof calls log.Infof
+func (l *Logger) Infof(template string, args ...interface{}) {
+	l.x.Infof(template, args...)
+}
+
+// Warnf calls log.Warnf
+func (l *Logger) Warnf(template string, args ...interface{}) {
+	l.x.Warnf(template, args...)
+}
+
+// Fatalf calls log.Fatalf
+func (l *Logger) Fatalf(template string, args ...interface{}) {
+	l.x.Fatalf(template, args...)
+}
+
+// Errorf calls log.Errorf and stores the error message into the ErrorFile
+func (l *Logger) Errorf(template string, args ...interface{}) {
+	l.x.Errorf(template, args...)
+}
+
+// Debug calls log.Debug on the root Logger.
 func Debug(args ...interface{}) {
 	getDefaultLog().Debug(args...)
 }
 
-// Info calls log.Info
+// Info calls log.Info on the root Logger.
 func Info(args ...interface{}) {
 	getDefaultLog().Info(args...)
 }
 
-// Warn calls log.Warn
+// Warn calls log.Warn on the root Logger.
 func Warn(args ...interface{}) {
 	getDefaultLog().Warn(args...)
 }
 
-// Error calls log.Error
+// Error calls log.Error on the root Logger.
 func Error(args ...interface{}) {
 	args = appendStackTraceMaybeArgs(args)
 	getDefaultLog().Error(args...)
 }
 
-// Fatal calls log.Fatal
+// Fatal calls log.Fatal on the root Logger.
 func Fatal(args ...interface{}) {
 	args = appendStackTraceMaybeArgs(args)
 	getDefaultLog().Fatal(args...)
 }
 
-// Debugf calls log.Debugf
+// Debugf calls log.Debugf on the root Logger.
 func Debugf(template string, args ...interface{}) {
 	getDefaultLog().Debugf(template, args...)
 }
 
-// Infof calls log.Infof
+// Infof calls log.Infof on the root Logger.
 func Infof(template string, args ...interface{}) {
 	getDefaultLog().Infof(template, args...)
 }
 
-// Warnf calls log.Warnf
+// Warnf calls log.Warnf on the root Logger.
 func Warnf(template string, args ...interface{}) {
 	getDefaultLog().Warnf(template, args...)
 }
 
-// Fatalf calls log.Fatalf
+// Fatalf calls log.Fatalf on the root Logger.
 func Fatalf(template string, args ...interface{}) {
 	args = appendStackTraceMaybeArgs(args)
 	getDefaultLog().Fatalf(template, args...)
 }
 
-// Errorf calls log.Errorf and stores the error message into the ErrorFile
+// Errorf calls log.Errorf on the root logger and stores the error message into
+// the ErrorFile.
 func Errorf(template string, args ...interface{}) {
 	args = appendStackTraceMaybeArgs(args)
 	getDefaultLog().Errorf(template, args...)
@@ -181,27 +267,52 @@ func appendStackTraceMaybeKV(msg string, kv []interface{}) string {
 }
 
 // Debugw calls log.Debugw
+func (l *Logger) Debugw(template string, kv ...interface{}) {
+	l.x.Debugw(template, kv...)
+}
+
+// Infow calls log.Infow
+func (l *Logger) Infow(template string, kv ...interface{}) {
+	l.x.Infow(template, kv...)
+}
+
+// Warnw calls log.Warnw
+func (l *Logger) Warnw(template string, kv ...interface{}) {
+	l.x.Warnw(template, kv...)
+}
+
+// Errorw calls log.Errorw
+func (l *Logger) Errorw(template string, kv ...interface{}) {
+	l.x.Errorw(template, kv...)
+}
+
+// Fatalw calls log.Fatalw
+func (l *Logger) Fatalw(template string, kv ...interface{}) {
+	l.x.Fatalw(template, kv...)
+}
+
+// Debugw calls log.Debugw on the root Logger.
 func Debugw(template string, kv ...interface{}) {
 	getDefaultLog().Debugw(template, kv...)
 }
 
-// Infow calls log.Infow
+// Infow calls log.Infow on the root Logger.
 func Infow(template string, kv ...interface{}) {
 	getDefaultLog().Infow(template, kv...)
 }
 
-// Warnw calls log.Warnw
+// Warnw calls log.Warnw on the root Logger.
 func Warnw(template string, kv ...interface{}) {
 	getDefaultLog().Warnw(template, kv...)
 }
 
-// Errorw calls log.Errorw
+// Errorw calls log.Errorw on the root Logger.
 func Errorw(template string, kv ...interface{}) {
 	template = appendStackTraceMaybeKV(template, kv)
 	getDefaultLog().Errorw(template, kv...)
 }
 
-// Fatalw calls log.Fatalw
+// Fatalw calls log.Fatalw on the root Logger.
 func Fatalw(template string, kv ...interface{}) {
 	template = appendStackTraceMaybeKV(template, kv)
 	getDefaultLog().Fatalw(template, kv...)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -18,9 +18,9 @@ func TestLogNotInitialized(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	cfg := Config{
-		Level:    "debug",
-		Encoding: "console",
-		Outputs:  []string{"stdout"}, //[]string{"stdout", "test.log"}
+		Environment: EnvironmentDevelopment,
+		Level:       "debug",
+		Outputs:     []string{"stderr"}, //[]string{"stdout", "test.log"}
 	}
 
 	Init(cfg)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -18,8 +18,9 @@ func TestLogNotInitialized(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	cfg := Config{
-		Level:   "debug",
-		Outputs: []string{"stdout"}, //[]string{"stdout", "test.log"}
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"}, //[]string{"stdout", "test.log"}
 	}
 
 	Init(cfg)

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -411,13 +411,13 @@ func registerGaugeIfNotExists(opts prometheus.GaugeOpts) {
 		return
 	}
 
-	log.Infof("Creating Gauge Metric '%v' ...", opts.Name)
+	log.Debugf("Creating Gauge Metric '%v' ...", opts.Name)
 	gauge := prometheus.NewGauge(opts)
-	log.Infof("Gauge Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Gauge Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
 
-	log.Infof("Registering Gauge Metric '%v' ...", opts.Name)
+	log.Debugf("Registering Gauge Metric '%v' ...", opts.Name)
 	registerer.MustRegister(gauge)
-	log.Infof("Gauge Metric '%v' successfully registered!", opts.Name)
+	log.Debugf("Gauge Metric '%v' successfully registered!", opts.Name)
 
 	gauges[opts.Name] = gauge
 }
@@ -434,14 +434,14 @@ func unregisterGaugeIfExists(name string) {
 		return
 	}
 
-	log.Infof("Unregistering Gauge Metric '%v' ...", name)
+	log.Debugf("Unregistering Gauge Metric '%v' ...", name)
 	ok = registerer.Unregister(gauge)
 	if !ok {
 		log.Errorf("Failed to unregister Gauge Metric '%v'.", name)
 		return
 	}
 	delete(gauges, name)
-	log.Infof("Gauge Metric '%v' successfully unregistered!", name)
+	log.Debugf("Gauge Metric '%v' successfully unregistered!", name)
 }
 
 // registerCounterIfNotExists registers single counter metric if not exists
@@ -451,13 +451,13 @@ func registerCounterIfNotExists(opts prometheus.CounterOpts) {
 		return
 	}
 
-	log.Infof("Creating Counter Metric '%v' ...", opts.Name)
+	log.Debugf("Creating Counter Metric '%v' ...", opts.Name)
 	counter := prometheus.NewCounter(opts)
-	log.Infof("Counter Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Counter Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
 
-	log.Infof("Registering Counter Metric '%v' ...", opts.Name)
+	log.Debugf("Registering Counter Metric '%v' ...", opts.Name)
 	registerer.MustRegister(counter)
-	log.Infof("Counter Metric '%v' successfully registered!", opts.Name)
+	log.Debugf("Counter Metric '%v' successfully registered!", opts.Name)
 
 	counters[opts.Name] = counter
 }
@@ -474,14 +474,14 @@ func unregisterCounterIfExists(name string) {
 		return
 	}
 
-	log.Infof("Unregistering Counter Metric '%v' ...", name)
+	log.Debugf("Unregistering Counter Metric '%v' ...", name)
 	ok = registerer.Unregister(counter)
 	if !ok {
 		log.Errorf("Failed to unregister Counter Metric '%v'.", name)
 		return
 	}
 	delete(counters, name)
-	log.Infof("Counter Metric '%v' successfully unregistered!", name)
+	log.Debugf("Counter Metric '%v' successfully unregistered!", name)
 }
 
 // registerCounterVecIfNotExists registers single counter vec metric if not exists
@@ -491,13 +491,13 @@ func registerCounterVecIfNotExists(opts CounterVecOpts) {
 		return
 	}
 
-	log.Infof("Creating Counter Vec Metric '%v' ...", opts.Name)
+	log.Debugf("Creating Counter Vec Metric '%v' ...", opts.Name)
 	counterVec := prometheus.NewCounterVec(opts.CounterOpts, opts.Labels)
-	log.Infof("Counter Vec Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Counter Vec Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
 
-	log.Infof("Registering Counter Vec Metric '%v' ...", opts.Name)
+	log.Debugf("Registering Counter Vec Metric '%v' ...", opts.Name)
 	registerer.MustRegister(counterVec)
-	log.Infof("Counter Vec Metric '%v' successfully registered!", opts.Name)
+	log.Debugf("Counter Vec Metric '%v' successfully registered!", opts.Name)
 
 	counterVecs[opts.Name] = counterVec
 }
@@ -514,14 +514,14 @@ func unregisterCounterVecIfExists(name string) {
 		return
 	}
 
-	log.Infof("Unregistering Counter Vec Metric '%v' ...", name)
+	log.Debugf("Unregistering Counter Vec Metric '%v' ...", name)
 	ok = registerer.Unregister(counterVec)
 	if !ok {
 		log.Errorf("Failed to unregister Counter Vec Metric '%v'.", name)
 		return
 	}
 	delete(counterVecs, name)
-	log.Infof("Counter Vec Metric '%v' successfully unregistered!", name)
+	log.Debugf("Counter Vec Metric '%v' successfully unregistered!", name)
 }
 
 // registerHistogramIfNotExists registers single histogram metric if not exists
@@ -531,13 +531,13 @@ func registerHistogramIfNotExists(opts prometheus.HistogramOpts) {
 		return
 	}
 
-	log.Infof("Creating Histogram Metric '%v' ...", opts.Name)
+	log.Debugf("Creating Histogram Metric '%v' ...", opts.Name)
 	histogram := prometheus.NewHistogram(opts)
-	log.Infof("Histogram Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Histogram Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
 
-	log.Infof("Registering Histogram Metric '%v' ...", opts.Name)
+	log.Debugf("Registering Histogram Metric '%v' ...", opts.Name)
 	registerer.MustRegister(histogram)
-	log.Infof("Histogram Metric '%v' successfully registered!", opts.Name)
+	log.Debugf("Histogram Metric '%v' successfully registered!", opts.Name)
 
 	histograms[opts.Name] = histogram
 }
@@ -554,14 +554,14 @@ func unregisterHistogramIfExists(name string) {
 		return
 	}
 
-	log.Infof("Unregistering Histogram Metric '%v' ...", name)
+	log.Debugf("Unregistering Histogram Metric '%v' ...", name)
 	ok = registerer.Unregister(histogram)
 	if !ok {
 		log.Errorf("Failed to unregister Histogram Metric '%v'.", name)
 		return
 	}
 	delete(histograms, name)
-	log.Infof("Histogram Metric '%v' successfully unregistered!", name)
+	log.Debugf("Histogram Metric '%v' successfully unregistered!", name)
 }
 
 // registerHistogramVecIfNotExists unregisters single counter metric if exists
@@ -611,13 +611,13 @@ func registerSummaryIfNotExists(opts prometheus.SummaryOpts) {
 		return
 	}
 
-	log.Infof("Creating Summary Metric '%v' ...", opts.Name)
+	log.Debugf("Creating Summary Metric '%v' ...", opts.Name)
 	summary := prometheus.NewSummary(opts)
-	log.Infof("Summary Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Summary Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
 
-	log.Infof("Registering Summary Metric '%v' ...", opts.Name)
+	log.Debugf("Registering Summary Metric '%v' ...", opts.Name)
 	registerer.MustRegister(summary)
-	log.Infof("Summary Metric '%v' successfully registered!", opts.Name)
+	log.Debugf("Summary Metric '%v' successfully registered!", opts.Name)
 
 	summaries[opts.Name] = summary
 }
@@ -634,12 +634,12 @@ func unregisterSummaryIfExists(name string) {
 		return
 	}
 
-	log.Infof("Unregistering Summary Metric '%v' ...", name)
+	log.Debugf("Unregistering Summary Metric '%v' ...", name)
 	ok = registerer.Unregister(summary)
 	if !ok {
 		log.Errorf("Failed to unregister Summary Metric '%v'.", name)
 		return
 	}
 	delete(summaries, name)
-	log.Infof("Summary Metric '%v' successfully unregistered!", name)
+	log.Debugf("Summary Metric '%v' successfully unregistered!", name)
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -406,18 +406,19 @@ func UnregisterSummaries(names ...string) {
 
 // registerGaugeIfNotExists registers single gauge metric if not exists
 func registerGaugeIfNotExists(opts prometheus.GaugeOpts) {
+	log := log.WithFields("metricName", opts.Name)
 	if _, exist := gauges[opts.Name]; exist {
-		log.Warnf("Gauge metric '%v' already exists.", opts.Name)
+		log.Warn("Gauge metric already exists.")
 		return
 	}
 
-	log.Debugf("Creating Gauge Metric '%v' ...", opts.Name)
+	log.Debug("Creating Gauge Metric...")
 	gauge := prometheus.NewGauge(opts)
-	log.Debugf("Gauge Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Gauge Metric successfully created! Labels: %p", opts.ConstLabels)
 
-	log.Debugf("Registering Gauge Metric '%v' ...", opts.Name)
+	log.Debug("Registering Gauge Metric...")
 	registerer.MustRegister(gauge)
-	log.Debugf("Gauge Metric '%v' successfully registered!", opts.Name)
+	log.Debug("Gauge Metric successfully registered!")
 
 	gauges[opts.Name] = gauge
 }
@@ -429,35 +430,37 @@ func unregisterGaugeIfExists(name string) {
 		ok    bool
 	)
 
+	log := log.WithFields("metricName", name)
 	if gauge, ok = gauges[name]; !ok {
-		log.Warnf("Trying to delete non-existing Gauge gauge '%v'.", name)
+		log.Warn("Trying to delete non-existing Gauge metrics.")
 		return
 	}
 
-	log.Debugf("Unregistering Gauge Metric '%v' ...", name)
+	log.Debug("Unregistering Gauge Metric...")
 	ok = registerer.Unregister(gauge)
 	if !ok {
-		log.Errorf("Failed to unregister Gauge Metric '%v'.", name)
+		log.Error("Failed to unregister Gauge Metric.")
 		return
 	}
 	delete(gauges, name)
-	log.Debugf("Gauge Metric '%v' successfully unregistered!", name)
+	log.Debug("Gauge Metric successfully unregistered!")
 }
 
 // registerCounterIfNotExists registers single counter metric if not exists
 func registerCounterIfNotExists(opts prometheus.CounterOpts) {
+	log := log.WithFields("metricName", opts.Name)
 	if _, exist := counters[opts.Name]; exist {
-		log.Warnf("Counter metric '%v' already exists.", opts.Name)
+		log.Warn("Counter metric already exists.")
 		return
 	}
 
-	log.Debugf("Creating Counter Metric '%v' ...", opts.Name)
+	log.Debug("Creating Counter Metric...")
 	counter := prometheus.NewCounter(opts)
-	log.Debugf("Counter Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Counter Metric successfully created! Labels: %p", opts.ConstLabels)
 
-	log.Debugf("Registering Counter Metric '%v' ...", opts.Name)
+	log.Debug("Registering Counter Metric...")
 	registerer.MustRegister(counter)
-	log.Debugf("Counter Metric '%v' successfully registered!", opts.Name)
+	log.Debug("Counter Metric successfully registered!")
 
 	counters[opts.Name] = counter
 }
@@ -469,15 +472,16 @@ func unregisterCounterIfExists(name string) {
 		ok      bool
 	)
 
+	log := log.WithFields("metricName", name)
 	if counter, ok = counters[name]; !ok {
-		log.Warnf("Trying to delete non-existing Counter counter '%v'.", name)
+		log.Warn("Trying to delete non-existing Counter counter.")
 		return
 	}
 
-	log.Debugf("Unregistering Counter Metric '%v' ...", name)
+	log.Debug("Unregistering Counter Metric...")
 	ok = registerer.Unregister(counter)
 	if !ok {
-		log.Errorf("Failed to unregister Counter Metric '%v'.", name)
+		log.Error("Failed to unregister Counter Metric.")
 		return
 	}
 	delete(counters, name)
@@ -486,18 +490,19 @@ func unregisterCounterIfExists(name string) {
 
 // registerCounterVecIfNotExists registers single counter vec metric if not exists
 func registerCounterVecIfNotExists(opts CounterVecOpts) {
+	log := log.WithFields("metricName", opts.Name)
 	if _, exist := counterVecs[opts.Name]; exist {
-		log.Warnf("Counter vec metric '%v' already exists.", opts.Name)
+		log.Warn("Counter vec metric already exists.")
 		return
 	}
 
-	log.Debugf("Creating Counter Vec Metric '%v' ...", opts.Name)
+	log.Debug("Creating Counter Vec Metric...")
 	counterVec := prometheus.NewCounterVec(opts.CounterOpts, opts.Labels)
-	log.Debugf("Counter Vec Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Counter Vec Metric successfully created! Labels: %p", opts.ConstLabels)
 
-	log.Debugf("Registering Counter Vec Metric '%v' ...", opts.Name)
+	log.Debug("Registering Counter Vec Metric...")
 	registerer.MustRegister(counterVec)
-	log.Debugf("Counter Vec Metric '%v' successfully registered!", opts.Name)
+	log.Debug("Counter Vec Metric successfully registered!")
 
 	counterVecs[opts.Name] = counterVec
 }
@@ -509,35 +514,37 @@ func unregisterCounterVecIfExists(name string) {
 		ok         bool
 	)
 
+	log := log.WithFields("metricName", name)
 	if counterVec, ok = counterVecs[name]; !ok {
-		log.Warnf("Trying to delete non-existing Counter Vec counter '%v'.", name)
+		log.Warn("Trying to delete non-existing Counter Vec counter.")
 		return
 	}
 
-	log.Debugf("Unregistering Counter Vec Metric '%v' ...", name)
+	log.Debug("Unregistering Counter Vec Metric...")
 	ok = registerer.Unregister(counterVec)
 	if !ok {
-		log.Errorf("Failed to unregister Counter Vec Metric '%v'.", name)
+		log.Error("Failed to unregister Counter Vec Metric.")
 		return
 	}
 	delete(counterVecs, name)
-	log.Debugf("Counter Vec Metric '%v' successfully unregistered!", name)
+	log.Debug("Counter Vec Metric successfully unregistered!")
 }
 
 // registerHistogramIfNotExists registers single histogram metric if not exists
 func registerHistogramIfNotExists(opts prometheus.HistogramOpts) {
+	log := log.WithFields("metricName", opts.Name)
 	if _, exist := histograms[opts.Name]; exist {
-		log.Warnf("Histogram metric '%v' already exists.", opts.Name)
+		log.Warn("Histogram metric already exists.")
 		return
 	}
 
-	log.Debugf("Creating Histogram Metric '%v' ...", opts.Name)
+	log.Debug("Creating Histogram Metric...")
 	histogram := prometheus.NewHistogram(opts)
-	log.Debugf("Histogram Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Histogram Metric successfully created! Labels: %p", opts.ConstLabels)
 
-	log.Debugf("Registering Histogram Metric '%v' ...", opts.Name)
+	log.Debug("Registering Histogram Metric...")
 	registerer.MustRegister(histogram)
-	log.Debugf("Histogram Metric '%v' successfully registered!", opts.Name)
+	log.Debug("Histogram Metric successfully registered!")
 
 	histograms[opts.Name] = histogram
 }
@@ -549,19 +556,20 @@ func unregisterHistogramIfExists(name string) {
 		ok        bool
 	)
 
+	log := log.WithFields("metricName", name)
 	if histogram, ok = histograms[name]; !ok {
-		log.Warnf("Trying to delete non-existing Histogram histogram '%v'.", name)
+		log.Warn("Trying to delete non-existing Histogram histogram.")
 		return
 	}
 
-	log.Debugf("Unregistering Histogram Metric '%v' ...", name)
+	log.Debug("Unregistering Histogram Metric...")
 	ok = registerer.Unregister(histogram)
 	if !ok {
-		log.Errorf("Failed to unregister Histogram Metric '%v'.", name)
+		log.Error("Failed to unregister Histogram Metric.")
 		return
 	}
 	delete(histograms, name)
-	log.Debugf("Histogram Metric '%v' successfully unregistered!", name)
+	log.Debug("Histogram Metric successfully unregistered!")
 }
 
 // registerHistogramVecIfNotExists unregisters single counter metric if exists
@@ -606,18 +614,19 @@ func unregisterHistogramVecIfExists(name string) {
 
 // registerSummaryIfNotExists registers single summary metric if not exists
 func registerSummaryIfNotExists(opts prometheus.SummaryOpts) {
+	log := log.WithFields("metricName", opts.Name)
 	if _, exist := summaries[opts.Name]; exist {
-		log.Warnf("Summary metric '%v' already exists.", opts.Name)
+		log.Warn("Summary metric already exists.")
 		return
 	}
 
-	log.Debugf("Creating Summary Metric '%v' ...", opts.Name)
+	log.Debug("Creating Summary Metric...")
 	summary := prometheus.NewSummary(opts)
-	log.Debugf("Summary Metric '%v' successfully created! Labels: %p", opts.Name, opts.ConstLabels)
+	log.Debugf("Summary Metric successfully created! Labels: %p", opts.ConstLabels)
 
-	log.Debugf("Registering Summary Metric '%v' ...", opts.Name)
+	log.Debug("Registering Summary Metric...")
 	registerer.MustRegister(summary)
-	log.Debugf("Summary Metric '%v' successfully registered!", opts.Name)
+	log.Debug("Summary Metric successfully registered!")
 
 	summaries[opts.Name] = summary
 }
@@ -629,17 +638,18 @@ func unregisterSummaryIfExists(name string) {
 		ok      bool
 	)
 
+	log := log.WithFields("metricName", name)
 	if summary, ok = summaries[name]; !ok {
-		log.Warnf("Trying to delete non-existing Summary summary '%v'.", name)
+		log.Warn("Trying to delete non-existing Summary summary.")
 		return
 	}
 
-	log.Debugf("Unregistering Summary Metric '%v' ...", name)
+	log.Debug("Unregistering Summary Metric...")
 	ok = registerer.Unregister(summary)
 	if !ok {
-		log.Errorf("Failed to unregister Summary Metric '%v'.", name)
+		log.Error("Failed to unregister Summary Metric.")
 		return
 	}
 	delete(summaries, name)
-	log.Debugf("Summary Metric '%v' successfully unregistered!", name)
+	log.Debug("Summary Metric successfully unregistered!")
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -53,8 +53,9 @@ var (
 
 func TestMain(m *testing.M) {
 	log.Init(log.Config{
-		Level:   "debug",
-		Outputs: []string{"stdout"},
+		Level:    "debug",
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
 	})
 
 	code := m.Run()

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -53,9 +53,8 @@ var (
 
 func TestMain(m *testing.M) {
 	log.Init(log.Config{
-		Level:    "debug",
-		Encoding: "console",
-		Outputs:  []string{"stdout"},
+		Level:   "debug",
+		Outputs: []string{"stderr"},
 	})
 
 	code := m.Run()

--- a/test/Makefile
+++ b/test/Makefile
@@ -257,6 +257,13 @@ run: ## Runs a full node
 stop: ## Stops all services
 	$(STOP)
 
+.PHONY: sail
+sail: ## Builds docker images and run them
+	cd .. && make build-docker && cd ./test && make run
+
+.PHONY: resail
+resail: stop sail ## Executes `make stop` and `make sail` commands
+
 .PHONY: restart
 restart: stop run ## Executes `make stop` and `make run` commands
 

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -1,9 +1,9 @@
 IsTrustedSequencer = true
 
 [Log]
+Environment = "development" # "production" or "development"
 Level = "debug"
-Encoding = "console" # valid values are "console" or "json"
-Outputs = ["stdout"]
+Outputs = ["stderr"]
 
 [StateDB]
 User = "state_user"

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -2,6 +2,7 @@ IsTrustedSequencer = true
 
 [Log]
 Level = "debug"
+Encoding = "console" # valid values are "console" or "json"
 Outputs = ["stdout"]
 
 [StateDB]

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -1,9 +1,9 @@
 IsTrustedSequencer = true
 
 [Log]
+Environment = "development" # "production" or "development"
 Level = "debug"
-Encoding = "console" # valid values are "console" or "json"
-Outputs = ["stdout"]
+Outputs = ["stderr"]
 
 [StateDB]
 User = "state_user"

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -2,6 +2,7 @@ IsTrustedSequencer = true
 
 [Log]
 Level = "debug"
+Encoding = "console" # valid values are "console" or "json"
 Outputs = ["stdout"]
 
 [StateDB]

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -83,7 +83,11 @@ func setLogLevel(ctx *cli.Context) error {
 		logLevel = "debug"
 	}
 
-	log.Init(log.Config{Level: logLevel, Outputs: []string{"stdout"}})
+	log.Init(log.Config{
+		Level:    logLevel,
+		Encoding: "console",
+		Outputs:  []string{"stdout"},
+	})
 	return nil
 }
 

--- a/test/scripts/batchsender/main.go
+++ b/test/scripts/batchsender/main.go
@@ -84,9 +84,8 @@ func setLogLevel(ctx *cli.Context) error {
 	}
 
 	log.Init(log.Config{
-		Level:    logLevel,
-		Encoding: "console",
-		Outputs:  []string{"stdout"},
+		Level:   logLevel,
+		Outputs: []string{"stderr"},
 	})
 	return nil
 }

--- a/test/scripts/txsender/main.go
+++ b/test/scripts/txsender/main.go
@@ -99,7 +99,10 @@ func setLogLevel(ctx *cli.Context) error {
 		logLevel = "debug"
 	}
 
-	log.Init(log.Config{Level: logLevel, Outputs: []string{"stdout"}})
+	log.Init(log.Config{
+		Level:   logLevel,
+		Outputs: []string{"stderr"},
+	})
 	return nil
 }
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,24 @@
+package zkevm
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+)
+
+// Populated during build, don't touch!
+var (
+	Version   = "v0.1.0"
+	GitRev    = "undefined"
+	GitBranch = "undefined"
+	BuildDate = "Fri, 17 Jun 1988 01:58:00 +0200"
+)
+
+func PrintVersion(w io.Writer) {
+	fmt.Fprintf(w, "Version:      %s\n", Version)
+	fmt.Fprintf(w, "Git revision: %s\n", GitRev)
+	fmt.Fprintf(w, "Git branch:   %s\n", GitBranch)
+	fmt.Fprintf(w, "Go version:   %s\n", runtime.Version())
+	fmt.Fprintf(w, "Built:        %s\n", BuildDate)
+	fmt.Fprintf(w, "OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}

--- a/version.go
+++ b/version.go
@@ -14,6 +14,7 @@ var (
 	BuildDate = "Fri, 17 Jun 1988 01:58:00 +0200"
 )
 
+// PrintVersion prints version info into the provided io.Writer.
 func PrintVersion(w io.Writer) {
 	fmt.Fprintf(w, "Version:      %s\n", Version)
 	fmt.Fprintf(w, "Git revision: %s\n", GitRev)

--- a/version.mk
+++ b/version.mk
@@ -1,0 +1,4 @@
+VERSION := $(shell git describe --tags --always)
+GITREV := $(shell git rev-parse --short HEAD)
+GITBRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+DATE := $(shell LANG=US date +"%a, %d %b %Y %X %z")


### PR DESCRIPTION
### What does this PR do?

This PR proposes to revamp our `log` package. The idea is to have more information in the logs without having to add them manually on each log line.

This is accomplished by providing a way to get **child loggers** derived from the **root** one: 
- **Every function** that needs to inject new fields in the logs can do so by calling `WithFields` on the current logger. 
- **This returns** a new child logger that will print the provided fields on every log line (within the function scope) in addition to the parent logger fields.

### Example

```go
// use root logger
log.Debug("This is a debug log line from the root logger")

// derive a child logger from the root one, with additional fields
childLog := log.WithFields("txHash", "0xbanana", "chainId", 42)

// these two log lines will be decorated with the `txHash` and `chainId` fields
childLog.Debug("This is a debug log line")
childLog.Debug("This is another debug log line")

// derive a child logger from the previous child, adding another field
grandChildLog := childLog.WithFields("proverId", "prover123")

// this log line will be decorated with the `txHash`, `chainId` and `proverId` fields
grandChildLog.Debug("This is a debug log line from the granchild logger")

// derive another child logger from the root one, with another field
childLog2 := log.WithFields("batchNum": 8)

// this line will only have the `batchNum` field
childLog2.Debug("This is a debug log line from the second child logger")
```


**NOTE:** here 2 default fields have been added to **every** log line: `version` and `pid`.
They are purely demonstrative and can be removed/replaced with better ones.

Other logs have been decorated with fields inside `jsonrpc` and `metrics` package. The idea is to gradually start using the feature while developing.

**ENCODING**
Now the encoding of the logs can be specified in the config file choosing between `console` and `json`. The default value is `console`, but `json` can be used in a deployed environment for better logs ingestion.

### Bonus

The log message on startup has been polished a bit:
```sh
Version:      v0.0.1-RC1-5-g8538ace
Git revision: 8538ace
Git branch:   feature/revamp-logs
Go version:   go1.17.13
Built:        Fri, 02 Dec 2022 16:47:58 +0000
OS/Arch:      linux/amd64
```

The env var to pass the commit hash is not needed any more, instead it is sourced from the `Makefile` through a linker flag.

### Reviewers

Main reviewers:

@arnaubennassar 
@ToniRamirezM 
@tclemos 
@Psykepro 

CC: @xavier-romero 
