### PR TITLE
add pool limits

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -315,6 +315,14 @@ func Test_Defaults(t *testing.T) {
 			expectedValue: types.NewDuration(15 * time.Second),
 		},
 		{
+			path:          "Pool.AccountQueue",
+			expectedValue: uint64(64),
+		},
+		{
+			path:          "Pool.GlobalQueue",
+			expectedValue: uint64(1024),
+		},
+		{
 			path:          "Pool.DB.User",
 			expectedValue: "pool_user",
 		},

--- a/config/default.go
+++ b/config/default.go
@@ -25,6 +25,8 @@ MaxTxDataBytesSize=100000
 DefaultMinGasPriceAllowed = 1000000000
 MinAllowedGasPriceInterval = "5m"
 PollMinAllowedGasPriceInterval = "15s"
+AccountQueue = 64
+GlobalQueue = 1024
 	[Pool.DB]
 	User = "pool_user"
 	Password = "pool_password"

--- a/pool/config.go
+++ b/pool/config.go
@@ -28,4 +28,10 @@ type Config struct {
 
 	// PollMinAllowedGasPriceInterval is the interval to poll the suggested min gas price for a tx
 	PollMinAllowedGasPriceInterval types.Duration `mapstructure:"PollMinAllowedGasPriceInterval"`
+
+	// AccountQueue represents the maximum number of non-executable transaction slots permitted per account
+	AccountQueue uint64 `mapstructure:"AccountQueue"`
+
+	// GlobalQueue represents the maximum number of non-executable transaction slots for all accounts
+	GlobalQueue uint64 `mapstructure:"GlobalQueue"`
 }

