### PR TITLE
add EIP-1898 support to eth_call

### DIFF
--- a/jsonrpc/types/codec.go
+++ b/jsonrpc/types/codec.go
@@ -296,7 +296,6 @@ func (b *BlockNumberOrHash) UnmarshalJSON(buffer []byte) error {
 				}
 				return nil
 			}
-
 		} else {
 			return fmt.Errorf("invalid block or hash")
 		}


### PR DESCRIPTION
Closes #1951.

Pending the following methods:

- eth_getBalance
- eth_getStorageAt
- eth_getTransactionCount
- eth_getCode

### What does this PR do?

Allows the eth_call endpoint to be compatible with the EIP-1898

### Reviewers

Main reviewers:

@arnaubennassar 
@Psykepro 
@ToniRamirezM 