### PR TITLE
Make max grpc message size configurable 

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,6 +387,10 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: "zkevm-prover:50071",
 		},
 		{
+			path:          "Executor.MaxGRPCMessageSize",
+			expectedValue: int(100000000),
+		},
+		{
 			path:          "Metrics.Host",
 			expectedValue: "0.0.0.0",
 		},

--- a/config/default.go
+++ b/config/default.go
@@ -139,6 +139,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -131,6 +131,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/mainnet/public.node.config.toml
+++ b/config/environments/mainnet/public.node.config.toml
@@ -55,6 +55,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/config/environments/public/public.node.config.toml
+++ b/config/environments/public/public.node.config.toml
@@ -55,6 +55,7 @@ URI = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -948,7 +948,7 @@ func newState(sqlDB *pgxpool.Pool, eventLog *event.EventLog) *state.State {
 	stateDb := state.NewPostgresStorage(sqlDB)
 	zkProverURI := testutils.GetEnv("ZKPROVER_URI", "localhost")
 
-	executorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI)}
+	executorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI), MaxGRPCMessageSize: 100000000}
 	mtDBServerConfig := merkletree.Config{URI: fmt.Sprintf("%s:50061", zkProverURI)}
 	executorClient, _, _ := executor.NewExecutorClient(ctx, executorServerConfig)
 	stateDBClient, _, _ := merkletree.NewMTDBServiceClient(ctx, mtDBServerConfig)

--- a/sequencer/closingsignalsmanager_test.go
+++ b/sequencer/closingsignalsmanager_test.go
@@ -56,7 +56,7 @@ func setupTest(t *testing.T) {
 
 	zkProverURI := testutils.GetEnv("ZKPROVER_URI", "localhost")
 	localMtDBServerConfig := merkletree.Config{URI: fmt.Sprintf("%s:50061", zkProverURI)}
-	localExecutorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI)}
+	localExecutorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI), MaxGRPCMessageSize: 100000000}
 
 	localExecutorClient, localExecutorClientConn, localExecutorCancel = executor.NewExecutorClient(localCtx, localExecutorServerConfig)
 	s := localExecutorClientConn.GetState()

--- a/state/runtime/executor/client.go
+++ b/state/runtime/executor/client.go
@@ -11,13 +11,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const maxMsgSize = 2 * 1024 * 1024 * 1024
-
 // NewExecutorClient is the executor client constructor.
 func NewExecutorClient(ctx context.Context, c Config) (pb.ExecutorServiceClient, *grpc.ClientConn, context.CancelFunc) {
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(c.MaxGRPCMessageSize)),
 		grpc.WithBlock(),
 	}
 	const maxWaitSeconds = 120

--- a/state/runtime/executor/config.go
+++ b/state/runtime/executor/config.go
@@ -2,5 +2,6 @@ package executor
 
 // Config represents the configuration of the executor server
 type Config struct {
-	URI string `mapstructure:"URI"`
+	URI                string `mapstructure:"URI"`
+	MaxGRPCMessageSize int    `mapstructure:"MaxGRPCMessageSize"`
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 
 	zkProverURI := testutils.GetEnv("ZKPROVER_URI", "localhost")
 
-	executorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI)}
+	executorServerConfig := executor.Config{URI: fmt.Sprintf("%s:50071", zkProverURI), MaxGRPCMessageSize: 100000000}
 	var executorCancel context.CancelFunc
 	executorClient, executorClientConn, executorCancel = executor.NewExecutorClient(ctx, executorServerConfig)
 	s := executorClientConn.GetState()

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -132,6 +132,7 @@ URI = "127.0.0.1:50061"
 
 [Executor]
 URI = "127.0.0.1:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -135,6 +135,7 @@ URI  = "zkevm-prover:50061"
 
 [Executor]
 URI = "zkevm-prover:50071"
+MaxGRPCMessageSize = 100000000
 
 [Metrics]
 Host = "0.0.0.0"

--- a/test/operations/manager.go
+++ b/test/operations/manager.go
@@ -59,7 +59,7 @@ var (
 
 	executorURI      = testutils.GetEnv(constants.ENV_ZKPROVER_URI, "127.0.0.1:50071")
 	merkleTreeURI    = testutils.GetEnv(constants.ENV_MERKLETREE_URI, "127.0.0.1:50061")
-	executorConfig   = executor.Config{URI: executorURI}
+	executorConfig   = executor.Config{URI: executorURI, MaxGRPCMessageSize: 100000000}
 	merkleTreeConfig = merkletree.Config{URI: merkleTreeURI}
 )
 

--- a/tools/executor/main.go
+++ b/tools/executor/main.go
@@ -108,7 +108,7 @@ func runTestCase(ctx context.Context, genesis []genesisItem, tc testCase) error 
 	}
 
 	// Executor connection
-	xecutor, _, _ := executor.NewExecutorClient(ctx, executor.Config{URI: executorURL})
+	xecutor, _, _ := executor.NewExecutorClient(ctx, executor.Config{URI: executorURL, MaxGRPCMessageSize: 100000000})
 	// Execute batches
 	for i := 0; i < len(tc.Requests); i++ {
 		pbr := pb.ProcessBatchRequest(tc.Requests[i]) //nolint

--- a/tools/executor/main.go
+++ b/tools/executor/main.go
@@ -108,7 +108,7 @@ func runTestCase(ctx context.Context, genesis []genesisItem, tc testCase) error 
 	}
 
 	// Executor connection
-	xecutor, _, _ := executor.NewExecutorClient(ctx, executor.Config{URI: executorURL, MaxGRPCMessageSize: 100000000})
+	xecutor, _, _ := executor.NewExecutorClient(ctx, executor.Config{URI: executorURL, MaxGRPCMessageSize: 100000000}) //nolint:gomnd
 	// Execute batches
 	for i := 0; i < len(tc.Requests); i++ {
 		pbr := pb.ProcessBatchRequest(tc.Requests[i]) //nolint


### PR DESCRIPTION
### What does this PR do?

Makes max grpc message size configurable.

New Config Parameter:

[Executor]
MaxGRPCMessageSize = 100000000

### Reviewers

Main reviewers:

- @agnusmor 
- @Psykepro 
