### PR TITLE
Fix log L1 tx too big

### DIFF
--- a/sequencer/sequencesender.go
+++ b/sequencer/sequencesender.go
@@ -196,7 +196,7 @@ func (s *Sequencer) handleEstimateGasSendSequenceErr(
 		// Remove the latest item and send the sequences
 		log.Infof(
 			"Done building sequences, selected batches to %d. Batch %d caused the L1 tx to be too big",
-			currentBatchNumToSequence, currentBatchNumToSequence+1,
+			currentBatchNumToSequence-1, currentBatchNumToSequence,
 		)
 		sequences = sequences[:len(sequences)-1]
 		return sequences, nil


### PR DESCRIPTION
This log in the sequencesender was not showing the correct batches num values. The num batch that is overflowing the size of the L1 tx is the currentBatchNumToSequence (not +1):

		log.Infof(
			"Done building sequences, selected batches to %d. Batch %d caused the L1 tx to be too big",
			currentBatchNumToSequence, currentBatchNumToSequence+1,
		)