### PR TITLE
Fix migrations check at startup with a read-only connection

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -117,7 +117,9 @@ func checkMigrations(cfg Config, packrName string, direction migrate.MigrationDi
 		log.Error("error getting migrations count: ", err)
 		return err
 	}
-	if expected != actual {
+	if expected == actual {
+		log.Infof("Found %d migrations as expected", actual)
+	} else {
 		return fmt.Errorf("error the component needs to run %d migrations before starting. DB only contains %d migrations", expected, actual)
 	}
 	return nil

--- a/db/db.go
+++ b/db/db.go
@@ -97,21 +97,29 @@ func checkMigrations(cfg Config, packrName string, direction migrate.MigrationDi
 		return fmt.Errorf("packr box not found with name: %v", packrName)
 	}
 
-	var migrations = &migrate.PackrMigrationSource{Box: box}
-	planMigrations, _, err := migrate.PlanMigration(db, "postgres", migrations, direction, maxPlanMigration)
+	migrationSource := &migrate.PackrMigrationSource{Box: box}
+	migrations, err := migrationSource.FindMigrations()
 	if err != nil {
-		log.Error("error planning migrations. Error: ", err)
+		log.Errorf("error getting migrations from source: %v", err)
 		return err
 	}
-	nmigrations := len(planMigrations)
-	if nmigrations != 0 {
-		log.Errorf("error the component needs to run %d migrations before starting", nmigrations)
-		records, err := migrate.GetMigrationRecords(db, "postgres")
-		if err != nil {
-			log.Error("error getting migration records. Error: ", err)
-			return err
+
+	var expected int
+	for _, migration := range migrations {
+		if len(migration.Up) != 0 {
+			expected++
 		}
-		return fmt.Errorf("error the component needs to run %d migrations before starting. DB only contains %d migrations", nmigrations, len(records))
+	}
+
+	var actual int
+	query := `SELECT COUNT(1) FROM public.gorp_migrations`
+	err = db.QueryRow(query).Scan(&actual)
+	if err != nil {
+		log.Error("error getting migrations count: ", err)
+		return err
+	}
+	if expected != actual {
+		return fmt.Errorf("error the component needs to run %d migrations before starting. DB only contains %d migrations", expected, actual)
 	}
 	return nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -17,7 +17,6 @@ const (
 	StateMigrationName = "zkevm-state-db"
 	// PoolMigrationName is the name of the migration used by packr to pack the migration file
 	PoolMigrationName = "zkevm-pool-db"
-	maxPlanMigration  = 1000
 )
 
 var packrMigrations = map[string]*packr.Box{


### PR DESCRIPTION
Closes #1653.

### Background

The `rpc` node is supposed to connect to the `state` database using a read-only connection, in order to not overwhelm the RW connection. This is made possible by the changes introduced in https://github.com/0xPolygonHermez/zkevm-node/pull/1531 that allow the `rpc` node to not run migrations.

### What does this PR do?

Unfortunately it turns out that the `sql-migrate` library requires a RW connection even for tasks that do not actually run the migrations. In our case we were calling `migrate.PlanMigration` and `migrate.GetMigrationRecords` but both fail on a RO connection.

To overcome this, here the proposal is to directly query the migrations table and compare the number of migrations found there with the number of `Up` migrations in our source code (by inspecting list the returned by `migrationSource.FindMigrations()`).

The solution has been tested to be working on the `develop` testnet. It may sound a bit "hacky" and thus alternative ideas/approaches are welcome.

### Reviewers

Main reviewers:

- @tclemos 
- @ARR552 
- @arnaubennassar 