### PR TITLE
Support fork id upgrades without down time for the trusted state

### DIFF
--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	ChainID uint64
 
 	// ForkID is the L2 ForkID provided by the Network Config
-	ForkId uint64 `mapstructure:"ForkId"`
+	ForkId uint64
 
 	// SenderAddress defines which private key the eth tx manager needs to use
 	// to sign the L1 txs

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -405,6 +405,8 @@ func createSequenceSender(cfg config.Config, pool *pool.Pool, etmStorage *ethtxm
 		}
 	}
 
+	cfg.SequenceSender.ForkUpgradeBatchNumber = cfg.ForkUpgradeBatchNumber
+
 	ethTxManager := ethtxmanager.New(cfg.EthTxManager, etherman, etmStorage, st)
 
 	seqSender, err := sequencesender.New(cfg.SequenceSender, st, etherman, ethTxManager, eventLog)
@@ -472,6 +474,8 @@ func newState(ctx context.Context, c *config.Config, l2ChainID uint64, forkIDInt
 		ForkIDIntervals:              forkIDIntervals,
 		MaxResourceExhaustedAttempts: c.Executor.MaxResourceExhaustedAttempts,
 		WaitOnResourceExhaustion:     c.Executor.WaitOnResourceExhaustion,
+		ForkUpgradeBatchNumber:       c.ForkUpgradeBatchNumber,
+		ForkUpgradeNewForkId:         c.ForkUpgradeNewForkId,
 	}
 
 	st := state.NewState(stateCfg, stateDb, executorClient, stateTree, eventLog)

--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	StateDB                db.Config
 	Metrics                metrics.Config
 	EventLog               event.Config
-  HashDB                 db.Config
+	HashDB                 db.Config
 }
 
 // Default parses the default configuration values.

