### PR TITLE
Remove PrivateKey config keys from public node config file

### DIFF
--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -23,8 +23,6 @@ MaxConns = 200
 [Etherman]
 URL = "http://your.L1node.url"
 L1ChainID = 5
-PrivateKeyPath = "/pk/keystore"
-PrivateKeyPassword = "testonly"
 PoEAddr = "0x14cB06e8dE2222912138F9a062E5a4d9F4821409"
 MaticAddr = "0x4701Aa9471d7bfAc765D87dcb1Ea6BB23AD32733"
 GlobalExitRootManagerAddr = "0x762d09Ed110ace4EaC94acbb67b1C35D16C3297b"


### PR DESCRIPTION
Closes #1415.

### What does this PR do?

Removes `PrivateKey` keys from public config for use in `make run-rpc`

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @kind84 
- @arnaubennassar 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->
