### PR TITLE
Avoid changes on go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.18
 
       - name: Get packr
-        run: go get -u github.com/gobuffalo/packr/v2/packr2
+        run: go install github.com/gobuffalo/packr/v2/packr2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.18
 
       - name: Get packr
-        run: go install github.com/gobuffalo/packr/v2/packr2
+        run: go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM golang:1.18 AS build
 
 # INSTALL DEPENDENCIES
-RUN go install github.com/gobuffalo/packr/v2/packr2
 COPY go.mod go.sum /src/
 RUN cd /src && go mod download
+RUN go install github.com/gobuffalo/packr/v2/packr2
 
 # BUILD BINARY
 COPY . /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM golang:1.18 AS build
 
 # INSTALL DEPENDENCIES
+RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
 COPY go.mod go.sum /src/
 RUN cd /src && go mod download
-RUN go install github.com/gobuffalo/packr/v2/packr2
 
 # BUILD BINARY
 COPY . /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.18 AS build
 
 # INSTALL DEPENDENCIES
-RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
+RUN go install github.com/gobuffalo/packr/v2/packr2
 COPY go.mod go.sum /src/
 RUN cd /src && go mod download
 


### PR DESCRIPTION
Closes #1781

### What does this PR do?

- Prevents the action of release from updating the go.mod file when installing packr to compile