### PR TITLE
add fault tolerance when failed to get revert message

### DIFF
--- a/test/operations/wait.go
+++ b/test/operations/wait.go
@@ -127,7 +127,13 @@ func RevertReason(ctx context.Context, c ethClienter, tx *types.Transaction, blo
 		return "", err
 	}
 
-	return abi.UnpackRevert(hex)
+	unpackedMsg, err := abi.UnpackRevert(hex)
+	if err != nil {
+		log.Warnf("failed to get the revert message for tx %v: %v", tx.Hash(), err)
+		return "", errors.New("execution reverted")
+	}
+
+	return unpackedMsg, nil
 }
 
 // WaitGRPCHealthy waits for a gRPC endpoint to be responding according to the


### PR DESCRIPTION
Closes #1818.

### What does this PR do?

If the revert message can be extracted from the chain, we assume the generic revert message.

### Reviewers

Main reviewers:

@arnaubennassar 