### PR TITLE
fix wrong state root when prevlastbatch & lastbatch are empty + restart

### DIFF
--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -626,7 +626,7 @@ func TestEstimateGas(t *testing.T) {
 					Once()
 				m.State.
 					On("EstimateGas", txMatchBy, *txArgs.From, nilUint64, m.DbTx).
-					Return(*testCase.expectedResult, nil).
+					Return(*testCase.expectedResult, nil, nil).
 					Once()
 			},
 		},
@@ -667,7 +667,7 @@ func TestEstimateGas(t *testing.T) {
 
 				m.State.
 					On("EstimateGas", txMatchBy, common.HexToAddress(c.DefaultSenderAddress), nilUint64, m.DbTx).
-					Return(*testCase.expectedResult, nil).
+					Return(*testCase.expectedResult, nil, nil).
 					Once()
 			},
 		},

--- a/sequencer/dbmanager.go
+++ b/sequencer/dbmanager.go
@@ -271,8 +271,8 @@ func (d *dbManager) GetWIPBatch(ctx context.Context) (*WipBatch, error) {
 	}
 
 	var lastStateRoot common.Hash
-	// If the last two batches has no txs, the stateRoot can not be retrieve from the l2block because there is no tx.
-	// In this case, the stateRoot must be get from the previousLastBatch
+	// If the last two batches have no txs, the stateRoot can not be retrieved from the l2block because there is no tx.
+	// In this case, the stateRoot must be gotten from the previousLastBatch
 	if len(lastBatchTxs) == 0 && previousLastBatch != nil && len(prevLastBatchTxs) == 0 {
 		lastStateRoot = previousLastBatch.StateRoot
 	} else {

--- a/sequencer/dbmanager.go
+++ b/sequencer/dbmanager.go
@@ -270,7 +270,6 @@ func (d *dbManager) GetWIPBatch(ctx context.Context) (*WipBatch, error) {
 		}
 	}
 
-
 	var lastStateRoot common.Hash
 	// If the last two batches has no txs, the stateRoot can not be retrieve from the l2block because there is no tx.
 	// In this case, the stateRoot must be get from the previousLastBatch


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug that consist in getting the wrong state root when the last two batches are empty (no txs = no l2blocks) and happens a reset of the sequencer. In this situation the sequencer was using the third to last batch stateroot.
![image](https://user-images.githubusercontent.com/11256256/233127588-7b01fd7c-256b-40ba-b0cb-85ff39b0ead2.png)
The sequencer was getting the stateRoot `0xc4c.....` for the batch 1236 as oldStateRoot instead of the `0x35.....` when it was executing tx by tx. However when it executed the whole batch it was using the correct one (`0x35...`).

### Reviewers

- @agnusmor 
- @ToniRamirezM 