### PR TITLE
Retry on resource exhausted 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -456,9 +456,11 @@ func newState(ctx context.Context, c *config.Config, l2ChainID uint64, forkIDInt
 	}
 
 	stateCfg := state.Config{
-		MaxCumulativeGasUsed: c.Sequencer.MaxCumulativeGasUsed,
-		ChainID:              l2ChainID,
-		ForkIDIntervals:      forkIDIntervals,
+		MaxCumulativeGasUsed:         c.Sequencer.MaxCumulativeGasUsed,
+		ChainID:                      l2ChainID,
+		ForkIDIntervals:              forkIDIntervals,
+		MaxResourceExhaustedAttempts: c.Executor.MaxResourceExhaustedAttempts,
+		WaitOnResourceExhaustion:     c.Executor.WaitOnResourceExhaustion,
 	}
 
 	st := state.NewState(stateCfg, stateDb, executorClient, stateTree, eventLog)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,6 +387,14 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: "zkevm-prover:50071",
 		},
 		{
+			path:          "Executor.MaxResourceExhaustedAttempts",
+			expectedValue: 3,
+		},
+		{
+			path:          "Executor.WaitOnResourceExhaustion",
+			expectedValue: "1s",
+		},
+		{
 			path:          "Metrics.Host",
 			expectedValue: "0.0.0.0",
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,7 +388,7 @@ func Test_Defaults(t *testing.T) {
 		},
 		{
 			path:          "Executor.MaxResourceExhaustedAttempts",
-			expectedValue: 1,
+			expectedValue: 3,
 		},
 		{
 			path:          "Executor.WaitOnResourceExhaustion",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,11 +388,11 @@ func Test_Defaults(t *testing.T) {
 		},
 		{
 			path:          "Executor.MaxResourceExhaustedAttempts",
-			expectedValue: 3,
+			expectedValue: 1,
 		},
 		{
 			path:          "Executor.WaitOnResourceExhaustion",
-			expectedValue: "1s",
+			expectedValue: types.NewDuration(1 * time.Second),
 		},
 		{
 			path:          "Metrics.Host",

--- a/config/default.go
+++ b/config/default.go
@@ -139,7 +139,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
-MaxResourceExhaustedAttempts = 3
+MaxResourceExhaustedAttempts = 1
 WaitOnResourceExhaustion = "1s"
 
 [Metrics]

--- a/config/default.go
+++ b/config/default.go
@@ -139,7 +139,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
-MaxResourceExhaustedAttempts = 1
+MaxResourceExhaustedAttempts = 3
 WaitOnResourceExhaustion = "1s"
 
 [Metrics]

--- a/config/default.go
+++ b/config/default.go
@@ -139,6 +139,8 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxResourceExhaustedAttempts = 3
+WaitOnResourceExhaustion = "1s"
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -131,6 +131,8 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxResourceExhaustedAttempts = 3
+WaitOnResourceExhaustion = "1s"
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/mainnet/public.node.config.toml
+++ b/config/environments/mainnet/public.node.config.toml
@@ -55,6 +55,8 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxResourceExhaustedAttempts = 3
+WaitOnResourceExhaustion = "1s"
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -55,6 +55,8 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxResourceExhaustedAttempts = 3
+WaitOnResourceExhaustion = "1s"
 
 [Metrics]
 Host = "0.0.0.0"

--- a/state/config.go
+++ b/state/config.go
@@ -1,5 +1,7 @@
 package state
 
+import "github.com/0xPolygonHermez/zkevm-node/config/types"
+
 // Config is state config
 type Config struct {
 	// MaxCumulativeGasUsed is the max gas allowed per batch
@@ -10,4 +12,10 @@ type Config struct {
 
 	// ForkIdIntervals is the list of fork id intervals
 	ForkIDIntervals []ForkIDInterval
+
+	// MaxResourceExhaustedAttempts is the max number of attempts to make a transaction succeed because of resource exhaustion
+	MaxResourceExhaustedAttempts int
+
+	// WaitOnResourceExhaustion is the time to wait before retrying a transaction because of resource exhaustion
+	WaitOnResourceExhaustion types.Duration
 }

--- a/state/runtime/executor/config.go
+++ b/state/runtime/executor/config.go
@@ -1,6 +1,12 @@
 package executor
 
+import "github.com/0xPolygonHermez/zkevm-node/config/types"
+
 // Config represents the configuration of the executor server
 type Config struct {
 	URI string `mapstructure:"URI"`
+	// MaxResourceExhaustedAttempts is the max number of attempts to make a transaction succeed because of resource exhaustion
+	MaxResourceExhaustedAttempts int `mapstructure:"MaxResourceExhaustedAttempts"`
+	// WaitOnResourceExhaustion is the time to wait before retrying a transaction because of resource exhaustion
+	WaitOnResourceExhaustion types.Duration `mapstructure:"WaitOnResourceExhaustion"`
 }

--- a/state/runtime/runtime.go
+++ b/state/runtime/runtime.go
@@ -69,6 +69,8 @@ var (
 	ErrFea2Scalar = errors.New("fea2scalar")
 	// ErrTos32 indicates a tos32 error in the ROM
 	ErrTos32 = errors.New("tos32")
+	// ErrGRPCResourceExhaustedAsTimeout indicates a GRPC resource exhausted error
+	ErrGRPCResourceExhaustedAsTimeout = errors.New("request timed out")
 )
 
 // ExecutionResult includes all output after executing given evm

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -801,7 +801,7 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 				time.Sleep(s.cfg.WaitOnResourceExhaustion.Duration)
 				log.Errorf("retrying to process unsigned transaction")
 				processBatchResponse, err = s.executorClient.ProcessBatch(ctx, processBatchRequest)
-				if err != nil && status.Code(err) == codes.ResourceExhausted {
+				if status.Code(err) == codes.ResourceExhausted {
 					log.Errorf("error processing unsigned transaction ", err)
 					attempts++
 					continue

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -802,9 +802,12 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 				log.Errorf("retrying to process unsigned transaction")
 				processBatchResponse, err = s.executorClient.ProcessBatch(ctx, processBatchRequest)
 				if err != nil {
-					log.Errorf("error processing unsigned transaction ", err)
-					attempts++
-					continue
+					if status.Code(err) == codes.ResourceExhausted {
+						log.Errorf("error processing unsigned transaction ", err)
+						attempts++
+						continue
+					}
+					break
 				}
 				break
 			}

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -811,6 +811,10 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 		}
 
 		if err != nil {
+			if status.Code(err) == codes.ResourceExhausted {
+				log.Error("reporting error as time out")
+				return nil, runtime.ErrGRPCResourceExhaustedAsTimeout
+			}
 			// Log this error as an executor unspecified error
 			s.eventLog.LogExecutorError(ctx, pb.ExecutorError_EXECUTOR_ERROR_UNSPECIFIED, processBatchRequest)
 			log.Errorf("error processing unsigned transaction ", err)

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -801,12 +801,10 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 				time.Sleep(s.cfg.WaitOnResourceExhaustion.Duration)
 				log.Errorf("retrying to process unsigned transaction")
 				processBatchResponse, err = s.executorClient.ProcessBatch(ctx, processBatchRequest)
-				if err != nil {
-					if status.Code(err) == codes.ResourceExhausted {
-						log.Errorf("error processing unsigned transaction ", err)
-						attempts++
-						continue
-					}
+				if err != nil && status.Code(err) == codes.ResourceExhausted {
+					log.Errorf("error processing unsigned transaction ", err)
+					attempts++
+					continue
 				}
 				break
 			}

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -27,6 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/holiman/uint256"
 	"github.com/jackc/pgx/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -703,6 +705,8 @@ func (s *State) ProcessUnsignedTransaction(ctx context.Context, tx *types.Transa
 
 // ProcessUnsignedTransaction processes the given unsigned transaction.
 func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, senderAddress common.Address, l2BlockNumber *uint64, noZKEVMCounters bool, dbTx pgx.Tx) (*ProcessBatchResponse, error) {
+	var attempts = 1
+
 	if s.executorClient == nil {
 		return nil, ErrExecutorNil
 	}
@@ -791,11 +795,30 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 	// Send Batch to the Executor
 	processBatchResponse, err := s.executorClient.ProcessBatch(ctx, processBatchRequest)
 	if err != nil {
-		// Log this error as an executor unspecified error
-		s.eventLog.LogExecutorError(ctx, pb.ExecutorError_EXECUTOR_ERROR_UNSPECIFIED, processBatchRequest)
-		log.Errorf("error processing unsigned transaction ", err)
-		return nil, err
-	} else if processBatchResponse.Error != executor.EXECUTOR_ERROR_NO_ERROR {
+		if status.Code(err) == codes.ResourceExhausted {
+			log.Errorf("error processing unsigned transaction ", err)
+			for attempts < s.cfg.MaxResourceExhaustedAttempts {
+				time.Sleep(s.cfg.WaitOnResourceExhaustion.Duration)
+				log.Errorf("retrying to process unsigned transaction")
+				processBatchResponse, err = s.executorClient.ProcessBatch(ctx, processBatchRequest)
+				if err != nil {
+					log.Errorf("error processing unsigned transaction ", err)
+					attempts++
+					continue
+				}
+				break
+			}
+		}
+
+		if err != nil {
+			// Log this error as an executor unspecified error
+			s.eventLog.LogExecutorError(ctx, pb.ExecutorError_EXECUTOR_ERROR_UNSPECIFIED, processBatchRequest)
+			log.Errorf("error processing unsigned transaction ", err)
+			return nil, err
+		}
+	}
+
+	if err == nil && processBatchResponse.Error != executor.EXECUTOR_ERROR_NO_ERROR {
 		err = executor.ExecutorErr(processBatchResponse.Error)
 		s.eventLog.LogExecutorError(ctx, processBatchResponse.Error, processBatchRequest)
 		return nil, err

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -807,7 +807,6 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 						attempts++
 						continue
 					}
-					break
 				}
 				break
 			}


### PR DESCRIPTION
Closes #2156

### What does this PR do?

Retries transaction execution in case of resource exhausted error from the executor. If the problem persists it is reported a as time out.

This PR creates 2 new config params:

[Executor]
MaxResourceExhaustedAttempts = 3
WaitOnResourceExhaustion = "1s"

### Reviewers

Main reviewers:

- @tclemos 
- @agnusmor 
- @ARR552 