### PR TITLE
trustedsequencer url as config param

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -205,10 +205,14 @@ func runSynchronizer(cfg config.Config, etherman *etherman.Client, ethTxManager 
 	var trustedSequencerURL string
 	var err error
 	if !cfg.IsTrustedSequencer {
-		log.Debug("getting trusted sequencer URL from smc")
-		trustedSequencerURL, err = etherman.GetTrustedSequencerURL()
-		if err != nil {
-			log.Fatal("error getting trusted sequencer URI. Error: %v", err)
+		if cfg.Synchronizer.TrustedSequencerURL != "" {
+			trustedSequencerURL = cfg.Synchronizer.TrustedSequencerURL
+		} else {
+			log.Debug("getting trusted sequencer URL from smc")
+			trustedSequencerURL, err = etherman.GetTrustedSequencerURL()
+			if err != nil {
+				log.Fatal("error getting trusted sequencer URI. Error: %v", err)
+			}
 		}
 		log.Debug("trustedSequencerURL ", trustedSequencerURL)
 	}

--- a/config/default.go
+++ b/config/default.go
@@ -67,6 +67,7 @@ EnableL2SuggestedGasPricePolling = true
 SyncInterval = "0s"
 SyncChunkSize = 100
 GenBlockNumber = 67
+trustedSequencerURL = ""
 
 [Sequencer]
 WaitPeriodPoolIsEmpty = "1s"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -58,6 +58,7 @@ EnableL2SuggestedGasPricePolling = true
 SyncInterval = "1s"
 SyncChunkSize = 100
 GenBlockNumber = 79
+trustedSequencerURL = ""
 
 [Sequencer]
 WaitPeriodPoolIsEmpty = "1s"

--- a/config/environments/mainnet/public.node.config.toml
+++ b/config/environments/mainnet/public.node.config.toml
@@ -56,6 +56,7 @@ EnableL2SuggestedGasPricePolling = false
 SyncInterval = "2s"
 SyncChunkSize = 100
 GenBlockNumber = 16896721
+trustedSequencerURL = ""
 
 [MTClient]
 URI = "zkevm-prover:50061"

--- a/synchronizer/config.go
+++ b/synchronizer/config.go
@@ -8,9 +8,10 @@ import (
 type Config struct {
 	// SyncInterval is the delay interval between reading new rollup information
 	SyncInterval types.Duration `mapstructure:"SyncInterval"`
-
 	// SyncChunkSize is the number of blocks to sync on each chunk
 	SyncChunkSize uint64 `mapstructure:"SyncChunkSize"`
-
+	// GenBlockNumber is the block number where the polygonZKEVM smc was deployed
 	GenBlockNumber uint64 `mapstructure:"GenBlockNumber"`
+	// TrustedSequencerURL is the rpc url to connect and sync the trusted state
+	TrustedSequencerURL string `mapstructure:"TrustedSequencerURL"`
 }

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -58,6 +58,7 @@ EnableL2SuggestedGasPricePolling = true
 SyncInterval = "5s"
 SyncChunkSize = 100
 GenBlockNumber = 79
+trustedSequencerURL = ""
 
 [Sequencer]
 WaitPeriodPoolIsEmpty = "1s"

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -58,6 +58,7 @@ EnableL2SuggestedGasPricePolling = true
 SyncInterval = "1s"
 SyncChunkSize = 100
 GenBlockNumber = 79
+trustedSequencerURL = ""
 
 [Sequencer]
 WaitPeriodPoolIsEmpty = "1s"


### PR DESCRIPTION
Closes #1955 

### What does this PR do?

This pr adds a config param to avoid getting the rpc from the smc

### Reviewers

- @arnaubennassar 
