### PR TITLE
[Aggregator]  More fine-grained logs in case of prover errors

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/0xPolygonHermez/zkevm-node/aggregator/metrics"
 	"github.com/0xPolygonHermez/zkevm-node/aggregator/pb"
@@ -124,7 +125,7 @@ func (a *Aggregator) Start(ctx context.Context) error {
 	address := fmt.Sprintf("%s:%d", a.cfg.Host, a.cfg.Port)
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		log.Fatalf("Failed to listen: %v", err)
 	}
 
 	a.srv = grpc.NewServer()
@@ -178,12 +179,13 @@ func (a *Aggregator) Channel(stream pb.AggregatorService_ChannelServer) error {
 		"proverId", prover.ID(),
 		"proverAddr", prover.Addr(),
 	)
-	log.Debug("Establishing stream connection with prover")
+	log.Info("Establishing stream connection with prover")
 
 	// Check if prover supports the required Fork ID
 	if !prover.SupportsForkID(a.cfg.ForkId) {
-		log.Warnf("Prover does not support required fork ID: %d.", a.cfg.ForkId)
-		return fmt.Errorf("prover does not support required fork ID: %d", a.cfg.ForkId)
+		err := errors.New("prover does not support required fork ID")
+		log.Warn(FirstToUpper(err.Error()))
+		return err
 	}
 
 	for {
@@ -198,7 +200,7 @@ func (a *Aggregator) Channel(stream pb.AggregatorService_ChannelServer) error {
 		default:
 			isIdle, err := prover.IsIdle()
 			if err != nil {
-				log.Errorf("failed to check if prover is idle: %v", err)
+				log.Errorf("Failed to check if prover is idle: %v", err)
 				time.Sleep(a.cfg.RetryTime.Duration)
 				continue
 			}
@@ -210,17 +212,17 @@ func (a *Aggregator) Channel(stream pb.AggregatorService_ChannelServer) error {
 
 			_, err = a.tryBuildFinalProof(ctx, prover, nil)
 			if err != nil {
-				log.Errorf("error checking proofs to verify: %v", err)
+				log.Errorf("Error checking proofs to verify: %v", err)
 			}
 
 			proofGenerated, err := a.tryAggregateProofs(ctx, prover)
 			if err != nil {
-				log.Errorf("error trying to aggregate proofs: %v", err)
+				log.Errorf("Error trying to aggregate proofs: %v", err)
 			}
 			if !proofGenerated {
 				proofGenerated, err = a.tryGenerateBatchProof(ctx, prover)
 				if err != nil {
-					log.Errorf("error trying to generate proof: %v", err)
+					log.Errorf("Error trying to generate proof: %v", err)
 				}
 			}
 			if !proofGenerated {
@@ -252,7 +254,7 @@ func (a *Aggregator) sendFinalProof() {
 
 			finalBatch, err := a.State.GetBatchByNumber(ctx, proof.BatchNumberFinal, nil)
 			if err != nil {
-				log.Errorf("failed to retrieve batch with number [%d]: %v", proof.BatchNumberFinal, err)
+				log.Errorf("Failed to retrieve batch with number [%d]: %v", proof.BatchNumberFinal, err)
 				a.endProofVerification()
 				continue
 			}
@@ -269,7 +271,7 @@ func (a *Aggregator) sendFinalProof() {
 			sender := common.HexToAddress(a.cfg.SenderAddress)
 			to, data, err := a.Ethman.BuildTrustedVerifyBatchesTxData(proof.BatchNumber-1, proof.BatchNumberFinal, &inputs)
 			if err != nil {
-				log.Errorf("error estimating batch verification to add to eth tx manager: %v", err)
+				log.Errorf("Error estimating batch verification to add to eth tx manager: %v", err)
 				a.handleFailureToAddVerifyBatchToBeMonitored(ctx, proof)
 				continue
 			}
@@ -277,7 +279,7 @@ func (a *Aggregator) sendFinalProof() {
 			err = a.EthTxManager.Add(ctx, ethTxManagerOwner, monitoredTxID, sender, to, nil, data, nil)
 			if err != nil {
 				log := log.WithFields("tx", monitoredTxID)
-				log.Errorf("error to add batch verification tx to eth tx manager: %v", err)
+				log.Errorf("Error to add batch verification tx to eth tx manager: %v", err)
 				a.handleFailureToAddVerifyBatchToBeMonitored(ctx, proof)
 				continue
 			}
@@ -298,7 +300,7 @@ func (a *Aggregator) handleFailureToAddVerifyBatchToBeMonitored(ctx context.Cont
 	proof.GeneratingSince = nil
 	err := a.State.UpdateGeneratedProof(ctx, proof, nil)
 	if err != nil {
-		log.Errorf("failed updating proof state (false): %v", err)
+		log.Errorf("Failed updating proof state (false): %v", err)
 	}
 	a.endProofVerification()
 }
@@ -404,7 +406,7 @@ func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterf
 				proof.GeneratingSince = nil
 				err2 := a.State.UpdateGeneratedProof(a.ctx, proof, nil)
 				if err2 != nil {
-					log.Errorf("failed to unlock proof: %v", err2)
+					log.Errorf("Failed to unlock proof: %v", err2)
 				}
 			}
 		}()
@@ -429,7 +431,7 @@ func (a *Aggregator) tryBuildFinalProof(ctx context.Context, prover proverInterf
 	finalProof, err := a.buildFinalProof(ctx, prover, proof)
 	if err != nil {
 		err = fmt.Errorf("failed to build final proof, %w", err)
-		log.Error(err)
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -521,7 +523,7 @@ func (a *Aggregator) unlockProofsToAggregate(ctx context.Context, proof1 *state.
 	if err != nil {
 		if err := dbTx.Rollback(ctx); err != nil {
 			err := fmt.Errorf("failed to rollback proof aggregation state: %w", err)
-			log.Error(err.Error())
+			log.Error(FirstToUpper(err.Error()))
 			return err
 		}
 		return fmt.Errorf("failed to release proof aggregation state: %w", err)
@@ -568,7 +570,7 @@ func (a *Aggregator) getAndLockProofsToAggregate(ctx context.Context, prover pro
 	if err != nil {
 		if err := dbTx.Rollback(ctx); err != nil {
 			err := fmt.Errorf("failed to rollback proof aggregation state %w", err)
-			log.Error(err.Error())
+			log.Error(FirstToUpper(err.Error()))
 			return nil, nil, err
 		}
 		return nil, nil, fmt.Errorf("failed to set proof aggregation state %w", err)
@@ -630,7 +632,7 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	b, err := json.Marshal(inputProver)
 	if err != nil {
 		err = fmt.Errorf("failed to serialize input prover, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -645,7 +647,7 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	aggrProofID, err = prover.AggregatedProof(proof1.Proof, proof2.Proof)
 	if err != nil {
 		err = fmt.Errorf("failed to get aggregated proof id, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -657,7 +659,7 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	recursiveProof, err := prover.WaitRecursiveProof(ctx, *proof.ProofID)
 	if err != nil {
 		err = fmt.Errorf("failed to get aggregated proof from prover, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -670,7 +672,7 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	dbTx, err := a.State.BeginStateTransaction(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to begin transaction to update proof aggregation state, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -678,11 +680,11 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	if err != nil {
 		if err := dbTx.Rollback(ctx); err != nil {
 			err := fmt.Errorf("failed to rollback proof aggregation state, %w", err)
-			log.Error(err.Error())
+			log.Error(FirstToUpper(err.Error()))
 			return false, err
 		}
 		err = fmt.Errorf("failed to delete previously aggregated proofs, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -693,18 +695,18 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 	if err != nil {
 		if err := dbTx.Rollback(ctx); err != nil {
 			err := fmt.Errorf("failed to rollback proof aggregation state, %w", err)
-			log.Error(err.Error())
+			log.Error(FirstToUpper(err.Error()))
 			return false, err
 		}
 		err = fmt.Errorf("failed to store the recursive proof, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
 	err = dbTx.Commit(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to store the recursive proof, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -727,8 +729,8 @@ func (a *Aggregator) tryAggregateProofs(ctx context.Context, prover proverInterf
 		// final proof has not been generated, update the recursive proof
 		err := a.State.UpdateGeneratedProof(a.ctx, proof, nil)
 		if err != nil {
-			err = fmt.Errorf("Failed to store batch proof result, %w", err)
-			log.Error(err.Error())
+			err = fmt.Errorf("failed to store batch proof result, %w", err)
+			log.Error(FirstToUpper(err.Error()))
 			return false, err
 		}
 	}
@@ -837,14 +839,14 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover proverInt
 	inputProver, err := a.buildInputProver(ctx, batchToProve)
 	if err != nil {
 		err = fmt.Errorf("failed to build input prover, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
 	b, err := json.Marshal(inputProver)
 	if err != nil {
 		err = fmt.Errorf("failed to serialize input prover, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -856,7 +858,7 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover proverInt
 	genProofID, err = prover.BatchProof(inputProver)
 	if err != nil {
 		err = fmt.Errorf("failed to get batch proof id, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -868,7 +870,7 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover proverInt
 	resGetProof, err := prover.WaitRecursiveProof(ctx, *proof.ProofID)
 	if err != nil {
 		err = fmt.Errorf("failed to get proof from prover, %w", err)
-		log.Error(err.Error())
+		log.Error(FirstToUpper(err.Error()))
 		return false, err
 	}
 
@@ -893,8 +895,8 @@ func (a *Aggregator) tryGenerateBatchProof(ctx context.Context, prover proverInt
 		// final proof has not been generated, update the batch proof
 		err := a.State.UpdateGeneratedProof(a.ctx, proof, nil)
 		if err != nil {
-			err = fmt.Errorf("Failed to store batch proof result, %w", err)
-			log.Error(err.Error())
+			err = fmt.Errorf("failed to store batch proof result, %w", err)
+			log.Error(FirstToUpper(err.Error()))
 			return false, err
 		}
 	}
@@ -1059,7 +1061,7 @@ func (a *Aggregator) handleMonitoredTxResult(result ethtxmanager.MonitoredTxResu
 	// proofs up to the last synced batch
 	err = a.State.CleanupGeneratedProofs(a.ctx, proofBatchNumberFinal, nil)
 	if err != nil {
-		log.Errorf("failed to store proof aggregation result: %v", err)
+		log.Errorf("Failed to store proof aggregation result: %v", err)
 	}
 }
 
@@ -1075,7 +1077,7 @@ func (a *Aggregator) cleanupLockedProofs() {
 		case <-time.After(a.TimeCleanupLockedProofs.Duration):
 			n, err := a.State.CleanupLockedProofs(a.ctx, a.cfg.GeneratingProofCleanupThreshold, nil)
 			if err != nil {
-				log.Errorf("failed to cleanup locked proofs: %v", err)
+				log.Errorf("Failed to cleanup locked proofs: %v", err)
 			}
 			if n == 1 {
 				log.Warn("Found a stale proof and removed form cache")
@@ -1084,4 +1086,12 @@ func (a *Aggregator) cleanupLockedProofs() {
 			}
 		}
 	}
+}
+
+// FirstToUpper returns the string passed as argument with the first letter in
+// uppercase.
+func FirstToUpper(s string) string {
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }


### PR DESCRIPTION
Closes #1717.

### What does this PR do?

This PR adds logs in case of errors happening in the methods responsible to interact with the prover for proof generation.
This additional logs are necessary in order to print more information, in particular, the `proofId` and `batches` (or `batch`) fields, which is not available in the outer scope (the `Channel` method) where the main error log is printed.

### Reviewers

- @agnusmor 
- @ToniRamirezM 
- @Psykepro 