### PR TITLE
Fix encoding bug in AddForcedBatch

### DIFF
--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -315,7 +315,7 @@ func (p *PostgresStorage) GetTimeForLatestBatchVirtualization(ctx context.Contex
 // AddForcedBatch adds a new ForcedBatch to the db
 func (p *PostgresStorage) AddForcedBatch(ctx context.Context, forcedBatch *ForcedBatch, tx pgx.Tx) error {
 	const addForcedBatchSQL = "INSERT INTO state.forced_batch (forced_batch_num, global_exit_root, timestamp, raw_txs_data, coinbase, block_num) VALUES ($1, $2, $3, $4, $5, $6)"
-	_, err := tx.Exec(ctx, addForcedBatchSQL, forcedBatch.ForcedBatchNumber, forcedBatch.GlobalExitRoot.String(), forcedBatch.ForcedAt, forcedBatch.RawTxsData, forcedBatch.Sequencer.String(), forcedBatch.BlockNumber)
+	_, err := tx.Exec(ctx, addForcedBatchSQL, forcedBatch.ForcedBatchNumber, forcedBatch.GlobalExitRoot.String(), forcedBatch.ForcedAt, hex.EncodeToString(forcedBatch.RawTxsData), forcedBatch.Sequencer.String(), forcedBatch.BlockNumber)
 	return err
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where raw transactions from a forced batch are not properly hex-encoded when storing in the database.

The forced_batch table expects the raw_txs_data column to be a string (specifically a hex encoding of the raw transaction bytes). The corresponding GetForcedBatch function uses hex.DecodeString to turn the value of this column back into raw bytes. However, AddForcedBatch is missing a hex.EncodeToString, so it is actually interpreting the raw transaction bytes as an ASCII representation of a hex-encoded string.

### Reviewers

Main reviewers: (not sure who to tag, happy to change it)

- @fgimenez 
- @tclemos 
