### PR TITLE
Fix GetWIPBatch when previous last batch is a forced batch

### DIFF
--- a/sequencer/dbmanager.go
+++ b/sequencer/dbmanager.go
@@ -257,18 +257,10 @@ func (d *dbManager) GetWIPBatch(ctx context.Context) (*WipBatch, error) {
 	}
 	lastBatch.Transactions = lastBatchTxs
 
-	var prevLastBatchTxs []types.Transaction
-	if previousLastBatch != nil {
-		prevLastBatchTxs, _, err = state.DecodeTxs(previousLastBatch.BatchL2Data)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var lastStateRoot common.Hash
-	// If the last two batches have no txs, the stateRoot can not be retrieved from the l2block because there is no tx.
+	// If the last batch have no txs, the stateRoot can not be retrieved from the l2block because there is no tx.
 	// In this case, the stateRoot must be gotten from the previousLastBatch
-	if len(lastBatchTxs) == 0 && previousLastBatch != nil && len(prevLastBatchTxs) == 0 {
+	if len(lastBatchTxs) == 0 && previousLastBatch != nil {
 		lastStateRoot = previousLastBatch.StateRoot
 	} else {
 		lastStateRoot, err = d.state.GetLastStateRoot(ctx, dbTx)

--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -275,7 +275,7 @@ func (w *Worker) GetBestFittingTx(resources state.BatchResources) *TxTracker {
 	if foundAt != -1 {
 		log.Infof("GetBestFittingTx found tx(%s) at index(%d) with efficiency(%f)", tx.Hash.String(), foundAt, tx.Efficiency)
 	} else {
-		log.Infof("GetBestFittingTx no tx found")
+		log.Debugf("GetBestFittingTx no tx found")
 	}
 
 	return tx


### PR DESCRIPTION
### What does this PR do?

It fixes an error in the GetWIPBatch when trying to decode the txs of the previous last batch. If the previous last batch was a forced batch containing invalid data, the DecodeTxs function failing when trying to decode this data and it returned an error that was managed as a fatal, stopping the execution of the sequencer.

Reviewing the code we figure out that was not needed to call DecodeTxs for the previous last batch as this info is not needed to check if we need to get the last stateroot from the l2block data or from the previous last batch. Removing this DecodeTxs we fix any decode problem with forceb batches in this point

### Reviewers

Main reviewers:
@ARR552 
@ToniRamirezM 
@tclemos 