### PR TITLE
fix zkevm response to hex and open-rpc refs

### DIFF
--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -71,7 +71,7 @@ func (z *ZKEVMEndpoints) BatchNumberByBlockNumber(blockNumber argUint64) (interf
 			return nil, newRPCError(defaultErrorCode, errorMessage)
 		}
 
-		return batchNum, nil
+		return hex.EncodeUint64(batchNum), nil
 	})
 }
 

--- a/jsonrpc/endpoints_zkevm.openrpc.json
+++ b/jsonrpc/endpoints_zkevm.openrpc.json
@@ -10,10 +10,7 @@
       "summary": "Returns the latest block number that is connected to the latest batch verified.",
       "params": [],
       "result": {
-        "name": "result",
-        "schema": {
-          "$ref": "#/components/contentDescriptors/BlockNumber"
-        }
+        "$ref": "#/components/contentDescriptors/BlockNumber"
       },
       "examples": [
         {
@@ -113,10 +110,7 @@
       "summary": "Returns the latest batch number.",
       "params": [],
       "result": {
-        "name": "result",
-        "schema": {
-          "$ref": "#/components/contentDescriptors/BatchNumber"
-        }
+        "$ref": "#/components/contentDescriptors/BatchNumber"
       },
       "examples": [
         {
@@ -136,10 +130,7 @@
       "summary": "Returns the latest virtual batch number.",
       "params": [],
       "result": {
-        "name": "result",
-        "schema": {
-          "$ref": "#/components/contentDescriptors/BatchNumber"
-        }
+        "$ref": "#/components/contentDescriptors/BatchNumber"
       },
       "examples": [
         {
@@ -159,10 +150,7 @@
       "summary": "Returns the latest verified batch number.",
       "params": [],
       "result": {
-        "name": "result",
-        "schema": {
-          "$ref": "#/components/contentDescriptors/BatchNumber"
-        }
+        "$ref": "#/components/contentDescriptors/BatchNumber"
       },
       "examples": [
         {
@@ -186,10 +174,7 @@
         }
       ],
       "result": {
-        "name": "result",
-        "schema": {
-          "$ref": "#/components/contentDescriptors/BatchNumber"
-        }
+        "$ref": "#/components/contentDescriptors/BatchNumber"
       },
       "examples": [
         {

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -319,10 +319,10 @@ func TestBatchNumberByBlockNumber(t *testing.T) {
 			require.NoError(t, err)
 
 			if res.Result != nil {
-				var result uint64
+				var result argUint64
 				err = json.Unmarshal(res.Result, &result)
 				require.NoError(t, err)
-				assert.Equal(t, tc.ExpectedResult, result)
+				assert.Equal(t, tc.ExpectedResult, uint64(result))
 			}
 
 			if res.Error != nil || tc.ExpectedError != nil {


### PR DESCRIPTION
Closes #1618 and #1619.

### What does this PR do?

- fix zkevm_batchNumberByBlockNumber response to hex instead of uint
- fix open-rpc doc refs

### Reviewers

Main reviewers:

@kind84
@arnaubennassar