--- a/config/config.go
+++ b/config/config.go
@@ -54,23 +54,25 @@ const (
 
 // Config represents the configuration of the entire Hermez Node
 type Config struct {
-	IsTrustedSequencer  bool `mapstructure:"IsTrustedSequencer"`
-	Log                 log.Config
-	Etherman            etherman.Config
-	EthTxManager        ethtxmanager.Config
-	Pool                pool.Config
-	RPC                 jsonrpc.Config
-	Synchronizer        synchronizer.Config
-	Sequencer           sequencer.Config
-	SequenceSender      sequencesender.Config
-	Aggregator          aggregator.Config
-	NetworkConfig       NetworkConfig
-	L2GasPriceSuggester gasprice.Config
-	Executor            executor.Config
-	MTClient            merkletree.Config
-	StateDB             db.Config
-	Metrics             metrics.Config
-	EventLog            event.Config
+	IsTrustedSequencer     bool   `mapstructure:"IsTrustedSequencer"`
+	ForkUpgradeBatchNumber uint64 `mapstructure:"ForkUpgradeBatchNumber"`
+	ForkUpgradeNewForkId   uint64 `mapstructure:"ForkUpgradeNewForkId"`
+	Log                    log.Config
+	Etherman               etherman.Config
+	EthTxManager           ethtxmanager.Config
+	Pool                   pool.Config
+	RPC                    jsonrpc.Config
+	Synchronizer           synchronizer.Config
+	Sequencer              sequencer.Config
+	SequenceSender         sequencesender.Config
+	Aggregator             aggregator.Config
+	NetworkConfig          NetworkConfig
+	L2GasPriceSuggester    gasprice.Config
+	Executor               executor.Config
+	MTClient               merkletree.Config
+	StateDB                db.Config
+	Metrics                metrics.Config
+	EventLog               event.Config
 }
 
 // Default parses the default configuration values.

--- a/config/default.go
+++ b/config/default.go
@@ -3,6 +3,8 @@ package config
 // DefaultValues is the default configuration
 const DefaultValues = `
 IsTrustedSequencer = false
+ForkUpgradeBatchNumber = 0
+ForkUpgradeNewForkId = 0
 
 [Log]
 Environment = "development" # "production" or "development"
@@ -117,7 +119,6 @@ PrivateKeys = [{Path = "/pk/sequencer.keystore", Password = "testonly"}]
 [Aggregator]
 Host = "0.0.0.0"
 Port = 50081
-ForkId = 2
 RetryTime = "5s"
 VerifyProofInterval = "90s"
 TxProfitabilityCheckerType = "acceptall"

--- a/config/environments/local/local.node.config.toml
+++ b/config/environments/local/local.node.config.toml
@@ -105,7 +105,6 @@ PrivateKeys = [{Path = "/pk/sequencer.keystore", Password = "testonly"}]
 [Aggregator]
 Host = "0.0.0.0"
 Port = 50081
-ForkId = 2
 RetryTime = "5s"
 VerifyProofInterval = "30s"
 TxProfitabilityCheckerType = "acceptall"

--- a/sequencesender/config.go
+++ b/sequencesender/config.go
@@ -22,4 +22,6 @@ type Config struct {
 	// PrivateKeys defines all the key store files that are going
 	// to be read in order to provide the private keys to sign the L1 txs
 	PrivateKeys []types.KeystoreFileConfig `mapstructure:"PrivateKeys"`
+	// Batch number where there is a forkid change (fork upgrade)
+	ForkUpgradeBatchNumber uint64
 }

--- a/state/batch.go
+++ b/state/batch.go
@@ -175,7 +175,7 @@ func (s *State) ProcessBatch(ctx context.Context, request ProcessRequest, update
 		updateMT = cTrue
 	}
 
-	forkID := GetForkIDByBatchNumber(s.cfg.ForkIDIntervals, request.BatchNumber)
+	forkID := s.GetForkIDByBatchNumber(request.BatchNumber)
 
 	// Create Batch
 	var processBatchRequest = &pb.ProcessBatchRequest{
@@ -312,7 +312,7 @@ func (s *State) processBatch(ctx context.Context, batchNumber uint64, batchL2Dat
 	if lastBatch.BatchNumber != batchNumber {
 		return nil, ErrInvalidBatchNumber
 	}
-	forkID := GetForkIDByBatchNumber(s.cfg.ForkIDIntervals, lastBatch.BatchNumber)
+	forkID := s.GetForkIDByBatchNumber(lastBatch.BatchNumber)
 
 	// Create Batch
 	processBatchRequest := &pb.ProcessBatchRequest{

--- a/state/config.go
+++ b/state/config.go
@@ -18,4 +18,10 @@ type Config struct {
 
 	// WaitOnResourceExhaustion is the time to wait before retrying a transaction because of resource exhaustion
 	WaitOnResourceExhaustion types.Duration
+
+	// Batch number where there is a forkid change (fork upgrade)
+	ForkUpgradeBatchNumber uint64
+
+	// New fork id to be used for batches greaters than ForkUpgradeBatchNumber (fork upgrade)
+	ForkUpgradeNewForkId uint64
 }

--- a/state/config.go
+++ b/state/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// WaitOnResourceExhaustion is the time to wait before retrying a transaction because of resource exhaustion
 	WaitOnResourceExhaustion types.Duration
 
-	// Batch number where there is a forkid change (fork upgrade)
+	// Batch number from which there is a forkid change (fork upgrade)
 	ForkUpgradeBatchNumber uint64
 
 	// New fork id to be used for batches greaters than ForkUpgradeBatchNumber (fork upgrade)

--- a/state/forkid.go
+++ b/state/forkid.go
@@ -17,18 +17,20 @@ func (s *State) UpdateForkIDIntervals(intervals []ForkIDInterval) {
 }
 
 // GetForkIDByBatchNumber returns the fork id for a given batch number
-func GetForkIDByBatchNumber(intervals []ForkIDInterval, batchNumber uint64) uint64 {
-	for _, interval := range intervals {
+func (s *State) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
+	// If NumBatchForkIdUpgrade is defined (!=0) we are performing forkid upgrade process
+	// In this case, if the batchNumber is the next to the NumBatchForkIdUpgrade, we need to return the
+	// new "future" forkId (last fork id + 1)
+	if (s.cfg.ForkUpgradeBatchNumber) != 0 && (batchNumber > s.cfg.ForkUpgradeBatchNumber) {
+		return s.cfg.ForkUpgradeNewForkId
+	}
+
+	for _, interval := range s.cfg.ForkIDIntervals {
 		if batchNumber >= interval.FromBatchNumber && batchNumber <= interval.ToBatchNumber {
 			return interval.ForkId
 		}
 	}
 
 	// If not found return the last fork id
-	return intervals[len(intervals)-1].ForkId
-}
-
-// GetForkIDByBatchNumber returns the fork id for the given batch number
-func (s *State) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
-	return GetForkIDByBatchNumber(s.cfg.ForkIDIntervals, batchNumber)
+	return s.cfg.ForkIDIntervals[len(s.cfg.ForkIDIntervals)-1].ForkId
 }

--- a/state/forkid.go
+++ b/state/forkid.go
@@ -20,7 +20,7 @@ func (s *State) UpdateForkIDIntervals(intervals []ForkIDInterval) {
 func (s *State) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
 	// If NumBatchForkIdUpgrade is defined (!=0) we are performing forkid upgrade process
 	// In this case, if the batchNumber is the next to the NumBatchForkIdUpgrade, we need to return the
-	// new "future" forkId (last fork id + 1)
+	// new "future" forkId (ForkUpgradeNewForkId)
 	if (s.cfg.ForkUpgradeBatchNumber) != 0 && (batchNumber > s.cfg.ForkUpgradeBatchNumber) {
 		return s.cfg.ForkUpgradeNewForkId
 	}

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -799,7 +799,7 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 		return nil, err
 	}
 
-	forkID := GetForkIDByBatchNumber(s.cfg.ForkIDIntervals, lastBatch.BatchNumber)
+	forkID := s.GetForkIDByBatchNumber(lastBatch.BatchNumber)
 	// Create Batch
 	processBatchRequest := &pb.ProcessBatchRequest{
 		OldBatchNum:      lastBatch.BatchNumber,
@@ -1042,7 +1042,7 @@ func (s *State) EstimateGas(transaction *types.Transaction, senderAddress common
 			return false, false, gasUsed, nil, err
 		}
 
-		forkID := GetForkIDByBatchNumber(s.cfg.ForkIDIntervals, lastBatch.BatchNumber)
+		forkID := s.GetForkIDByBatchNumber(lastBatch.BatchNumber)
 		// Create a batch to be sent to the executor
 		processBatchRequest := &pb.ProcessBatchRequest{
 			OldBatchNum:      lastBatch.BatchNumber,

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -105,7 +105,7 @@ PrivateKeys = [{Path = "./test/sequencer.keystore", Password = "testonly"}]
 
 [Aggregator]
 Host = "0.0.0.0"
-Port = 500
+Port = 50081
 RetryTime = "5s"
 VerifyProofInterval = "30s"
 TxProfitabilityCheckerType = "acceptall"

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -105,8 +105,7 @@ PrivateKeys = [{Path = "./test/sequencer.keystore", Password = "testonly"}]
 
 [Aggregator]
 Host = "0.0.0.0"
-Port = 50081
-ForkId = 2
+Port = 500
 RetryTime = "5s"
 VerifyProofInterval = "30s"
 TxProfitabilityCheckerType = "acceptall"

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -107,7 +107,6 @@ PrivateKeys = [{Path = "/pk/sequencer.keystore", Password = "testonly"}]
 [Aggregator]
 Host = "0.0.0.0"
 Port = 50081
-ForkId = 2
 RetryTime = "5s"
 VerifyProofInterval = "10s"
 TxProfitabilityCheckerType = "acceptall"


### PR DESCRIPTION
Closes [#2236](https://github.com/0xPolygonHermez/zkevm-node/issues/2236).

### What does this PR do?

Support fork id upgrades without down time for the trusted state.

Steps to perform a forkid upgrade using this feature (e.g upgrading from forkid 4 to 5):
1. Update node/executor to new forkid 5 versions. Keep provers running on previous version (previous forkid 4)
2. Set ForkUpgradeBatchNumber config parameter to the batch number that will be the last batch using the previous forkid 4 and set ForkUpgradeNewForkId to the new forkid value (5). 
3. Start/restart node components to get the new config values 
4. Wait until ForkUpgradeBatchNumber batch has been virtualized and verfied. While waiting for this the system we will continue processing txs and batches and adding it to the trusted state (but virtualization and verification will be on hold from ForkUpgradeNewForkId+1 batch)
5. Update SC to the new forkid 5
6. Stop provers using previous forkid 4
7. Set ForkUpgradeNewForkId = 0 and ForkUpgradeNewForkId = 0 to disable this feature
8. Restart node components (RPC, Synchornizer, Sequencer, SequenceSender, Aggregator) to get the config changes
9. Update provers to new forkid 5 versions
10. Check the service resumes correctly and new batches are virtualized and verified using new forkid 5

New config parameters in the node (at root level of the toml file):
ForkUpgradeBatchNumber = 0
ForkUpgradeNewForkId = 0

### Reviewers

Main reviewers:
@ToniRamirezM 
@ARR552 