### PR TITLE
bugfix: adding missing closing reason when receiving forced batch deadline signal.

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -1159,6 +1159,7 @@ func (f *finalizer) isDeadlineEncountered() bool {
 	// Forced batch deadline
 	if f.nextForcedBatchDeadline != 0 && now().Unix() >= f.nextForcedBatchDeadline {
 		log.Infof("Closing batch: %d, forced batch deadline encountered.", f.batch.batchNumber)
+		f.batch.closingReason = state.ForcedBatchDeadlineClosingReason
 		return true
 	}
 	// Global Exit Root deadline


### PR DESCRIPTION
Closes #2254.

### What does this PR do?

Adding missing `closingReason` to be set before storing info for the batch closed on receiving the `Forced Batch deadline` signal.

### Reviewers

Main reviewers:
- @agnusmor 
- @ARR552 
- @tclemos 