### PR TITLE
Make PostgreSQL version persistent to 14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
   zkevm-state-db:
     container_name: zkevm-state-db
     restart: unless-stopped
-    image: postgres
+    image: postgres:14
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready" ]
       interval: 10s
@@ -83,7 +83,7 @@ services:
   zkevm-pool-db:
     container_name: zkevm-pool-db
     restart: unless-stopped
-    image: postgres
+    image: postgres:14
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready" ]
       interval: 10s


### PR DESCRIPTION
For new installations, the PostgreSQL version would be >14 and it breaks running migrations: the `init_prover_db.sql` runs successfully but when PostgreSQL restarts after this, it shows the following errors:

```
zkevm-state-db: ERROR:  permission denied for schema public
zkevm-state-db: STATEMENT:  create or replace function get_tree (root_hash bytea, remaining_key bytea)
```

Making PostgreSQL version fixed to 14 solves the problem.