### PR TITLE
Fix outdated explorer image in test/docker-compose.yml

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -210,7 +210,7 @@ services:
 
   zkevm-explorer-l1:
     container_name: zkevm-explorer-l1
-    image: hermeznetwork/hermez-node-blockscout:latest
+    image: hermeznetwork/zkevm-explorer:latest
     ports:
       - 4000:4000
     environment:
@@ -243,7 +243,7 @@ services:
 
   zkevm-explorer-l2:
     container_name: zkevm-explorer-l2
-    image: hermeznetwork/hermez-node-blockscout:latest
+    image: hermeznetwork/zkevm-explorer:latest
     ports:
       - 4001:4000
     environment:


### PR DESCRIPTION
### What does this PR do?

The explorer image `hermez-node-blockscout` does not exist anymore in the official [hub](https://hub.docker.com/u/hermeznetwork).

[zkevm-explorer](https://hub.docker.com/r/hermeznetwork/zkevm-explorer) is the one to use in the `test/docker-compose.yml` file

### Test Plan

`make run run-l2-explorer` and open http://localhost:4001/. See the explorer loads correctly

<img width="2022" alt="image" src="https://user-images.githubusercontent.com/111917526/235379879-6e10797d-dae0-4249-9624-dcc866d47b47.png">

### Reviewers

Main reviewers:

- @arnaubennassar
- @ToniRamirezM
- @ARR552 