### PR TITLE
Fix/1472 verify batches timeout

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -743,8 +743,8 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover *prover.P
 	return true, nil
 }
 
-// canVerifyProof returns if we have reached the timeout to verify a
-// proof.
+// canVerifyProof returns true if we have reached the timeout to verify a proof
+// and no other prover is verifying a proof.
 func (a *Aggregator) canVerifyProof() bool {
 	a.TimeSendFinalProofMutex.Lock()
 	defer a.TimeSendFinalProofMutex.Unlock()
@@ -762,7 +762,6 @@ func (a *Aggregator) enableProofVerification() {
 	a.TimeSendFinalProofMutex.Lock()
 	defer a.TimeSendFinalProofMutex.Unlock()
 	a.verifyingProof = false
-
 }
 
 // resetVerifyProofTime updates the timeout to verify a proof.

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -767,9 +767,9 @@ func (a *Aggregator) enableProofVerification() {
 
 // resetVerifyProofTime updates the timeout to verify a proof.
 func (a *Aggregator) resetVerifyProofTime() {
-	a.enableProofVerification()
 	a.TimeSendFinalProofMutex.Lock()
 	defer a.TimeSendFinalProofMutex.Unlock()
+	a.verifyingProof = false
 	a.TimeSendFinalProof = time.Now().Add(a.cfg.VerifyProofInterval.Duration)
 }
 

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -45,7 +45,8 @@ type Aggregator struct {
 	StateDBMutex            *sync.Mutex
 	TimeSendFinalProofMutex *sync.RWMutex
 
-	finalProof chan finalProofMsg
+	finalProof     chan finalProofMsg
+	verifyingProof bool
 
 	srv  *grpc.Server
 	ctx  context.Context
@@ -207,6 +208,7 @@ func (a *Aggregator) sendFinalProof() {
 			finalBatch, err := a.State.GetBatchByNumber(ctx, proof.BatchNumberFinal, nil)
 			if err != nil {
 				log.Errorf("Failed to retrieve batch with number [%d]", proof.BatchNumberFinal)
+				a.enableProofVerification()
 				continue
 			}
 
@@ -228,6 +230,7 @@ func (a *Aggregator) sendFinalProof() {
 				if err != nil {
 					log.Errorf("Rollback failed updating proof state (false) for proof ID [%v], err: %v", proof.ProofID, err)
 				}
+				a.enableProofVerification()
 				continue
 			}
 
@@ -302,11 +305,18 @@ func (a *Aggregator) buildFinalProof(ctx context.Context, prover proverInterface
 func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterface, proof *state.Proof) (bool, error) {
 	log.Debugf("tryBuildFinalProof start prover { ID [%s], addr [%s] }", prover.ID(), prover.Addr())
 
-	if !a.verifyProofTimeReached() {
+	var err error
+	if !a.canVerifyProof() {
 		log.Debug("Time to verify proof not reached")
 		return false, nil
 	}
 	log.Debug("Send final proof time reached")
+
+	defer func() {
+		if err != nil {
+			a.enableProofVerification()
+		}
+	}()
 
 	for !a.isSynced(ctx) {
 		log.Info("Waiting for synchronizer to sync...")
@@ -351,7 +361,8 @@ func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterf
 		// we do have a proof generating at the moment, check if it is
 		// eligible to be verified
 
-		eligible, err := a.validateEligibleFinalProof(ctx, proof, lastVerifiedBatchNum)
+		var eligible bool // we need this to keep using err from the outer scope and trigger the defer func
+		eligible, err = a.validateEligibleFinalProof(ctx, proof, lastVerifiedBatchNum)
 		if err != nil {
 			return false, fmt.Errorf("Failed to validate eligible final proof, %w", err)
 		}
@@ -732,16 +743,31 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover *prover.P
 	return true, nil
 }
 
-// verifyProofTimeReached returns if we have reached the timeout to verify a
+// canVerifyProof returns if we have reached the timeout to verify a
 // proof.
-func (a *Aggregator) verifyProofTimeReached() bool {
-	a.TimeSendFinalProofMutex.RLock()
-	defer a.TimeSendFinalProofMutex.RUnlock()
-	return a.TimeSendFinalProof.Before(time.Now())
+func (a *Aggregator) canVerifyProof() bool {
+	a.TimeSendFinalProofMutex.Lock()
+	defer a.TimeSendFinalProofMutex.Unlock()
+	if a.TimeSendFinalProof.Before(time.Now()) {
+		if a.verifyingProof {
+			return false
+		}
+		a.verifyingProof = true
+		return true
+	}
+	return false
+}
+
+func (a *Aggregator) enableProofVerification() {
+	a.TimeSendFinalProofMutex.Lock()
+	defer a.TimeSendFinalProofMutex.Unlock()
+	a.verifyingProof = false
+
 }
 
 // resetVerifyProofTime updates the timeout to verify a proof.
 func (a *Aggregator) resetVerifyProofTime() {
+	a.enableProofVerification()
 	a.TimeSendFinalProofMutex.Lock()
 	defer a.TimeSendFinalProofMutex.Unlock()
 	a.TimeSendFinalProof = time.Now().Add(a.cfg.VerifyProofInterval.Duration)

--- a/test/config/test.prover.config.json
+++ b/test/config/test.prover.config.json
@@ -9,6 +9,7 @@
     "runAggregatorServer": false,
     "runAggregatorClient": false,
     "runAggregatorClientMock": true, 
+    "aggregatorClientMockTimeout": 15000000,
     
     "runFileGenBatchProof": false,
     "runFileGenAggregatedProof": false,


### PR DESCRIPTION
Closes #1472

### What does this PR do?

During testing we faced an issue of two consecutive verified batches on L1 without respecting the time spacing.
The problem was that we were relying on the timer to check if we can start generating a new final proof. That timer is only reset after the final proof is sent to L1. This means that there's a time window between the generation of a final proof and its verification in which a new proof eligible to be final can be generated and immediately trigger another final proof generation.

The fix introduced here is to have a `verifyingProof` flag that gets checked when the final proof generation process begins and released only when the verification phase ends (or in case of errors).

### Reviewers

Main reviewers:

@agnusmor 