### PR TITLE
add pool.gas_price history cleanup mechanism

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -133,6 +133,7 @@ Type = "follower"
 UpdatePeriod = "10s"
 Factor = 0.15
 DefaultGasPriceWei = 2000000000
+CleanHistoryPeriod = "1h"
 
 [MTClient]
 URI = "zkevm-prover:50061"

--- a/gasprice/config.go
+++ b/gasprice/config.go
@@ -28,5 +28,6 @@ type Config struct {
 	CheckBlocks        int            `mapstructure:"CheckBlocks"`
 	Percentile         int            `mapstructure:"Percentile"`
 	UpdatePeriod       types.Duration `mapstructure:"UpdatePeriod"`
+	CleanHistoryPeriod types.Duration `mapstructure:"CleanHistoryPeriod"`
 	Factor             float64        `mapstructure:"Factor"`
 }

--- a/gasprice/interfaces.go
+++ b/gasprice/interfaces.go
@@ -14,6 +14,7 @@ import (
 type pool interface {
 	SetGasPrice(ctx context.Context, gasPrice uint64) error
 	GetGasPrice(ctx context.Context) (uint64, error)
+	DeleteGasPricesHistory(ctx context.Context) error
 }
 
 // stateInterface gathers the methods required to interact with the state.

--- a/gasprice/mock_pool.go
+++ b/gasprice/mock_pool.go
@@ -13,6 +13,20 @@ type poolMock struct {
 	mock.Mock
 }
 
+// DeleteGasPricesHistory provides a mock function with given fields: ctx
+func (_m *poolMock) DeleteGasPricesHistory(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetGasPrice provides a mock function with given fields: ctx
 func (_m *poolMock) GetGasPrice(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)

--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -23,6 +23,7 @@ type storage interface {
 	GetNonWIPTxsByStatus(ctx context.Context, status TxStatus, limit uint64) ([]Transaction, error)
 	IsTxPending(ctx context.Context, hash common.Hash) (bool, error)
 	SetGasPrice(ctx context.Context, gasPrice uint64) error
+	DeleteGasPricesHistory(ctx context.Context) error
 	UpdateTxsStatus(ctx context.Context, updateInfo []TxStatusUpdateInfo) error
 	UpdateTxStatus(ctx context.Context, updateInfo TxStatusUpdateInfo) error
 	UpdateTxWIPStatus(ctx context.Context, hash common.Hash, isWIP bool) error

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -414,6 +414,21 @@ func (p *PostgresPoolStorage) SetGasPrice(ctx context.Context, gasPrice uint64) 
 	return nil
 }
 
+// DeleteGasPricesHistory deletes all gas prices except the last one
+func (p *PostgresPoolStorage) DeleteGasPricesHistory(ctx context.Context) error {
+	sql := `DELETE FROM pool.gas_price
+		WHERE item_id NOT IN (
+			SELECT item_id
+			FROM pool.gas_price
+			ORDER BY item_id DESC
+			LIMIT 1
+		)`
+	if _, err := p.db.Exec(ctx, sql); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetGasPrice returns the current gas price
 func (p *PostgresPoolStorage) GetGasPrice(ctx context.Context) (uint64, error) {
 	sql := "SELECT price FROM pool.gas_price ORDER BY item_id DESC LIMIT 1"

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -232,6 +232,11 @@ func (p *Pool) UpdateTxStatus(ctx context.Context, hash common.Hash, newStatus T
 	})
 }
 
+// DeleteGasPricesHistory delete old gas price except the most recent one
+func (p *Pool) DeleteGasPricesHistory(ctx context.Context) error {
+	return p.storage.DeleteGasPricesHistory(ctx)
+}
+
 // SetGasPrice allows an external component to define the gas price
 func (p *Pool) SetGasPrice(ctx context.Context, gasPrice uint64) error {
 	return p.storage.SetGasPrice(ctx, gasPrice)


### PR DESCRIPTION
Closes #2035 .

### What does this PR do?

It adds a new timer in the gas price suggester to Cleanup `pool.gas_price` history at recurrent elapsed time.
The Period is declared in the `L2GasPriceSuggester` section of the config with the field `CleanHistoryPeriod`.

### Reviewers

Main reviewers:

@ARR552 

Codeowner reviewers:

