### PR TITLE
change ports for explorer db to remove conflict

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -245,7 +245,7 @@ services:
     container_name: zkevm-explorer-l1-db
     image: postgres
     ports:
-      - 5435:5432
+      - 5436:5432
     environment:
       - POSTGRES_USER=l1_explorer_user
       - POSTGRES_PASSWORD=l1_explorer_password
@@ -299,7 +299,7 @@ services:
     container_name: zkevm-explorer-l2-db
     image: postgres
     ports:
-      - 5436:5432
+      - 5437:5432
     environment:
       - POSTGRES_USER=l2_explorer_user
       - POSTGRES_PASSWORD=l2_explorer_password


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

zkevm-explorer-l1-db and zkevm-event-db were exposed to the same port on the host manchine, this pr just increments the explorers db ports to remove that conflicting ports

### Reviewers

Main reviewers:

@tclemos 