### PR TITLE
Fix/jsonrpc call incompatible

### DIFF
--- a/jsonrpc/codec.go
+++ b/jsonrpc/codec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/0xPolygonHermez/zkevm-node/encoding"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/jackc/pgx/v4"
 )
 
@@ -183,6 +184,21 @@ func stringToBlockNumber(str string) (BlockNumber, error) {
 		return 0, err
 	}
 	return BlockNumber(n), nil
+}
+
+func fromEthBlockNumber(ethBlockNumber rpc.BlockNumber) BlockNumber {
+	switch ethBlockNumber {
+	case rpc.PendingBlockNumber:
+		return PendingBlockNumber
+	case rpc.LatestBlockNumber:
+		return LatestBlockNumber
+	case rpc.FinalizedBlockNumber:
+		return LatestBlockNumber
+	case rpc.EarliestBlockNumber:
+		return EarliestBlockNumber
+	default:
+		return BlockNumber(ethBlockNumber)
+	}
 }
 
 // Index of a item

--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gorilla/websocket"
 	"github.com/jackc/pgx/v4"
 )
@@ -50,8 +51,22 @@ func (e *EthEndpoints) BlockNumber() (interface{}, rpcError) {
 // executed contract and potential error.
 // Note, this function doesn't make any changes in the state/blockchain and is
 // useful to execute view/pure methods and retrieve values.
-func (e *EthEndpoints) Call(arg *txnArgs, number *BlockNumber) (interface{}, rpcError) {
+func (e *EthEndpoints) Call(arg *txnArgs, blockNrOrHash *rpc.BlockNumberOrHash) (interface{}, rpcError) {
 	return e.txMan.NewDbTxScope(e.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, rpcError) {
+		ethBlockNumber, hasNum := blockNrOrHash.Number()
+		bnValue := fromEthBlockNumber(ethBlockNumber)
+		if !hasNum {
+			if blockHash, hasHash := blockNrOrHash.Hash(); hasHash {
+				if block, err := e.state.GetL2BlockByHash(ctx, blockHash, dbTx); err != nil {
+					return rpcErrorResponse(defaultErrorCode, "Unknown block hash", err)
+				} else {
+					bnValue = BlockNumber(block.Header().Number.Int64())
+				}
+			}
+			bnValue = LatestBlockNumber
+		}
+		number := &bnValue
+
 		// If the caller didn't supply the gas limit in the message, then we set it to maximum possible => block gas limit
 		if arg.Gas == nil || *arg.Gas == argUint64(0) {
 			header, err := e.getBlockHeader(ctx, *number, dbTx)

--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -68,7 +68,11 @@ func (e *EthEndpoints) Call(arg *txnArgs, blockNrOrHash *rpc.BlockNumberOrHash) 
 		number := &bnValue
 
 		// If the caller didn't supply the gas limit in the message, then we set it to maximum possible => block gas limit
-		if arg.Gas == nil || *arg.Gas == argUint64(0) {
+		header, err := e.getBlockHeader(ctx, *number, dbTx)
+		if err != nil {
+			return rpcErrorResponse(defaultErrorCode, "failed to get block header", err)
+		}
+		if arg.Gas == nil || *arg.Gas == argUint64(0) || *arg.Gas > argUint64(header.GasLimit) {
 			header, err := e.getBlockHeader(ctx, *number, dbTx)
 			if err != nil {
 				return rpcErrorResponse(defaultErrorCode, "failed to get block header", err)

--- a/jsonrpc/types.go
+++ b/jsonrpc/types.go
@@ -118,7 +118,7 @@ func encodeToHex(b []byte) []byte {
 
 // txnArgs is the transaction argument for the rpc endpoints
 type txnArgs struct {
-	From     common.Address
+	From     *common.Address
 	To       *common.Address
 	Gas      *argUint64
 	GasPrice *argUint64
@@ -143,7 +143,10 @@ func (args *txnArgs) ToUnsignedTransaction(ctx context.Context, st stateInterfac
 		data = *args.Data
 	}
 
-	sender := args.From
+	sender := state.ZeroAddress
+	if args.From != nil {
+		sender = *args.From
+	}
 	nonce := uint64(0)
 	gasPrice := big.NewInt(0)
 


### PR DESCRIPTION
### What does this PR do?

This PR is about fixing the RPC discrepancy of eth_call. 

commit 80faa38 
fixes "eth_call" does not support requests with block hash instead of block number

commit 9367571
fixes "eth_call" returns an error when the sender addr is nil, or when the gas limit is higher than header.GasLimit

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @ToniRamirezM 
- @ARR552 