### PR TITLE
improve: adding logs of tx efficiency

### DIFF
--- a/sequencer/efficiencylist.go
+++ b/sequencer/efficiencylist.go
@@ -103,6 +103,7 @@ func (e *efficiencyList) addSort(tx *TxTracker) {
 	e.sorted = append(e.sorted, nil)
 	copy(e.sorted[i+1:], e.sorted[i:])
 	e.sorted[i] = tx
+	log.Infof("Added tx(%s) to efficiencyList. With efficiency(%f) at index(%d) from total(%d)", tx.HashStr, tx.Efficiency, i, len(e.sorted))
 }
 
 // isGreaterThan returns true if the tx1 has best efficiency than tx2

--- a/sequencer/txtracker.go
+++ b/sequencer/txtracker.go
@@ -100,6 +100,7 @@ func (tx *TxTracker) calculateEfficiency(constraints batchConstraints, weights b
 
 	var accuracy big.Accuracy
 	tx.Efficiency, accuracy = eff.Float64()
+	log.Infof("CalculateEfficiency(%f) for tx(%s)", tx.Efficiency, tx.Hash.String())
 	if accuracy != big.Exact {
 		log.Errorf("CalculateEfficiency accuracy warning (%s). Calculated=%s Assigned=%f", accuracy.String(), eff.String(), tx.Efficiency)
 	}

--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -256,7 +256,7 @@ func (w *Worker) GetBestFittingTx(resources batchResources) *TxTracker {
 				if foundAt == -1 || foundAt > i {
 					foundAt = i
 					tx = txCandidate
-					log.Infof("GetBestFittingTx found tx(%s) at index(%d)", tx.Hash.String(), i)
+					log.Infof("GetBestFittingTx found tx(%s) at index(%d) with efficiency(%f)", tx.Hash.String(), i, tx.Efficiency)
 				}
 				foundMutex.Unlock()
 


### PR DESCRIPTION
Closes #1731 .

### What does this PR do?

Adding logs for `efficiency`:

- When adding the tx to the list
- on `getBestFittingTx`
- on update tx because of new counters

### Reviewers

Main reviewers:
- @ToniRamirezM 
- @agnusmor