### PR TITLE
Change position of the log.Info for the best fitting tx

### DIFF
--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -263,7 +263,6 @@ func (w *Worker) GetBestFittingTx(resources state.BatchResources) *TxTracker {
 				if foundAt == -1 || foundAt > i {
 					foundAt = i
 					tx = txCandidate
-					log.Infof("GetBestFittingTx found tx(%s) at index(%d) with efficiency(%f)", tx.Hash.String(), i, tx.Efficiency)
 				}
 				foundMutex.Unlock()
 
@@ -272,6 +271,12 @@ func (w *Worker) GetBestFittingTx(resources state.BatchResources) *TxTracker {
 		}(i, resources)
 	}
 	wg.Wait()
+
+	if foundAt != -1 {
+		log.Infof("GetBestFittingTx found tx(%s) at index(%d) with efficiency(%f)", tx.Hash.String(), foundAt, tx.Efficiency)
+	} else {
+		log.Infof("GetBestFittingTx no tx found")
+	}
 
 	return tx
 }


### PR DESCRIPTION
### What does this PR do?

Moved the log that shows info of the best fitting tx at the end of the function worker.GetBestFittingTx. In the actual position the log can be showed several times, since the for loop is performed by several go funcs in parallel, and sometimes, when reviewing the logs,  is not clear which was the tx selected

### Reviewers
Main reviewers:
- @ToniRamirezM 

