### PR TITLE
improve: adding missing counting of metric for expired transactions in the sequencer.

### DIFF
--- a/sequencer/metrics/metrics.go
+++ b/sequencer/metrics/metrics.go
@@ -119,7 +119,7 @@ func SequencesSentToL1(numSequences float64) {
 }
 
 // TxProcessed increases the counter vector by the provided transactions count
-// and for the given label.
+// and for the given label (status).
 func TxProcessed(status TxProcessedLabel, count float64) {
 	metrics.CounterVecAdd(TxProcessedName, string(status), count)
 }

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -173,6 +173,7 @@ func (s *Sequencer) Start(ctx context.Context) {
 			failedReason := ErrExpiredTransaction.Error()
 			for _, txTracker := range txTrackers {
 				err := s.pool.UpdateTxStatus(ctx, txTracker.Hash, pool.TxStatusFailed, false, &failedReason)
+				metrics.TxProcessed(metrics.TxProcessedLabelFailed, 1)
 				if err != nil {
 					log.Errorf("failed to update tx status, err: %v", err)
 				}


### PR DESCRIPTION
Closes #2150 

### What does this PR do?

Adding missing counting of metric for expired transactions in the sequencer.

### Reviewers

Main reviewers:
- @ToniRamirezM 
- @tclemos 

Codeowner reviewers:
- @ToniRamirezM