### PR TITLE
Hotfix/v0.1.x timestamp fix

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -176,11 +176,6 @@ func (f *finalizer) finalizeBatches(ctx context.Context) {
 		tx := f.worker.GetBestFittingTx(f.batch.remainingResources)
 		metrics.WorkerProcessingTime(time.Since(start))
 		if tx != nil {
-			// Timestamp resolution
-			if f.batch.isEmpty() {
-				f.batch.timestamp = now()
-			}
-
 			f.sharedResourcesMux.Lock()
 			log.Debugf("processing tx: %s", tx.Hash.Hex())
 			_, err := f.processTransaction(ctx, tx)


### PR DESCRIPTION
Closes #2249 .

### What does this PR do?

Fixing bug with L2 Block wrong timestamp. The L2 Block Timestamp is different than the one for the batch.

### Reviewers
- @arnaubennassar 
- @ARR552  
- @agnusmor