### PR TITLE
Fix BlockExplorer L2 Port in Local documentation

### DIFF
--- a/docs/running_local.md
+++ b/docs/running_local.md
@@ -154,7 +154,7 @@ make run-approve-matic
     - `Type:` Web
     - `Host:` localhost
     - `Port:` 4001
-    - `Url:` <http://localhost:4000>
+    - `Url:` <http://localhost:4001>
 - Prover
   - `Type:` Mock
   - `Host:` localhost


### PR DESCRIPTION
### What does this PR do?

Fixes documentation of local zkEvm-node spin-up.

