### PR TITLE
Fix consecutive proofs verifications. Verify proof including batches lower than last verified batch

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -47,7 +47,7 @@ type Aggregator struct {
 
 	finalProof     chan finalProofMsg
 	verifyingProof bool
- 
+
 	srv  *grpc.Server
 	ctx  context.Context
 	exit context.CancelFunc

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -47,7 +47,7 @@ type Aggregator struct {
 
 	finalProof     chan finalProofMsg
 	verifyingProof bool
-  
+ 
 	srv  *grpc.Server
 	ctx  context.Context
 	exit context.CancelFunc


### PR DESCRIPTION
Closes [#1472](https://github.com/0xPolygonHermez/zkevm-node/issues/1472)

### What does this PR do?

- Fix aggregator doing 2 consecutives proof verifications
- Workaround to manage proofs that contains batches behind the last verified batch

### Reviewers

Main reviewers:

- @kind84 
- @arnaubennassar 
- @ToniRamirezM 
