### PR TITLE
Fix blockNumberOrHash Unmarshal

### DIFF
--- a/jsonrpc/types/codec.go
+++ b/jsonrpc/types/codec.go
@@ -325,10 +325,11 @@ func (b *BlockNumberOrHash) UnmarshalJSON(buffer []byte) error {
 				return err
 			}
 			err = json.Unmarshal(input, &number)
-			if err == nil {
-				b.SetNumber(number)
-				return nil
+			if err != nil {
+				return fmt.Errorf("invalid %v", BlockNumberKey)
 			}
+			b.SetNumber(number)
+			return nil
 		} else if v, ok := m[BlockHashKey]; ok {
 			vStr, ok := v.(string)
 			if !ok {
@@ -339,20 +340,21 @@ func (b *BlockNumberOrHash) UnmarshalJSON(buffer []byte) error {
 				return err
 			}
 			err = json.Unmarshal(input, &hash)
-			if err == nil {
-				requireCanonical, ok := m[RequireCanonicalKey]
-				if ok {
-					switch v := requireCanonical.(type) {
-					case bool:
-						b.SetHash(hash, v)
-					default:
-						return fmt.Errorf("invalid %v", RequireCanonicalKey)
-					}
-				} else {
-					b.SetHash(hash, false)
-				}
-				return nil
+			if err != nil {
+				return fmt.Errorf("invalid %v", BlockHashKey)
 			}
+			requireCanonical, ok := m[RequireCanonicalKey]
+			if ok {
+				switch v := requireCanonical.(type) {
+				case bool:
+					b.SetHash(hash, v)
+				default:
+					return fmt.Errorf("invalid %v", RequireCanonicalKey)
+				}
+			} else {
+				b.SetHash(hash, false)
+			}
+			return nil
 		} else {
 			return fmt.Errorf("invalid block or hash")
 		}

--- a/jsonrpc/types/codec_test.go
+++ b/jsonrpc/types/codec_test.go
@@ -270,11 +270,22 @@ func TestBlockNumberOrHashMarshaling(t *testing.T) {
 	}
 
 	testCases := []testCase{
+		// success
 		{`{"blockNumber":"1"}`, &BlockNumberOrHash{number: bnPtr(BlockNumber(uint64(1)))}, nil},
 		{`{"blockHash":"0x1"}`, &BlockNumberOrHash{hash: argHashPtr(common.HexToHash("0x1"))}, nil},
+		{`{"blockHash":"0x1", "requireCanonical":true}`, &BlockNumberOrHash{hash: argHashPtr(common.HexToHash("0x1")), requireCanonical: true}, nil},
+		// float wrong value
 		{`{"blockNumber":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
 		{`{"blockHash":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
 		{`{"blockHash":"0x1", "requireCanonical":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+		// int wrong value
+		{`{"blockNumber":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
+		{`{"blockHash":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+		// string wrong value
+		{`{"blockNumber":"aaa"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
+		{`{"blockHash":"ggg"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":"aaa"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
 	}
 
 	for _, testCase := range testCases {

--- a/jsonrpc/types/codec_test.go
+++ b/jsonrpc/types/codec_test.go
@@ -3,10 +3,12 @@ package types
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/mocks"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -260,6 +262,43 @@ func TestBlockNumberStringOrHex(t *testing.T) {
 	}
 }
 
+func TestBlockNumberOrHashMarshaling(t *testing.T) {
+	type testCase struct {
+		json           string
+		expectedResult *BlockNumberOrHash
+		expectedError  error
+	}
+
+	testCases := []testCase{
+		{`{"blockNumber":"1"}`, &BlockNumberOrHash{number: bnPtr(BlockNumber(uint64(1)))}, nil},
+		{`{"blockHash":"0x1"}`, &BlockNumberOrHash{hash: argHashPtr(common.HexToHash("0x1"))}, nil},
+		{`{"blockNumber":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
+		{`{"blockHash":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+	}
+
+	for _, testCase := range testCases {
+		var result *BlockNumberOrHash
+		err := json.Unmarshal([]byte(testCase.json), &result)
+
+		assert.NotNil(t, result)
+		assert.Equal(t, testCase.expectedResult.number, result.number)
+		assert.Equal(t, testCase.expectedResult.hash, result.hash)
+		assert.Equal(t, testCase.expectedResult.requireCanonical, testCase.expectedResult.requireCanonical)
+
+		if testCase.expectedError == nil {
+			assert.Nil(t, err)
+		} else {
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
+		}
+	}
+}
+
 func bnPtr(bn BlockNumber) *BlockNumber {
 	return &bn
+}
+
+func argHashPtr(hash common.Hash) *ArgHash {
+	h := ArgHash(hash)
+	return &h
 }


### PR DESCRIPTION
Closes #2123.

### What does this PR do?

improve fault tolerance for blockNumberOrHash when unmarshaling invalid values.

### Reviewers

Main reviewers:

@ToniRamirezM 