### PR TITLE
fix BatchNumberByBlockNumber when batch is not found

### DIFF
--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -66,7 +66,9 @@ func (z *ZKEVMEndpoints) IsBlockVirtualized(blockNumber types.ArgUint64) (interf
 func (z *ZKEVMEndpoints) BatchNumberByBlockNumber(blockNumber types.ArgUint64) (interface{}, types.Error) {
 	return z.txMan.NewDbTxScope(z.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, types.Error) {
 		batchNum, err := z.state.BatchNumberByL2BlockNumber(ctx, uint64(blockNumber), dbTx)
-		if err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			return nil, nil
+		} else if err != nil {
 			const errorMessage = "failed to get batch number from block number"
 			log.Errorf("%v: %v", errorMessage, err.Error())
 			return nil, types.NewRPCError(types.DefaultErrorCode, errorMessage)

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -262,15 +262,15 @@ func TestBatchNumberByBlockNumber(t *testing.T) {
 
 	type testCase struct {
 		Name           string
-		ExpectedResult uint64
+		ExpectedResult *uint64
 		ExpectedError  types.Error
 		SetupMocks     func(m *mocksWrapper)
 	}
 
 	testCases := []testCase{
 		{
-			Name:           "Query status of batch number of l2 block by its number successfully",
-			ExpectedResult: batchNumber,
+			Name:           "get batch number by block number successfully",
+			ExpectedResult: &batchNumber,
 			SetupMocks: func(m *mocksWrapper) {
 				m.DbTx.
 					On("Commit", context.Background()).
@@ -289,8 +289,8 @@ func TestBatchNumberByBlockNumber(t *testing.T) {
 			},
 		},
 		{
-			Name:           "Failed to query the consolidation status",
-			ExpectedResult: uint64(0),
+			Name:           "failed to get batch number",
+			ExpectedResult: nil,
 			ExpectedError:  types.NewRPCError(types.DefaultErrorCode, "failed to get batch number from block number"),
 			SetupMocks: func(m *mocksWrapper) {
 				m.DbTx.
@@ -309,6 +309,27 @@ func TestBatchNumberByBlockNumber(t *testing.T) {
 					Once()
 			},
 		},
+		{
+			Name:           "batch number not found",
+			ExpectedResult: nil,
+			ExpectedError:  nil,
+			SetupMocks: func(m *mocksWrapper) {
+				m.DbTx.
+					On("Commit", context.Background()).
+					Return(nil).
+					Once()
+
+				m.State.
+					On("BeginStateTransaction", context.Background()).
+					Return(m.DbTx, nil).
+					Once()
+
+				m.State.
+					On("BatchNumberByL2BlockNumber", context.Background(), blockNumber, m.DbTx).
+					Return(uint64(0), state.ErrNotFound).
+					Once()
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -319,16 +340,27 @@ func TestBatchNumberByBlockNumber(t *testing.T) {
 			res, err := s.JSONRPCCall("zkevm_batchNumberByBlockNumber", hex.EncodeUint64(blockNumber))
 			require.NoError(t, err)
 
-			if res.Result != nil {
+			if tc.ExpectedResult != nil {
 				var result types.ArgUint64
 				err = json.Unmarshal(res.Result, &result)
 				require.NoError(t, err)
-				assert.Equal(t, tc.ExpectedResult, uint64(result))
+				assert.Equal(t, *tc.ExpectedResult, uint64(result))
+			} else {
+				if res.Result == nil {
+					assert.Nil(t, res.Result)
+				} else {
+					var result *uint64
+					err = json.Unmarshal(res.Result, &result)
+					require.NoError(t, err)
+					assert.Nil(t, result)
+				}
 			}
 
-			if res.Error != nil || tc.ExpectedError != nil {
+			if tc.ExpectedError != nil {
 				assert.Equal(t, tc.ExpectedError.ErrorCode(), res.Error.Code)
 				assert.Equal(t, tc.ExpectedError.Error(), res.Error.Message)
+			} else {
+				assert.Nil(t, res.Error)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1855.

### What does this PR do?

Return null Instead of returning an error when the batch is not found when calling `zkevm_batchNumberByBlockNumber` 

### Reviewers

Main reviewers:

@arnaubennassar
@ToniRamirezM