### PR TITLE
Fix load zkCounters from pool

### DIFF
--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/hex"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/pool"
 	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -636,8 +635,6 @@ func scanTx(rows pgx.Rows) (*pool.Transaction, error) {
 	tx.ZKCounters.UsedBinaries = usedBinaries
 	tx.ZKCounters.UsedSteps = usedSteps
 	tx.FailedReason = failedReason
-
-	log.Infof("ZKCounters", tx.ZKCounters)
 
 	return tx, nil
 }

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/hex"
+	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/pool"
 	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -138,10 +139,12 @@ func (p *PostgresPoolStorage) GetTxsByStatus(ctx context.Context, status pool.Tx
 		sql  string
 	)
 	if limit == 0 {
-		sql = "SELECT encoded, status, received_at, is_wip, ip, failed_reason FROM pool.transaction WHERE status = $1 ORDER BY gas_price DESC"
+		sql = `SELECT encoded, status, received_at, is_wip, ip, cumulative_gas_used, used_keccak_hashes, used_poseidon_hashes, used_poseidon_paddings, used_mem_aligns,
+				used_arithmetics, used_binaries, used_steps, failed_reason FROM pool.transaction WHERE status = $1 ORDER BY gas_price DESC`
 		rows, err = p.db.Query(ctx, sql, status.String())
 	} else {
-		sql = "SELECT encoded, status, received_at, is_wip, ip, failed_reason FROM pool.transaction WHERE status = $1 ORDER BY gas_price DESC LIMIT $2"
+		sql = `SELECT encoded, status, received_at, is_wip, ip, cumulative_gas_used, used_keccak_hashes, used_poseidon_hashes, used_poseidon_paddings, used_mem_aligns,
+				used_arithmetics, used_binaries, used_steps, failed_reason FROM pool.transaction WHERE status = $1 ORDER BY gas_price DESC LIMIT $2`
 		rows, err = p.db.Query(ctx, sql, status.String(), limit)
 	}
 	if err != nil {
@@ -170,11 +173,14 @@ func (p *PostgresPoolStorage) GetNonWIPTxsByStatus(ctx context.Context, status p
 		err  error
 		sql  string
 	)
+
 	if limit == 0 {
-		sql = "SELECT encoded, status, received_at, is_wip, ip, failed_reason FROM pool.transaction WHERE is_wip IS FALSE and status = $1 ORDER BY gas_price DESC"
+		sql = `SELECT encoded, status, received_at, is_wip, ip, cumulative_gas_used, used_keccak_hashes, used_poseidon_hashes, used_poseidon_paddings, used_mem_aligns,
+		used_arithmetics, used_binaries, used_steps, failed_reason FROM pool.transaction WHERE is_wip IS FALSE and status = $1`
 		rows, err = p.db.Query(ctx, sql, status.String())
 	} else {
-		sql = "SELECT encoded, status, received_at, is_wip, ip, failed_reason FROM pool.transaction WHERE is_wip IS FALSE and status = $1 ORDER BY gas_price DESC LIMIT $2"
+		sql = `SELECT encoded, status, received_at, is_wip, ip, cumulative_gas_used, used_keccak_hashes, used_poseidon_hashes, used_poseidon_paddings, used_mem_aligns,
+		used_arithmetics, used_binaries, used_steps, failed_reason FROM pool.transaction WHERE is_wip IS FALSE and status = $1 DESC LIMIT $2`
 		rows, err = p.db.Query(ctx, sql, status.String(), limit)
 	}
 	if err != nil {
@@ -467,7 +473,8 @@ func (p *PostgresPoolStorage) IsTxPending(ctx context.Context, hash common.Hash)
 
 // GetTxsByFromAndNonce get all the transactions from the pool with the same from and nonce
 func (p *PostgresPoolStorage) GetTxsByFromAndNonce(ctx context.Context, from common.Address, nonce uint64) ([]pool.Transaction, error) {
-	sql := `SELECT encoded, status, received_at, is_wip, ip, failed_reason
+	sql := `SELECT encoded, status, received_at, is_wip, ip, cumulative_gas_used, used_keccak_hashes, used_poseidon_hashes, 
+				   used_poseidon_paddings, used_mem_aligns,	used_arithmetics, used_binaries, used_steps, failed_reason
 	          FROM pool.transaction
 			 WHERE from_address = $1
 			   AND nonce = $2`
@@ -586,13 +593,22 @@ func (p *PostgresPoolStorage) GetTxByHash(ctx context.Context, hash common.Hash)
 
 func scanTx(rows pgx.Rows) (*pool.Transaction, error) {
 	var (
-		encoded, status, ip string
-		receivedAt          time.Time
-		isWIP               bool
-		failedReason        *string
+		encoded, status, ip  string
+		receivedAt           time.Time
+		isWIP                bool
+		cumulativeGasUsed    uint64
+		usedKeccakHashes     uint32
+		usedPoseidonHashes   uint32
+		usedPoseidonPaddings uint32
+		usedMemAligns        uint32
+		usedArithmetics      uint32
+		usedBinaries         uint32
+		usedSteps            uint32
+		failedReason         *string
 	)
 
-	if err := rows.Scan(&encoded, &status, &receivedAt, &isWIP, &ip, &failedReason); err != nil {
+	if err := rows.Scan(&encoded, &status, &receivedAt, &isWIP, &ip, &cumulativeGasUsed, &usedKeccakHashes, &usedPoseidonHashes,
+		&usedPoseidonPaddings, &usedMemAligns, &usedArithmetics, &usedBinaries, &usedSteps, &failedReason); err != nil {
 		return nil, err
 	}
 
@@ -611,7 +627,17 @@ func scanTx(rows pgx.Rows) (*pool.Transaction, error) {
 	tx.ReceivedAt = receivedAt
 	tx.IsWIP = isWIP
 	tx.IP = ip
+	tx.ZKCounters.CumulativeGasUsed = cumulativeGasUsed
+	tx.ZKCounters.UsedKeccakHashes = usedKeccakHashes
+	tx.ZKCounters.UsedPoseidonHashes = usedPoseidonHashes
+	tx.ZKCounters.UsedPoseidonPaddings = usedPoseidonPaddings
+	tx.ZKCounters.UsedMemAligns = usedMemAligns
+	tx.ZKCounters.UsedArithmetics = usedArithmetics
+	tx.ZKCounters.UsedBinaries = usedBinaries
+	tx.ZKCounters.UsedSteps = usedSteps
 	tx.FailedReason = failedReason
+
+	log.Infof("ZKCounters", tx.ZKCounters)
 
 	return tx, nil
 }


### PR DESCRIPTION
### What does this PR do?

It fixes the load of the zkCounters values in the function GetNonWIPTxsByStatus as it was not adding the zkCounters fields to the query and therefore the zkCounters was 0 for all the counters. When adding these txs to the worker, it was calculating a wrong efficiency, as all the zkcounters were 0. This bug was reported here (bug bounty):

https://polygon.atlassian.net/browse/ASF-285

### Reviewers

Main reviewers:
@tclemos 
@ToniRamirezM 
@Psykepro 