### PR TITLE
fix default trace values for custom tracers

### DIFF
--- a/state/transaction.go
+++ b/state/transaction.go
@@ -243,19 +243,29 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 	traceConfigRequest := &pb.TraceConfig{
 		TxHashToGenerateCallTrace:    transactionHash.Bytes(),
 		TxHashToGenerateExecuteTrace: transactionHash.Bytes(),
+		// set the defaults to the maximum information we can have.
+		// this is needed to process custom tracers later
+		DisableStorage:   cFalse,
+		DisableStack:     cFalse,
+		EnableMemory:     cTrue,
+		EnableReturnData: cTrue,
 	}
 
-	if traceConfig.DisableStorage {
-		traceConfigRequest.DisableStorage = cTrue
-	}
-	if traceConfig.DisableStack {
-		traceConfigRequest.DisableStack = cTrue
-	}
-	if traceConfig.EnableMemory {
-		traceConfigRequest.EnableMemory = cTrue
-	}
-	if traceConfig.EnableReturnData {
-		traceConfigRequest.EnableReturnData = cTrue
+	// if the default tracer is used, then we review the information
+	// we want to have in the trace related to the parameters we received.
+	if traceConfig.IsDefaultTracer() {
+		if traceConfig.DisableStorage {
+			traceConfigRequest.DisableStorage = cTrue
+		}
+		if traceConfig.DisableStack {
+			traceConfigRequest.DisableStack = cTrue
+		}
+		if traceConfig.EnableMemory {
+			traceConfigRequest.EnableMemory = cTrue
+		}
+		if traceConfig.EnableReturnData {
+			traceConfigRequest.EnableReturnData = cTrue
+		}
 	}
 
 	oldStateRoot := previousBlock.Root()

--- a/test/e2e/debug_test.go
+++ b/test/e2e/debug_test.go
@@ -618,11 +618,7 @@ func TestDebugTraceTransactionCallTracer(t *testing.T) {
 				}
 
 				debugOptions := map[string]interface{}{
-					"disableStorage":   false,
-					"disableStack":     false,
-					"enableMemory":     true,
-					"enableReturnData": true,
-					"tracer":           "callTracer",
+					"tracer": "callTracer",
 					"tracerConfig": map[string]interface{}{
 						"onlyTopCall": false,
 						"withLog":     true,


### PR DESCRIPTION
What does this PR do?
fix default trace values for custom tracers, because they need the full trace in order to generate the custom tracer response.

Reviewers
Main reviewers:

@ToniRamirezM