### PR TITLE
Fix/unsigned tx state root

### DIFF
--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -73,12 +73,7 @@ func (e *EthEndpoints) Call(arg *txnArgs, number *BlockNumber) (interface{}, rpc
 			return rpcErrorResponse(defaultErrorCode, "failed to convert arguments into an unsigned transaction", err)
 		}
 
-		var blockNumberToProcessTx *uint64
-		if number != nil && *number != LatestBlockNumber && *number != PendingBlockNumber {
-			blockNumberToProcessTx = &blockNumber
-		}
-
-		result := e.state.ProcessUnsignedTransaction(ctx, tx, sender, blockNumberToProcessTx, false, dbTx)
+		result := e.state.ProcessUnsignedTransaction(ctx, tx, sender, blockNumber, false, dbTx)
 		if result.Failed() {
 			data := make([]byte, len(result.ReturnValue))
 			copy(data, result.ReturnValue)

--- a/jsonrpc/interfaces.go
+++ b/jsonrpc/interfaces.go
@@ -53,7 +53,7 @@ type stateInterface interface {
 	GetTransactionReceipt(ctx context.Context, transactionHash common.Hash, dbTx pgx.Tx) (*types.Receipt, error)
 	IsL2BlockConsolidated(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (bool, error)
 	IsL2BlockVirtualized(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (bool, error)
-	ProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, l2BlockNumber *uint64, noZKEVMCounters bool, dbTx pgx.Tx) *runtime.ExecutionResult
+	ProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, l2BlockNumber uint64, noZKEVMCounters bool, dbTx pgx.Tx) *runtime.ExecutionResult
 	RegisterNewL2BlockEventHandler(h state.NewL2BlockEventHandler)
 	GetLastVirtualBatchNum(ctx context.Context, dbTx pgx.Tx) (uint64, error)
 	GetLastVerifiedBatch(ctx context.Context, dbTx pgx.Tx) (*state.VerifiedBatch, error)

--- a/state/state.go
+++ b/state/state.go
@@ -1237,7 +1237,7 @@ func (s *State) ProcessUnsignedTransaction(ctx context.Context, tx *types.Transa
 
 // ProcessUnsignedTransaction processes the given unsigned transaction.
 func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, l2BlockNumber uint64, noZKEVMCounters bool, dbTx pgx.Tx) (*ProcessBatchResponse, error) {
-	lastBatches, l2BlockStateRoot, err := s.PostgresStorage.GetLastNBatchesByL2BlockNumber(ctx, &l2BlockNumber, two, dbTx)
+	lastBatches, _, err := s.PostgresStorage.GetLastNBatchesByL2BlockNumber(ctx, &l2BlockNumber, two, dbTx)
 	if err != nil {
 		return nil, err
 	}
@@ -1247,8 +1247,6 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 		log.Errorf("error getting l2 block", err)
 		return nil, err
 	}
-	log.Debug(l2Block.Root().Hex())
-	log.Debug(l2BlockStateRoot.Hex())
 
 	nonce, err := s.tree.GetNonce(ctx, senderAddress, l2Block.Root().Bytes())
 	if err != nil {


### PR DESCRIPTION
Closes #1824.

### What does this PR do?

Fix unsigned tx to use the specified l2block state root instead of the last l2block state root related to the batch.

### Reviewers

Main reviewers:

@ToniRamirezM
@ARR552 