### PR TITLE
fix estimate gas root

### DIFF
--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -141,14 +141,12 @@ func (e *EthEndpoints) EstimateGas(arg *types.TxArgs, blockArg *types.BlockNumbe
 			return nil, respErr
 		}
 
-		var blockToProcess *uint64
+		n := block.NumberU64()
+		blockToProcess := &n
 		if blockArg != nil {
 			blockNumArg := blockArg.Number()
 			if blockNumArg != nil && (*blockArg.Number() == types.LatestBlockNumber || *blockArg.Number() == types.PendingBlockNumber) {
 				blockToProcess = nil
-			} else {
-				n := block.NumberU64()
-				blockToProcess = &n
 			}
 		}
 


### PR DESCRIPTION
Closes #2202

### What does this PR do?

This PR fixes an edge case where the l2block root used to get the nonce could be different to the root used to estimate gas if the block is not set as an argument of the call

### Reviewers

- @tclemos 
- @ToniRamirezM 