### PR TITLE
Fix config files formatting

### DIFF
--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -22,14 +22,15 @@ MaxTxDataBytesSize=30000
 DefaultMinGasPriceAllowed = 1000000000
 MinAllowedGasPriceInterval = "5m"
 PollMinAllowedGasPriceInterval = "15s"
-	[Pool.DB]
-	User = "pool_user"
-	Password = "pool_password"
-	Name = "pool_db"
-	Host = "zkevm-pool-db"
-	Port = "5432"
-	EnableLog = false
-	MaxConns = 200
+
+[Pool.DB]
+User = "pool_user"
+Password = "pool_password"
+Name = "pool_db"
+Host = "zkevm-pool-db"
+Port = "5432"
+EnableLog = false
+MaxConns = 200
 
 [Etherman]
 URL = "http://your.L1node.url"
@@ -38,8 +39,9 @@ PoEAddr = "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
 MaticAddr = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
 GlobalExitRootManagerAddr = "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
 MultiGasProvider = false
-	[Etherman.Etherscan]
-		ApiKey = ""
+
+[Etherman.Etherscan]
+ApiKey = ""
 
 [RPC]
 Host = "0.0.0.0"
@@ -50,9 +52,10 @@ MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://internal.zkevm-test.net:2083/"
 DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = true
-	[RPC.WebSockets]
-		Enabled = true
-		Port = 8546
+
+[RPC.WebSockets]
+Enabled = true
+Port = 8546
 
 [Synchronizer]
 SyncInterval = "1s"
@@ -88,24 +91,27 @@ WeightSteps = 1
 TxLifetimeCheckTimeout = "10m"
 MaxTxLifetime = "3h"
 MaxTxSizeForL1 = 131072
-	[Sequencer.Finalizer]
-		GERDeadlineTimeoutInSec = "5s"
-		ForcedBatchDeadlineTimeoutInSec = "60s"
-		SleepDurationInMs = "100ms"
-		ResourcePercentageToCloseBatch = 10
-		GERFinalityNumberOfBlocks = 0
-		ClosingSignalsManagerWaitForCheckingL1Timeout = "10s"
-		ClosingSignalsManagerWaitForCheckingGER = "10s"
-		ClosingSignalsManagerWaitForCheckingForcedBatches = "10s"
-		ForcedBatchesFinalityNumberOfBlocks = 64
-		TimestampResolution = "15s"
-		SenderAddress = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
-		PrivateKeys = [{Path = "/pk/sequencer.keystore", Password = "testonly"}]
-	[Sequencer.DBManager]
-		PoolRetrievalInterval = "500ms"
-		L2ReorgRetrievalInterval = "5s"
-	[Sequencer.Worker]
-		ResourceCostMultiplier = 1000
+
+[Sequencer.Finalizer]
+GERDeadlineTimeoutInSec = "5s"
+ForcedBatchDeadlineTimeoutInSec = "60s"
+SleepDurationInMs = "100ms"
+ResourcePercentageToCloseBatch = 10
+GERFinalityNumberOfBlocks = 0
+ClosingSignalsManagerWaitForCheckingL1Timeout = "10s"
+ClosingSignalsManagerWaitForCheckingGER = "10s"
+ClosingSignalsManagerWaitForCheckingForcedBatches = "10s"
+ForcedBatchesFinalityNumberOfBlocks = 64
+TimestampResolution = "15s"
+SenderAddress = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+PrivateKeys = [{Path = "/pk/sequencer.keystore", Password = "testonly"}]
+
+[Sequencer.DBManager]
+PoolRetrievalInterval = "500ms"
+L2ReorgRetrievalInterval = "5s"
+
+[Sequencer.Worker]
+ResourceCostMultiplier = 1000
 
 [Aggregator]
 Host = "0.0.0.0"

--- a/config/environments/mainnet/public.node.config.toml
+++ b/config/environments/mainnet/public.node.config.toml
@@ -19,14 +19,15 @@ MaxTxDataBytesSize=30000
 DefaultMinGasPriceAllowed = 1000000000
 MinAllowedGasPriceInterval = "5m"
 PollMinAllowedGasPriceInterval = "15s"
-	[Pool.DB]
-	User = "pool_user"
-	Password = "pool_password"
-	Name = "pool_db"
-	Host = "zkevm-pool-db"
-	Port = "5432"
-	EnableLog = false
-	MaxConns = 200
+
+[Pool.DB]
+User = "pool_user"
+Password = "pool_password"
+Name = "pool_db"
+Host = "zkevm-pool-db"
+Port = "5432"
+EnableLog = false
+MaxConns = 200
 
 [Etherman]
 URL = "http://your.L1node.url"
@@ -35,8 +36,9 @@ PoEAddr = "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
 MaticAddr = "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0"
 GlobalExitRootManagerAddr = "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb"
 MultiGasProvider = false
-	[Etherman.Etherscan]
-		ApiKey = ""
+
+[Etherman.Etherscan]
+ApiKey = ""
 
 [RPC]
 Host = "0.0.0.0"
@@ -47,9 +49,10 @@ MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://zkevm-rpc.com"
 DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = false
-	[RPC.WebSockets]
-		Enabled = true
-		Port = 8546
+
+[RPC.WebSockets]
+Enabled = true
+Port = 8546
 
 [Synchronizer]
 SyncInterval = "2s"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -20,14 +20,15 @@ MaxTxDataBytesSize=30000
 DefaultMinGasPriceAllowed = 1000000000
 MinAllowedGasPriceInterval = "5m"
 PollMinAllowedGasPriceInterval = "15s"
-	[Pool.DB]
-	User = "pool_user"
-	Password = "pool_password"
-	Name = "pool_db"
-	Host = "zkevm-pool-db"
-	Port = "5432"
-	EnableLog = false
-	MaxConns = 200
+
+[Pool.DB]
+User = "pool_user"
+Password = "pool_password"
+Name = "pool_db"
+Host = "zkevm-pool-db"
+Port = "5432"
+EnableLog = false
+MaxConns = 200
 
 [Etherman]
 URL = "http://your.L1node.url"
@@ -36,8 +37,9 @@ PoEAddr = "0xa997cfD539E703921fD1e3Cf25b4c241a27a4c7A"
 MaticAddr = "0x1319D23c2F7034F52Eb07399702B040bA278Ca49"
 GlobalExitRootManagerAddr = "0x4d9427DCA0406358445bC0a8F88C26b704004f74"
 MultiGasProvider = false
-	[Etherman.Etherscan]
-		ApiKey = ""
+
+[Etherman.Etherscan]
+ApiKey = ""
 
 [RPC]
 Host = "0.0.0.0"
@@ -48,9 +50,10 @@ MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://rpc.public.zkevm-test.net/"
 DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = false
-	[RPC.WebSockets]
-		Enabled = true
-		Port = 8546
+
+[RPC.WebSockets]
+Enabled = true
+Port = 8546
 
 [Synchronizer]
 SyncInterval = "2s"


### PR DESCRIPTION
Because of the config files formatting, some values did not set up, for example:

* `[Pool.DB]`
* `[Etherman.Etherscan]`
* `[RPC.WebSockets]`
* `[Sequencer.Finalizer]`
* `[Sequencer.DBManager]`
* `[Sequencer.Worker]`

Relates to #1953.