--- a/pool/errors.go
+++ b/pool/errors.go
@@ -30,9 +30,26 @@ var (
 	// ErrBlockedSender is returned if the transaction is sent by a blocked account.
 	ErrBlockedSender = errors.New("blocked sender")
 
+	// ErrGasLimit is returned if a transaction's requested gas limit exceeds the
+	// maximum allowance of the current block.
+	ErrGasLimit = errors.New("exceeds block gas limit")
+
+	// ErrTxPoolAccountOverflow is returned if the account sending the transaction
+	// has already reached the limit of transactions in the pool set by the config
+	// AccountQueue and can't accept another remote transaction.
+	ErrTxPoolAccountOverflow = errors.New("account has reached the tx limit in the txpool")
+
+	// ErrTxPoolOverflow is returned if the transaction pool is full and can't accept
+	// another remote transaction.
+	ErrTxPoolOverflow = errors.New("txpool is full")
+
 	// ErrNonceTooLow is returned if the nonce of a transaction is lower than the
 	// one present in the local chain.
 	ErrNonceTooLow = errors.New("nonce too low")
+
+	// ErrNonceTooHigh is returned if the nonce of a transaction is higher than the
+	// current + the configured AccountQueue.
+	ErrNonceTooHigh = errors.New("nonce too high")
 
 	// ErrInsufficientFunds is returned if the total cost of executing a transaction
 	// is higher than the balance of the user's account.

--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -13,7 +13,8 @@ import (
 
 type storage interface {
 	AddTx(ctx context.Context, tx Transaction) error
-	CountTransactionsByStatus(ctx context.Context, status TxStatus) (uint64, error)
+	CountTransactionsByStatus(ctx context.Context, status ...TxStatus) (uint64, error)
+	CountTransactionsByFromAndStatus(ctx context.Context, from common.Address, status ...TxStatus) (uint64, error)
 	DeleteTransactionsByHashes(ctx context.Context, hashes []common.Hash) error
 	GetGasPrice(ctx context.Context) (uint64, error)
 	GetNonce(ctx context.Context, address common.Address) (uint64, error)

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -347,11 +347,23 @@ func (p *PostgresPoolStorage) GetTxs(ctx context.Context, filterStatus pool.TxSt
 }
 
 // CountTransactionsByStatus get number of transactions
-// accordingly to the provided status
-func (p *PostgresPoolStorage) CountTransactionsByStatus(ctx context.Context, status pool.TxStatus) (uint64, error) {
-	sql := "SELECT COUNT(*) FROM pool.transaction WHERE status = $1"
+// accordingly to the provided statuses
+func (p *PostgresPoolStorage) CountTransactionsByStatus(ctx context.Context, status ...pool.TxStatus) (uint64, error) {
+	sql := "SELECT COUNT(*) FROM pool.transaction WHERE status = ANY ($1)"
 	var counter uint64
-	err := p.db.QueryRow(ctx, sql, status.String()).Scan(&counter)
+	err := p.db.QueryRow(ctx, sql, status).Scan(&counter)
+	if err != nil {
+		return 0, err
+	}
+	return counter, nil
+}
+
+// CountTransactionsByFromAndStatus get number of transactions
+// accordingly to the from address and provided statuses
+func (p *PostgresPoolStorage) CountTransactionsByFromAndStatus(ctx context.Context, from common.Address, status ...pool.TxStatus) (uint64, error) {
+	sql := "SELECT COUNT(*) FROM pool.transaction WHERE from_address = $1 AND status = ANY ($2)"
+	var counter uint64
+	err := p.db.QueryRow(ctx, sql, from.String(), status).Scan(&counter)
 	if err != nil {
 		return 0, err
 	}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1558,14 +1558,14 @@ func Test_AddTx_AccountQueueLimit(t *testing.T) {
 		Nonce:    nonce,
 		Value:    big.NewInt(0),
 		Gas:      uint64(1000000),
-		GasPrice: big.NewInt(1),
+		GasPrice: gasPrice,
 	})
 
 	signedTx, err := auth.Signer(auth.From, tx)
 	require.NoError(t, err)
 
 	err = p.AddTx(ctx, *signedTx, "")
-	require.Error(t, err, pool.ErrTxPoolAccountOverflow)
+	require.Error(t, err, pool.ErrNonceTooHigh)
 }
 
 func Test_AddTx_GlobalQueueLimit(t *testing.T) {
@@ -1719,7 +1719,7 @@ func Test_AddTx_NonceTooHigh(t *testing.T) {
 	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
 
 	tx := ethTypes.NewTx(&ethTypes.LegacyTx{
-		Nonce:    cfg.AccountQueue + 1,
+		Nonce:    cfg.AccountQueue,
 		Value:    big.NewInt(0),
 		Gas:      uint64(1000000),
 		GasPrice: big.NewInt(1),

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -65,8 +65,8 @@ var (
 		PollMinAllowedGasPriceInterval:    cfgTypes.NewDuration(15 * time.Second),
 		DefaultMinGasPriceAllowed:         1000000000,
 		IntervalToRefreshBlockedAddresses: cfgTypes.NewDuration(5 * time.Minute),
-		AccountQueue:                      5,
-		GlobalQueue:                       10,
+		AccountQueue:                      15,
+		GlobalQueue:                       20,
 	}
 	gasPrice = big.NewInt(1000000000)
 	gasLimit = uint64(21000)
@@ -1330,6 +1330,8 @@ func Test_BlockedAddress(t *testing.T) {
 		PollMinAllowedGasPriceInterval:    cfgTypes.NewDuration(15 * time.Second),
 		DefaultMinGasPriceAllowed:         1000000000,
 		IntervalToRefreshBlockedAddresses: cfgTypes.NewDuration(5 * time.Second),
+		AccountQueue:                      64,
+		GlobalQueue:                       1024,
 	}
 	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -2,6 +2,7 @@ package pool_test
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
 	"math"
@@ -64,6 +65,8 @@ var (
 		PollMinAllowedGasPriceInterval:    cfgTypes.NewDuration(15 * time.Second),
 		DefaultMinGasPriceAllowed:         1000000000,
 		IntervalToRefreshBlockedAddresses: cfgTypes.NewDuration(5 * time.Minute),
+		AccountQueue:                      5,
+		GlobalQueue:                       10,
 	}
 	gasPrice = big.NewInt(1000000000)
 	gasLimit = uint64(21000)
@@ -197,15 +200,14 @@ func Test_AddTx_OversizedData(t *testing.T) {
 	s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
 	require.NoError(t, err)
 
-	const chainID = 2576980377
-	p := pool.NewPool(cfg, s, st, common.Address{}, chainID, eventLog)
+	p := pool.NewPool(cfg, s, st, common.Address{}, chainID.Uint64(), eventLog)
 
 	b := make([]byte, cfg.MaxTxBytesSize+1)
 	to := common.HexToAddress(operations.DefaultSequencerAddress)
 	tx := ethTypes.NewTransaction(0, to, big.NewInt(0), gasLimit, big.NewInt(0), b)
 
 	// GetAuth configures and returns an auth object.
-	auth, err := operations.GetAuth(operations.DefaultSequencerPrivateKey, chainID)
+	auth, err := operations.GetAuth(operations.DefaultSequencerPrivateKey, chainID.Uint64())
 	require.NoError(t, err)
 	signedTx, err := auth.Signer(auth.From, tx)
 	require.NoError(t, err)
@@ -1181,8 +1183,7 @@ func Test_AddTx_GasPriceErr(t *testing.T) {
 			s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
 			require.NoError(t, err)
 
-			const chainID = 2576980377
-			p := setupPool(t, cfg, s, st, chainID, ctx, eventLog)
+			p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
 			tx := ethTypes.NewTx(&ethTypes.LegacyTx{
 				Nonce:    tc.nonce,
 				To:       tc.to,
@@ -1194,7 +1195,7 @@ func Test_AddTx_GasPriceErr(t *testing.T) {
 			privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(senderPrivateKey, "0x"))
 			require.NoError(t, err)
 
-			auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(chainID))
+			auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(int64(chainID.Uint64())))
 			require.NoError(t, err)
 
 			signedTx, err := auth.Signer(auth.From, tx)
@@ -1292,8 +1293,7 @@ func Test_BlockedAddress(t *testing.T) {
 
 	st := newState(stateSqlDB, eventLog)
 
-	const chainID = 2576980377
-	auth := operations.MustGetAuth(operations.DefaultSequencerPrivateKey, chainID)
+	auth := operations.MustGetAuth(operations.DefaultSequencerPrivateKey, chainID.Uint64())
 
 	genesisBlock := state.Block{
 		BlockNumber: 0,
@@ -1331,7 +1331,7 @@ func Test_BlockedAddress(t *testing.T) {
 		DefaultMinGasPriceAllowed:         1000000000,
 		IntervalToRefreshBlockedAddresses: cfgTypes.NewDuration(5 * time.Second),
 	}
-	p := setupPool(t, cfg, s, st, chainID, ctx, eventLog)
+	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
 
 	gasPrice, err := p.GetGasPrice(ctx)
 	require.NoError(t, err)
@@ -1381,6 +1381,359 @@ func Test_BlockedAddress(t *testing.T) {
 	// allowed to add tx again
 	err = p.AddTx(ctx, *signedTx, "")
 	require.NoError(t, err)
+}
+
+func Test_AddTx_GasOverBatchLimit(t *testing.T) {
+	testCases := []struct {
+		name          string
+		nonce         uint64
+		to            *common.Address
+		value         *big.Int
+		gasLimit      uint64
+		gasPrice      *big.Int
+		data          []byte
+		expectedError error
+	}{
+		{
+			name:          "Gas over batch limit",
+			nonce:         0,
+			to:            nil,
+			value:         big.NewInt(0),
+			gasLimit:      uint64(30000001),
+			gasPrice:      big.NewInt(1000000000000),
+			data:          []byte{},
+			expectedError: pool.ErrGasLimit,
+		},
+	}
+
+	eventStorage, err := nileventstorage.NewNilEventStorage()
+	if err != nil {
+		log.Fatal(err)
+	}
+	eventLog := event.NewEventLog(event.Config{}, eventStorage)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			initOrResetDB(t)
+
+			stateSqlDB, err := db.NewSQLDB(stateDBCfg)
+			if err != nil {
+				panic(err)
+			}
+			defer stateSqlDB.Close() //nolint:gosec,errcheck
+
+			poolSqlDB, err := db.NewSQLDB(poolDBCfg)
+			require.NoError(t, err)
+			defer poolSqlDB.Close() //nolint:gosec,errcheck
+
+			st := newState(stateSqlDB, eventLog)
+
+			genesisBlock := state.Block{
+				BlockNumber: 0,
+				BlockHash:   state.ZeroHash,
+				ParentHash:  state.ZeroHash,
+				ReceivedAt:  time.Now(),
+			}
+			genesis := state.Genesis{
+				GenesisActions: []*state.GenesisAction{
+					{
+						Address: senderAddress,
+						Type:    int(merkletree.LeafTypeBalance),
+						Value:   "1000000000000000000000",
+					},
+				},
+			}
+			ctx := context.Background()
+			dbTx, err := st.BeginStateTransaction(ctx)
+			require.NoError(t, err)
+			_, err = st.SetGenesis(ctx, genesisBlock, genesis, dbTx)
+			require.NoError(t, err)
+			require.NoError(t, dbTx.Commit(ctx))
+
+			s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
+			require.NoError(t, err)
+
+			p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
+			tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+				Nonce:    tc.nonce,
+				To:       tc.to,
+				Value:    tc.value,
+				Gas:      tc.gasLimit,
+				GasPrice: tc.gasPrice,
+				Data:     tc.data,
+			})
+			privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(senderPrivateKey, "0x"))
+			require.NoError(t, err)
+
+			auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+			require.NoError(t, err)
+
+			signedTx, err := auth.Signer(auth.From, tx)
+			require.NoError(t, err)
+
+			err = p.AddTx(ctx, *signedTx, "")
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_AddTx_AccountQueueLimit(t *testing.T) {
+	eventStorage, err := nileventstorage.NewNilEventStorage()
+	if err != nil {
+		log.Fatal(err)
+	}
+	eventLog := event.NewEventLog(event.Config{}, eventStorage)
+
+	initOrResetDB(t)
+
+	stateSqlDB, err := db.NewSQLDB(stateDBCfg)
+	if err != nil {
+		panic(err)
+	}
+	defer stateSqlDB.Close() //nolint:gosec,errcheck
+
+	poolSqlDB, err := db.NewSQLDB(poolDBCfg)
+	require.NoError(t, err)
+	defer poolSqlDB.Close() //nolint:gosec,errcheck
+
+	st := newState(stateSqlDB, eventLog)
+
+	genesisBlock := state.Block{
+		BlockNumber: 0,
+		BlockHash:   state.ZeroHash,
+		ParentHash:  state.ZeroHash,
+		ReceivedAt:  time.Now(),
+	}
+	genesis := state.Genesis{
+		GenesisActions: []*state.GenesisAction{
+			{
+				Address: senderAddress,
+				Type:    int(merkletree.LeafTypeBalance),
+				Value:   "1000000000000000000000",
+			},
+		},
+	}
+	ctx := context.Background()
+	dbTx, err := st.BeginStateTransaction(ctx)
+	require.NoError(t, err)
+	_, err = st.SetGenesis(ctx, genesisBlock, genesis, dbTx)
+	require.NoError(t, err)
+	require.NoError(t, dbTx.Commit(ctx))
+
+	s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
+	require.NoError(t, err)
+
+	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
+
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(senderPrivateKey, "0x"))
+	require.NoError(t, err)
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(t, err)
+
+	nonce := uint64(0)
+	for nonce < cfg.AccountQueue {
+		tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+			Nonce:    nonce,
+			Value:    big.NewInt(0),
+			Gas:      uint64(1000000),
+			GasPrice: gasPrice,
+		})
+
+		signedTx, err := auth.Signer(auth.From, tx)
+		require.NoError(t, err)
+
+		err = p.AddTx(ctx, *signedTx, "")
+		require.NoError(t, err)
+		nonce++
+	}
+
+	tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+		Nonce:    nonce,
+		Value:    big.NewInt(0),
+		Gas:      uint64(1000000),
+		GasPrice: big.NewInt(1),
+	})
+
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
+	err = p.AddTx(ctx, *signedTx, "")
+	require.Error(t, err, pool.ErrTxPoolAccountOverflow)
+}
+
+func Test_AddTx_GlobalQueueLimit(t *testing.T) {
+	eventStorage, err := nileventstorage.NewNilEventStorage()
+	if err != nil {
+		log.Fatal(err)
+	}
+	eventLog := event.NewEventLog(event.Config{}, eventStorage)
+
+	initOrResetDB(t)
+
+	stateSqlDB, err := db.NewSQLDB(stateDBCfg)
+	if err != nil {
+		panic(err)
+	}
+	defer stateSqlDB.Close() //nolint:gosec,errcheck
+
+	poolSqlDB, err := db.NewSQLDB(poolDBCfg)
+	require.NoError(t, err)
+	defer poolSqlDB.Close() //nolint:gosec,errcheck
+
+	st := newState(stateSqlDB, eventLog)
+
+	// generate accounts
+	accounts := map[common.Address]*ecdsa.PrivateKey{}
+	genesisActions := []*state.GenesisAction{
+		{
+			Address: senderAddress,
+			Type:    int(merkletree.LeafTypeBalance),
+			Value:   "1000000000000000000000",
+		},
+	}
+	for i := 0; i < int(cfg.GlobalQueue); i++ {
+		privateKey, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		publicKey := privateKey.Public().(*ecdsa.PublicKey)
+		fromAddress := crypto.PubkeyToAddress(*publicKey)
+		accounts[fromAddress] = privateKey
+		genesisActions = append(genesisActions, &state.GenesisAction{
+			Address: fromAddress.String(),
+			Type:    int(merkletree.LeafTypeBalance),
+			Value:   "1000000000000000000000",
+		})
+	}
+
+	genesisBlock := state.Block{
+		BlockNumber: 0,
+		BlockHash:   state.ZeroHash,
+		ParentHash:  state.ZeroHash,
+		ReceivedAt:  time.Now(),
+	}
+	genesis := state.Genesis{
+		GenesisActions: genesisActions,
+	}
+	ctx := context.Background()
+	dbTx, err := st.BeginStateTransaction(ctx)
+	require.NoError(t, err)
+	_, err = st.SetGenesis(ctx, genesisBlock, genesis, dbTx)
+	require.NoError(t, err)
+	require.NoError(t, dbTx.Commit(ctx))
+
+	s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
+	require.NoError(t, err)
+
+	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
+
+	for _, privateKey := range accounts {
+		auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+		require.NoError(t, err)
+		tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+			Nonce:    0,
+			Value:    big.NewInt(0),
+			Gas:      uint64(1000000),
+			GasPrice: gasPrice,
+		})
+
+		signedTx, err := auth.Signer(auth.From, tx)
+		require.NoError(t, err)
+
+		err = p.AddTx(ctx, *signedTx, "")
+		require.NoError(t, err)
+	}
+
+	tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+		Nonce:    0,
+		Value:    big.NewInt(0),
+		Gas:      uint64(1000000),
+		GasPrice: big.NewInt(1),
+	})
+
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(senderPrivateKey, "0x"))
+	require.NoError(t, err)
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(t, err)
+
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
+	err = p.AddTx(ctx, *signedTx, "")
+	require.Error(t, err, pool.ErrTxPoolOverflow)
+}
+
+func Test_AddTx_NonceTooHigh(t *testing.T) {
+	eventStorage, err := nileventstorage.NewNilEventStorage()
+	if err != nil {
+		log.Fatal(err)
+	}
+	eventLog := event.NewEventLog(event.Config{}, eventStorage)
+
+	initOrResetDB(t)
+
+	stateSqlDB, err := db.NewSQLDB(stateDBCfg)
+	if err != nil {
+		panic(err)
+	}
+	defer stateSqlDB.Close() //nolint:gosec,errcheck
+
+	poolSqlDB, err := db.NewSQLDB(poolDBCfg)
+	require.NoError(t, err)
+	defer poolSqlDB.Close() //nolint:gosec,errcheck
+
+	st := newState(stateSqlDB, eventLog)
+
+	// generate accounts
+	genesisBlock := state.Block{
+		BlockNumber: 0,
+		BlockHash:   state.ZeroHash,
+		ParentHash:  state.ZeroHash,
+		ReceivedAt:  time.Now(),
+	}
+	genesis := state.Genesis{
+		GenesisActions: []*state.GenesisAction{
+			{
+				Address: senderAddress,
+				Type:    int(merkletree.LeafTypeBalance),
+				Value:   "1000000000000000000000",
+			},
+		},
+	}
+	ctx := context.Background()
+	dbTx, err := st.BeginStateTransaction(ctx)
+	require.NoError(t, err)
+	_, err = st.SetGenesis(ctx, genesisBlock, genesis, dbTx)
+	require.NoError(t, err)
+	require.NoError(t, dbTx.Commit(ctx))
+
+	s, err := pgpoolstorage.NewPostgresPoolStorage(poolDBCfg)
+	require.NoError(t, err)
+
+	p := setupPool(t, cfg, s, st, chainID.Uint64(), ctx, eventLog)
+
+	tx := ethTypes.NewTx(&ethTypes.LegacyTx{
+		Nonce:    cfg.AccountQueue + 1,
+		Value:    big.NewInt(0),
+		Gas:      uint64(1000000),
+		GasPrice: big.NewInt(1),
+	})
+
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(senderPrivateKey, "0x"))
+	require.NoError(t, err)
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(t, err)
+
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
+	err = p.AddTx(ctx, *signedTx, "")
+	require.Error(t, err, pool.ErrNonceTooHigh)
 }
 
 func setupPool(t *testing.T, cfg pool.Config, s *pgpoolstorage.PostgresPoolStorage, st *state.State, chainID uint64, ctx context.Context, eventLog *event.EventLog) *pool.Pool {

--- a/test/benchmarks/sequencer/common/transactions/transactions.go
+++ b/test/benchmarks/sequencer/common/transactions/transactions.go
@@ -20,7 +20,7 @@ func SendAndWait(
 	ctx context.Context,
 	auth *bind.TransactOpts,
 	client *ethclient.Client,
-	countByStatusFunc func(ctx context.Context, status pool.TxStatus) (uint64, error),
+	countByStatusFunc func(ctx context.Context, status ...pool.TxStatus) (uint64, error),
 	nTxs int,
 	erc20SC *ERC20.ERC20,
 	txSenderFunc func(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20) error,
@@ -70,7 +70,7 @@ func SendAndWait(
 }
 
 // WaitStatusSelected waits for a number of transactions to be marked as selected in the pool
-func WaitStatusSelected(countByStatusFunc func(ctx context.Context, status pool.TxStatus) (uint64, error), initialCount uint64, nTxs uint64) error {
+func WaitStatusSelected(countByStatusFunc func(ctx context.Context, status ...pool.TxStatus) (uint64, error), initialCount uint64, nTxs uint64) error {
 	log.Debug("Wait for sequencer to select all txs from the pool")
 	pollingInterval := 1 * time.Second
 


### PR DESCRIPTION
Closes #2185.
Closes #2188.

## What does this PR do?

Improve the checks before adding a tx to the pool.

### New errors:
- `ErrGasLimit`: This happens when the tx exceeds the configured gas limit
- `ErrTxPoolOverflow`: This happens when the pool reaches the configured limit of txs allowed to be added.
- `ErrNonceTooHigh`: This happens when the tx has a nonce equal or higher to the current account nonce + the configured limit of txs allowed to be added in the pool for each account.


### Configuration changes, and parameters added:

Default values:
```toml
[Pool]
AccountQueue = 64
GlobalQueue = 1024
```

`AccountQueue` represents the maximum number of non-executable transaction slots permitted per account
`GlobalQueue` represents the maximum number of non-executable transaction slots for all accounts

## Reviewers

Main reviewers:

@ToniRamirezM 
@agnusmor 