### PR TITLE
Improve claim checks

### DIFF
--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -683,12 +683,16 @@ func (p *PostgresPoolStorage) GetAllAddressesBlocked(ctx context.Context) ([]com
 	return addrs, nil
 }
 
-// DepositCountExists checks if already exists a transaction in the pool with the
-// provided deposit count
+// DepositCountExists checks if already exists a `pending` or `selected` transaction
+// in the pool with the provided deposit count
 func (p *PostgresPoolStorage) DepositCountExists(ctx context.Context, depositCount uint64) (bool, error) {
 	var exists bool
-	req := "SELECT exists (SELECT 1 FROM pool.transaction WHERE deposit_count = $1)"
-	err := p.db.QueryRow(ctx, req, depositCount).Scan(&exists)
+	req := `
+        SELECT EXISTS (SELECT 1
+                         FROM pool.transaction
+                        WHERE deposit_count = $1
+                          AND status IN ($2, $3))`
+	err := p.db.QueryRow(ctx, req, depositCount, pool.TxStatusPending, pool.TxStatusSelected).Scan(&exists)
 	if err != nil && err != sql.ErrNoRows {
 		return false, err
 	}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1430,16 +1430,28 @@ func Test_AvoidDuplicatedClaims(t *testing.T) {
 	auth.GasPrice = big.NewInt(0)
 	auth.Nonce = big.NewInt(0)
 
-	signedTx, err := bridgeSC.ClaimAsset(auth, [32][32]byte{}, uint32(123456789), [32]byte{}, [32]byte{}, 69, common.Address{}, uint32(20), common.Address{}, big.NewInt(0), []byte{})
+	depositCount := uint32(123456789)
+	signedTx, err := bridgeSC.ClaimAsset(auth, [32][32]byte{}, depositCount, [32]byte{}, [32]byte{}, 69, common.Address{}, uint32(20), common.Address{}, big.NewInt(0), []byte{})
 	require.NoError(t, err)
 
+	// add claim
 	err = p.AddTx(ctx, *signedTx, "")
 	require.NoError(t, err)
 
-	auth.Nonce = big.NewInt(1)
-	signedTx, err = bridgeSC.ClaimAsset(auth, [32][32]byte{}, uint32(123456789), [32]byte{}, [32]byte{}, 69, common.Address{}, uint32(20), common.Address{}, big.NewInt(0), []byte{})
+	auth.GasLimit++
+	signedTx, err = bridgeSC.ClaimAsset(auth, [32][32]byte{}, depositCount, [32]byte{}, [32]byte{}, 69, common.Address{}, uint32(20), common.Address{}, big.NewInt(0), []byte{})
 	require.NoError(t, err)
 
+	// add claim with same deposit count
 	err = p.AddTx(ctx, *signedTx, "")
 	require.Equal(t, err.Error(), "deposit count already exists")
+
+	auth.Nonce = big.NewInt(1)
+	depositCount = uint32(12345678)
+	signedTx, err = bridgeSC.ClaimAsset(auth, [32][32]byte{}, depositCount, [32]byte{}, [32]byte{}, 69, common.Address{}, uint32(20), common.Address{}, big.NewInt(0), []byte{})
+	require.NoError(t, err)
+
+	// add claim with wrong nonce
+	err = p.AddTx(ctx, *signedTx, "")
+	require.Equal(t, err.Error(), "invalid nonce")
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1112,7 +1112,7 @@ func Test_AddTx_GasPriceErr(t *testing.T) {
 		},
 		{
 			name:          "NoGasPriceTooLowErr_ForClaims",
-			nonce:         1,
+			nonce:         0,
 			to:            &l2BridgeAddr,
 			gasLimit:      cfg.FreeClaimGasLimit,
 			gasPrice:      big.NewInt(0),


### PR DESCRIPTION
Closes #2014.

### What does this PR do?

check the deposit count only for `pending` and `selected` TXs in the pool.
allow claims only when the tx nonce matches the sender account's current nonce.

### Reviewers

Main reviewers:

@ToniRamirezM 
@arnaubennassar 
@agnusmor 