### PR TITLE
Review jRPC default configuration

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -127,7 +127,6 @@ func start(cliCtx *cli.Context) error {
 
 	c.Aggregator.ChainID = l2ChainID
 	c.Aggregator.ForkId = currentForkID
-	c.RPC.ChainID = l2ChainID
 	log.Infof("Chain ID read from POE SC = %v", l2ChainID)
 
 	ctx := context.Background()
@@ -201,7 +200,7 @@ func start(cliCtx *cli.Context) error {
 			for _, a := range cliCtx.StringSlice(config.FlagHTTPAPI) {
 				apis[a] = true
 			}
-			go runJSONRPCServer(*c, poolInstance, st, apis)
+			go runJSONRPCServer(*c, l2ChainID, poolInstance, st, apis)
 		case SYNCHRONIZER:
 			ev.Component = event.Component_Synchronizer
 			ev.Description = "Running synchronizer"
@@ -312,11 +311,11 @@ func runSynchronizer(cfg config.Config, etherman *etherman.Client, ethTxManager 
 	}
 }
 
-func runJSONRPCServer(c config.Config, pool *pool.Pool, st *state.State, apis map[string]bool) {
+func runJSONRPCServer(c config.Config, chainID uint64, pool *pool.Pool, st *state.State, apis map[string]bool) {
 	storage := jsonrpc.NewStorage()
 	c.RPC.MaxCumulativeGasUsed = c.Sequencer.MaxCumulativeGasUsed
 
-	if err := jsonrpc.NewServer(c.RPC, pool, st, storage, apis).Start(); err != nil {
+	if err := jsonrpc.NewServer(c.RPC, chainID, pool, st, storage, apis).Start(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -343,6 +343,10 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: 200,
 		},
 		{
+			path:          "RPC.Host",
+			expectedValue: "0.0.0.0",
+		},
+		{
 			path:          "RPC.Port",
 			expectedValue: int(8545),
 		},
@@ -369,6 +373,10 @@ func Test_Defaults(t *testing.T) {
 		{
 			path:          "RPC.WebSockets.Enabled",
 			expectedValue: false,
+		},
+		{
+			path:          "RPC.WebSockets.Host",
+			expectedValue: "0.0.0.0",
 		},
 		{
 			path:          "RPC.WebSockets.Port",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -343,12 +343,8 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: 200,
 		},
 		{
-			path:          "RPC.Host",
-			expectedValue: "0.0.0.0",
-		},
-		{
 			path:          "RPC.Port",
-			expectedValue: int(8123),
+			expectedValue: int(8545),
 		},
 		{
 			path:          "RPC.ReadTimeout",
@@ -367,21 +363,16 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: float64(50),
 		},
 		{
-			path:          "RPC.DefaultSenderAddress",
-			expectedValue: "0x1111111111111111111111111111111111111111",
-		},
-		{
-			path:          "RPC.WebSockets.Enabled",
-			expectedValue: true,
-		},
-
-		{
 			path:          "RPC.EnableL2SuggestedGasPricePolling",
 			expectedValue: true,
 		},
 		{
+			path:          "RPC.WebSockets.Enabled",
+			expectedValue: false,
+		},
+		{
 			path:          "RPC.WebSockets.Port",
-			expectedValue: 8124,
+			expectedValue: int(8546),
 		},
 		{
 			path:          "Executor.URI",

--- a/config/default.go
+++ b/config/default.go
@@ -55,6 +55,7 @@ SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
 		Enabled = false
+		Host = "0.0.0.0"
 		Port = 8546
 
 [Synchronizer]

--- a/config/default.go
+++ b/config/default.go
@@ -47,16 +47,15 @@ ForcedGas = 0
 
 [RPC]
 Host = "0.0.0.0"
-Port = 8123
+Port = 8545
 ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 50
 SequencerNodeURI = ""
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
-		Enabled = true
-		Port = 8124
+		Enabled = false
+		Port = 8546
 
 [Synchronizer]
 SyncInterval = "0s"
@@ -65,7 +64,6 @@ TrustedSequencerURL = ""
 
 [Sequencer]
 WaitPeriodPoolIsEmpty = "1s"
-
 BlocksAmountForTxsToBeDeleted = 100
 FrequencyToCheckTxsForDelete = "12h"
 MaxTxsPerBatch = 150

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -43,7 +43,6 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://internal.zkevm-test.net:2083/"
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
 		Enabled = true

--- a/config/environments/mainnet/public.node.config.toml
+++ b/config/environments/mainnet/public.node.config.toml
@@ -40,7 +40,6 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://zkevm-rpc.com"
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = false
 	[RPC.WebSockets]
 		Enabled = true

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -41,7 +41,6 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = "https://rpc.public.zkevm-test.net/"
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = false
 	[RPC.WebSockets]
 		Enabled = true

--- a/jsonrpc/config.go
+++ b/jsonrpc/config.go
@@ -4,6 +4,9 @@ import "github.com/0xPolygonHermez/zkevm-node/config/types"
 
 // Config represents the configuration of the json rpc
 type Config struct {
+	// Host defines the network adapter that will be used to serve the HTTP requests
+	Host string `mapstructure:"Host"`
+
 	// Port defines the port to serve the endpoints via HTTP
 	Port int `mapstructure:"Port"`
 
@@ -35,6 +38,12 @@ type Config struct {
 
 // WebSocketsConfig has parameters to config the rpc websocket support
 type WebSocketsConfig struct {
+	// Enabled defines if the WebSocket requests are enabled or disabled
 	Enabled bool `mapstructure:"Enabled"`
-	Port    int  `mapstructure:"Port"`
+
+	// Host defines the network adapter that will be used to serve the WS requests
+	Host string `mapstructure:"Host"`
+
+	// Port defines the port to serve the endpoints via WS
+	Port int `mapstructure:"Port"`
 }

--- a/jsonrpc/config.go
+++ b/jsonrpc/config.go
@@ -4,29 +4,29 @@ import "github.com/0xPolygonHermez/zkevm-node/config/types"
 
 // Config represents the configuration of the json rpc
 type Config struct {
-	Host         string         `mapstructure:"Host"`
-	Port         int            `mapstructure:"Port"`
-	ReadTimeout  types.Duration `mapstructure:"ReadTimeout"`
+	// Port defines the port to serve the endpoints via HTTP
+	Port int `mapstructure:"Port"`
+
+	// ReadTimeout is the HTTP server read timeout
+	// check net/http.server.ReadTimeout and net/http.server.ReadHeaderTimeout
+	ReadTimeout types.Duration `mapstructure:"ReadTimeout"`
+
+	// WriteTimeout is the HTTP server write timeout
+	// check net/http.server.WriteTimeout
 	WriteTimeout types.Duration `mapstructure:"WriteTimeout"`
 
+	// MaxRequestsPerIPAndSecond defines how much requests a single IP can
+	// send within a single second
 	MaxRequestsPerIPAndSecond float64 `mapstructure:"MaxRequestsPerIPAndSecond"`
 
 	// SequencerNodeURI is used allow Non-Sequencer nodes
 	// to relay transactions to the Sequencer node
 	SequencerNodeURI string `mapstructure:"SequencerNodeURI"`
 
-	// DefaultSenderAddress is the address that jRPC will use
-	// to communicate with the state for eth_EstimateGas and eth_Call when
-	// the From field is not specified because it is optional
-	DefaultSenderAddress string `mapstructure:"DefaultSenderAddress"`
-
 	// MaxCumulativeGasUsed is the max gas allowed per batch
 	MaxCumulativeGasUsed uint64
 
-	// ChainID is the L2 ChainID provided by the Network Config
-	ChainID uint64
-
-	// Websockets
+	// WebSockets configuration
 	WebSockets WebSocketsConfig `mapstructure:"WebSockets"`
 
 	// EnableL2SuggestedGasPricePolling enables polling of the L2 gas price to block tx in the RPC with lower gas price.

--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -377,7 +377,7 @@ func TestCall(t *testing.T) {
 				block := ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: blockNumOne, Root: blockRoot})
 				m.State.On("GetL2BlockByNumber", context.Background(), blockNumOneUint64, m.DbTx).Return(block, nil).Once()
 				m.State.
-					On("ProcessUnsignedTransaction", context.Background(), txMatchBy, common.HexToAddress(c.DefaultSenderAddress), nilUint64, true, m.DbTx).
+					On("ProcessUnsignedTransaction", context.Background(), txMatchBy, common.HexToAddress(DefaultSenderAddress), nilUint64, true, m.DbTx).
 					Return(&runtime.ExecutionResult{ReturnValue: testCase.expectedResult}, nil).
 					Once()
 			},
@@ -416,7 +416,7 @@ func TestCall(t *testing.T) {
 				block := ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: blockNumOne, Root: blockRoot})
 				m.State.On("GetL2BlockByNumber", context.Background(), blockNumOneUint64, m.DbTx).Return(block, nil).Once()
 				m.State.
-					On("ProcessUnsignedTransaction", context.Background(), txMatchBy, common.HexToAddress(c.DefaultSenderAddress), nilUint64, true, m.DbTx).
+					On("ProcessUnsignedTransaction", context.Background(), txMatchBy, common.HexToAddress(DefaultSenderAddress), nilUint64, true, m.DbTx).
 					Return(&runtime.ExecutionResult{ReturnValue: testCase.expectedResult}, nil).
 					Once()
 			},
@@ -566,7 +566,7 @@ func TestChainID(t *testing.T) {
 	chainID, err := c.ChainID(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, s.Config.ChainID, chainID.Uint64())
+	assert.Equal(t, s.ChainID(), chainID.Uint64())
 }
 
 func TestEstimateGas(t *testing.T) {
@@ -666,7 +666,7 @@ func TestEstimateGas(t *testing.T) {
 				m.State.On("GetLastL2Block", context.Background(), m.DbTx).Return(block, nil).Once()
 
 				m.State.
-					On("EstimateGas", txMatchBy, common.HexToAddress(c.DefaultSenderAddress), nilUint64, m.DbTx).
+					On("EstimateGas", txMatchBy, common.HexToAddress(DefaultSenderAddress), nilUint64, m.DbTx).
 					Return(*testCase.expectedResult, nil, nil).
 					Once()
 			},

--- a/jsonrpc/endpoints_net.go
+++ b/jsonrpc/endpoints_net.go
@@ -9,10 +9,11 @@ import (
 
 // NetEndpoints contains implementations for the "net" RPC endpoints
 type NetEndpoints struct {
-	cfg Config
+	cfg     Config
+	chainID uint64
 }
 
 // Version returns the current network id
 func (n *NetEndpoints) Version() (interface{}, types.Error) {
-	return strconv.FormatUint(n.cfg.ChainID, encoding.Base10), nil
+	return strconv.FormatUint(n.chainID, encoding.Base10), nil
 }

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -704,8 +704,8 @@ func TestGetBatchByNumber(t *testing.T) {
 					Once()
 
 				txs := []*ethTypes.Transaction{
-					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
-					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
+					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
+					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
 				}
 
 				batchTxs := make([]ethTypes.Transaction, 0, len(txs))
@@ -828,8 +828,8 @@ func TestGetBatchByNumber(t *testing.T) {
 					Once()
 
 				txs := []*ethTypes.Transaction{
-					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
-					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
+					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
+					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
 				}
 
 				batchTxs := make([]ethTypes.Transaction, 0, len(txs))
@@ -937,8 +937,8 @@ func TestGetBatchByNumber(t *testing.T) {
 					Once()
 
 				txs := []*ethTypes.Transaction{
-					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
-					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.Config.ChainID),
+					signTx(ethTypes.NewTransaction(1001, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
+					signTx(ethTypes.NewTransaction(1002, common.HexToAddress("0x1000"), big.NewInt(1000), 1001, big.NewInt(1002), []byte("1003")), s.ChainID()),
 				}
 
 				batchTxs := make([]ethTypes.Transaction, 0, len(txs))

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -19,9 +19,6 @@ import (
 )
 
 const (
-	// Host defines the server host to the default network adapter
-	Host = "0.0.0.0"
-
 	// APIEth represents the eth API prefix.
 	APIEth = "eth"
 	// APINet represents the net API prefix.
@@ -115,7 +112,7 @@ func (s *Server) startHTTP() error {
 		return fmt.Errorf("server already started")
 	}
 
-	address := fmt.Sprintf("%s:%d", Host, s.config.Port)
+	address := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
 
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
@@ -155,7 +152,7 @@ func (s *Server) startWS() {
 		return
 	}
 
-	address := fmt.Sprintf("%s:%d", Host, s.config.WebSockets.Port)
+	address := fmt.Sprintf("%s:%d", s.config.WebSockets.Host, s.config.WebSockets.Port)
 
 	lis, err := net.Listen("tcp", address)
 	if err != nil {

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	host                      = "localhost"
-	maxRequestsPerIPAndSecond = 1000
+	maxRequestsPerIPAndSecond        = 1000
+	chainID                   uint64 = 1000
 )
 
 type mockedServer struct {
@@ -51,7 +51,7 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 	st.On("RegisterNewL2BlockEventHandler", mock.IsType(newL2BlockEventHandler)).Once()
 
 	st.On("PrepareWebSocket").Once()
-	server := NewServer(cfg, pool, st, storage, apis)
+	server := NewServer(cfg, chainID, pool, st, storage, apis)
 
 	go func() {
 		err := server.Start()
@@ -60,7 +60,7 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 		}
 	}()
 
-	serverURL := fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
+	serverURL := fmt.Sprintf("http://%s:%d", Host, cfg.Port)
 	for {
 		fmt.Println("waiting server to get ready...") // fmt is used here to avoid race condition with logs
 		res, err := http.Get(serverURL)               //nolint:gosec
@@ -92,12 +92,9 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 
 func getDefaultConfig() Config {
 	cfg := Config{
-		Host:                      host,
 		Port:                      9123,
 		MaxRequestsPerIPAndSecond: maxRequestsPerIPAndSecond,
-		DefaultSenderAddress:      "0x1111111111111111111111111111111111111111",
 		MaxCumulativeGasUsed:      300000,
-		ChainID:                   1000,
 	}
 	return cfg
 }
@@ -123,4 +120,8 @@ func (s *mockedServer) Stop() {
 
 func (s *mockedServer) JSONRPCCall(method string, parameters ...interface{}) (types.Response, error) {
 	return client.JSONRPCCall(s.ServerURL, method, parameters...)
+}
+
+func (s *mockedServer) ChainID() uint64 {
+	return chainID
 }

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -60,7 +60,7 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 		}
 	}()
 
-	serverURL := fmt.Sprintf("http://%s:%d", Host, cfg.Port)
+	serverURL := fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
 	for {
 		fmt.Println("waiting server to get ready...") // fmt is used here to avoid race condition with logs
 		res, err := http.Get(serverURL)               //nolint:gosec
@@ -92,6 +92,7 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 
 func getDefaultConfig() Config {
 	cfg := Config{
+		Host:                      "0.0.0.0",
 		Port:                      9123,
 		MaxRequestsPerIPAndSecond: maxRequestsPerIPAndSecond,
 		MaxCumulativeGasUsed:      300000,

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -44,7 +44,6 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 10000
 SequencerNodeURI = ""
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
 		Enabled = true

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -44,7 +44,6 @@ ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
 SequencerNodeURI = ""
-DefaultSenderAddress = "0x1111111111111111111111111111111111111111"
 EnableL2SuggestedGasPricePolling = true
 	[RPC.WebSockets]
 		Enabled = true


### PR DESCRIPTION
Closes #2082.

### What does this PR do?

- Removes the jRPC unnecessary `RPC.ChainID`, and `RPC.DefaultSenderAddress` configurations
- Replaces the default configuration value below:
  - `RPC.Port` from `8123` to `8545`
  - `RPC.WebSockets.Enabled` from `true` to `false`
  - `RPC.WebSockets.Port` from `8124` to `8546`

### Reviewers

@ToniRamirezM 
@agnusmor 