### PR TITLE
[Aggregator] Add metrics package and ConnectedProvers metric

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0xPolygonHermez/zkevm-node/aggregator/metrics"
 	"github.com/0xPolygonHermez/zkevm-node/aggregator/pb"
 	"github.com/0xPolygonHermez/zkevm-node/aggregator/prover"
 	ethmanTypes "github.com/0xPolygonHermez/zkevm-node/etherman/types"
@@ -94,6 +95,8 @@ func (a *Aggregator) Start(ctx context.Context) error {
 	a.ctx = ctx
 	a.exit = cancel
 
+	metrics.Register()
+
 	// Delete ungenerated recursive proofs
 	err := a.State.DeleteUngeneratedProofs(ctx, nil)
 	if err != nil {
@@ -137,6 +140,9 @@ func (a *Aggregator) Stop() {
 // Channel implements the bi-directional communication channel between the
 // Prover client and the Aggregator server.
 func (a *Aggregator) Channel(stream pb.AggregatorService_ChannelServer) error {
+	metrics.ConnectedProver()
+	defer metrics.DisconnectedProver()
+
 	ctx := stream.Context()
 	var proverAddr net.Addr
 	p, ok := peer.FromContext(ctx)

--- a/aggregator/metrics/metrics.go
+++ b/aggregator/metrics/metrics.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"github.com/0xPolygonHermez/zkevm-node/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prefix                      = "aggregator_"
+	currentConnectedProversName = prefix + "current_connected_provers"
+)
+
+// Register the metrics for the sequencer package.
+func Register() {
+	gauges := []prometheus.GaugeOpts{
+		{
+			Name: currentConnectedProversName,
+			Help: "[AGGREGATOR] current connected provers",
+		},
+	}
+
+	metrics.RegisterGauges(gauges...)
+}
+
+// ConnectedProver increments the gauge for the current number of connected
+// provers.
+func ConnectedProver() {
+	metrics.GaugeInc(currentConnectedProversName)
+}
+
+// DisconnectedProver decrements the gauge for the current number of connected
+// provers.
+func DisconnectedProver() {
+	metrics.GaugeDec(currentConnectedProversName)
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -111,6 +111,28 @@ func GaugeSet(name string, value float64) {
 	}
 }
 
+// GaugeInc increments the gauge with the given name.
+func GaugeInc(name string) {
+	if !initialized {
+		return
+	}
+
+	if g, ok := Gauge(name); ok {
+		g.Inc()
+	}
+}
+
+// GaugeDec decrements the gauge with the given name.
+func GaugeDec(name string) {
+	if !initialized {
+		return
+	}
+
+	if g, ok := Gauge(name); ok {
+		g.Dec()
+	}
+}
+
 // RegisterCounters registers the provided counter metrics to the Prometheus
 // registerer.
 func RegisterCounters(opts ...prometheus.CounterOpts) {

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -96,6 +96,31 @@ func TestGaugeSet(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestGaugeInc(t *testing.T) {
+	setup()
+	defer cleanup()
+	gauges[gaugeName] = gauge
+	expected := float64(1)
+
+	GaugeInc(gaugeName)
+	actual := testutil.ToFloat64(gauge)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestGaugeDec(t *testing.T) {
+	setup()
+	defer cleanup()
+	gauges[gaugeName] = gauge
+	gauge.Set(2)
+	expected := float64(1)
+
+	GaugeDec(gaugeName)
+	actual := testutil.ToFloat64(gauge)
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestUnregisterGauges(t *testing.T) {
 	setup()
 	defer cleanup()

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -104,6 +104,7 @@ services:
     image: zkevm-node
     ports:
       - 50081:50081
+      - 9093:9091 # needed if metrics enabled
     environment:
       - ZKEVM_NODE_STATEDB_HOST=zkevm-state-db
     volumes:


### PR DESCRIPTION
Closes #1497.

### What does this PR do?

This PR adds the `metrics` subpackage in the `aggregator` package. It also adds the `aggregator_current_connected_provers` gauge metric to keep track of the number of currently connected provers.

### Reviewers

Main reviewers:

@arnaubennassar 