### PR TITLE
Fully check synchronization on permissionless E2E sync

### DIFF
--- a/test/e2e/permissionlessrpc_test.go
+++ b/test/e2e/permissionlessrpc_test.go
@@ -127,4 +127,20 @@ func TestPermissionlessJRPC(t *testing.T) {
 	isThereL2Reorg := true
 	require.NoError(t, row.Scan(&isThereL2Reorg))
 	require.False(t, isThereL2Reorg)
+
+	// Assert that he permissionless node is fully synced
+	time.Sleep(30 * time.Second) // Give some time for the permissionless node to get synced
+	clientTrusted, err := ethclient.Dial(operations.DefaultL1NetworkURL)
+	require.NoError(t, err)
+	expectedBlock, err := clientTrusted.BlockByNumber(ctx, nil)
+	require.NoError(t, err)
+	actualBlock, err := client.BlockByNumber(ctx, nil)
+	require.NoError(t, err)
+	je, err := expectedBlock.Header().MarshalJSON()
+	require.NoError(t, err)
+	log.Info(string(je))
+	ja, err := actualBlock.Header().MarshalJSON()
+	require.NoError(t, err)
+	log.Info(string(ja))
+	require.Equal(t, string(je), string(ja))
 }


### PR DESCRIPTION
It looks like there is a problem with the timestamp in the synchronization of the persmissionless nodes.

I've added an assert to `test/e2e/permissionlessrpc_test.go` that checks that the block header of the last L2 block is the same in both the permissionless and the trusted node. There are a few fields that are different but most likely all come from just the timestamp, that is very different (`0x649ef99c` vs `0x649ef968`)