### PR TITLE
Fix pending tx when duplicate nonce

### DIFF
--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -74,9 +74,10 @@ func (p *PostgresPoolStorage) AddTx(ctx context.Context, tx pool.Transaction) er
 			from_address,
 			is_wip,
 			ip,
+			failed_reason
 		) 
 		VALUES 
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NULL)
 			ON CONFLICT (hash) DO UPDATE SET 
 			encoded = $2,
 			decoded = $3,

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -73,7 +73,7 @@ func (p *PostgresPoolStorage) AddTx(ctx context.Context, tx pool.Transaction) er
 			received_at,
 			from_address,
 			is_wip,
-			ip
+			ip,
 		) 
 		VALUES 
 			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
@@ -94,7 +94,8 @@ func (p *PostgresPoolStorage) AddTx(ctx context.Context, tx pool.Transaction) er
 			received_at = $15,
 			from_address = $16,
 			is_wip = $17,
-			ip = $18
+			ip = $18,
+			failed_reason = NULL
 	`
 
 	// Get FromAddress from the JSON data

--- a/sequencer/addrqueue_test.go
+++ b/sequencer/addrqueue_test.go
@@ -73,7 +73,6 @@ func processAddTxTestCases(t *testing.T, testCases []addrQueueAddTxTestCase) {
 					t.Fatalf("Error discardedTx. Expected=%s, Actual=%s", tc.expectedDiscardedTx, replacedTxStr)
 				}
 			}
-
 		})
 	}
 }

--- a/sequencer/addrqueue_test.go
+++ b/sequencer/addrqueue_test.go
@@ -13,13 +13,14 @@ type notReadyTx struct {
 }
 
 type addrQueueAddTxTestCase struct {
-	name               string
-	hash               common.Hash
-	nonce              uint64
-	gasPrice           *big.Int
-	cost               *big.Int
-	expectedReadyTx    common.Hash
-	expectedNotReadyTx []notReadyTx
+	name                string
+	hash                common.Hash
+	nonce               uint64
+	gasPrice            *big.Int
+	cost                *big.Int
+	expectedReadyTx     common.Hash
+	expectedNotReadyTx  []notReadyTx
+	expectedDiscardedTx common.Hash
 }
 
 var addr addrQueue
@@ -35,10 +36,10 @@ func processAddTxTestCases(t *testing.T, testCases []addrQueueAddTxTestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tx := newTestTxTracker(tc.hash, tc.nonce, tc.gasPrice, tc.cost)
-			newReadyTx, _, _ := addr.addTx(tx)
+			newReadyTx, _, replacedTx, _ := addr.addTx(tx)
 			if tc.expectedReadyTx.String() == emptyHash.String() {
 				if !(addr.readyTx == nil) {
-					t.Fatalf("Error readyTx. Expected=%s, Actual=%s", tc.expectedReadyTx, "")
+					t.Fatalf("Error readyTx. Expected=nil, Actual=%s", addr.readyTx.HashStr)
 				}
 				if !(newReadyTx == nil) {
 					t.Fatalf("Error newReadyTx. Expected=nil, Actual=%s", newReadyTx.HashStr)
@@ -58,6 +59,21 @@ func processAddTxTestCases(t *testing.T, testCases []addrQueueAddTxTestCase) {
 					t.Fatalf("Error notReadyTx nonce=%d. Expected=%s, Actual=%s", nr.nonce, nr.hash.String(), txTmp.HashStr)
 				}
 			}
+
+			if tc.expectedDiscardedTx.String() == emptyHash.String() {
+				if !(replacedTx == nil) {
+					t.Fatalf("Error discardedTx. Expected=%s, Actual=%s", tc.expectedDiscardedTx, replacedTx.HashStr)
+				}
+			} else {
+				if (replacedTx == nil) || ((replacedTx != nil) && !(replacedTx.Hash == tc.expectedDiscardedTx)) {
+					replacedTxStr := "nil"
+					if replacedTx != nil {
+						replacedTxStr = replacedTx.HashStr
+					}
+					t.Fatalf("Error discardedTx. Expected=%s, Actual=%s", tc.expectedDiscardedTx, replacedTxStr)
+				}
+			}
+
 		})
 	}
 }
@@ -67,22 +83,37 @@ func TestAddrQueue(t *testing.T) {
 
 	addTxTestCases := []addrQueueAddTxTestCase{
 		{
-			name: "Add not ready tx 0x02", hash: common.Hash{0x2}, nonce: 2, gasPrice: new(big.Int).SetInt64(2), cost: new(big.Int).SetInt64(5),
+			name: "Add not ready tx 0x02 nonce 2", hash: common.Hash{0x2}, nonce: 2, gasPrice: new(big.Int).SetInt64(2), cost: new(big.Int).SetInt64(5),
 			expectedReadyTx: common.Hash{},
 			expectedNotReadyTx: []notReadyTx{
 				{nonce: 2, hash: common.Hash{0x2}},
 			},
 		},
 		{
-			name: "Add ready tx 0x01", hash: common.Hash{0x1}, nonce: 1, gasPrice: new(big.Int).SetInt64(2), cost: new(big.Int).SetInt64(5),
-			expectedReadyTx: common.Hash{1},
+			name: "Add ready tx 0x011 nonce 1", hash: common.Hash{0x11}, nonce: 1, gasPrice: new(big.Int).SetInt64(5), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x11},
 			expectedNotReadyTx: []notReadyTx{
 				{nonce: 2, hash: common.Hash{0x2}},
 			},
 		},
 		{
-			name: "Add not ready tx 0x04", hash: common.Hash{0x4}, nonce: 4, gasPrice: new(big.Int).SetInt64(2), cost: new(big.Int).SetInt64(5),
-			expectedReadyTx: common.Hash{1},
+			name: "Replace readyTx 0x11 by tx 0x1 with best gasPrice", hash: common.Hash{0x1}, nonce: 1, gasPrice: new(big.Int).SetInt64(6), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x1},
+			expectedNotReadyTx: []notReadyTx{
+				{nonce: 2, hash: common.Hash{0x2}},
+			},
+			expectedDiscardedTx: common.Hash{0x11},
+		},
+		{
+			name: "Replace readyTx for the same tx 0x1 with best gasPrice", hash: common.Hash{0x1}, nonce: 1, gasPrice: new(big.Int).SetInt64(8), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x1},
+			expectedNotReadyTx: []notReadyTx{
+				{nonce: 2, hash: common.Hash{0x2}},
+			},
+		},
+		{
+			name: "Add not ready tx 0x04 nonce 4", hash: common.Hash{0x4}, nonce: 4, gasPrice: new(big.Int).SetInt64(2), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x1},
 			expectedNotReadyTx: []notReadyTx{
 				{nonce: 2, hash: common.Hash{0x2}},
 				{nonce: 4, hash: common.Hash{0x4}},
@@ -90,18 +121,37 @@ func TestAddrQueue(t *testing.T) {
 		},
 		{
 			name: "Replace tx with nonce 4 for tx 0x44 with best GasPrice", hash: common.Hash{0x44}, nonce: 4, gasPrice: new(big.Int).SetInt64(3), cost: new(big.Int).SetInt64(5),
-			expectedReadyTx: common.Hash{1},
+			expectedReadyTx: common.Hash{0x1},
 			expectedNotReadyTx: []notReadyTx{
 				{nonce: 2, hash: common.Hash{0x2}},
 				{nonce: 4, hash: common.Hash{0x44}},
 			},
+			expectedDiscardedTx: common.Hash{0x4},
+		},
+		{
+			name: "Replace tx with nonce 4 for the same tx 0x44 with best GasPrice", hash: common.Hash{0x44}, nonce: 4, gasPrice: new(big.Int).SetInt64(4), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x1},
+			expectedNotReadyTx: []notReadyTx{
+				{nonce: 2, hash: common.Hash{0x2}},
+				{nonce: 4, hash: common.Hash{0x44}},
+			},
+			expectedDiscardedTx: common.Hash{},
+		},
+		{
+			name: "Add tx 0x22 with nonce 2 with lower GasPrice than 0x2", hash: common.Hash{0x22}, nonce: 2, gasPrice: new(big.Int).SetInt64(1), cost: new(big.Int).SetInt64(5),
+			expectedReadyTx: common.Hash{0x1},
+			expectedNotReadyTx: []notReadyTx{
+				{nonce: 2, hash: common.Hash{0x2}},
+				{nonce: 4, hash: common.Hash{0x44}},
+			},
+			expectedDiscardedTx: common.Hash{0x22},
 		},
 	}
 
 	processAddTxTestCases(t, addTxTestCases)
 
 	t.Run("Delete readyTx 0x01", func(t *testing.T) {
-		tc := addTxTestCases[1]
+		tc := addTxTestCases[2]
 		tx := newTestTxTracker(tc.hash, tc.nonce, tc.gasPrice, tc.cost)
 		deltx := addr.deleteTx(tx.Hash)
 		if !(addr.readyTx == nil) {

--- a/sequencer/dbmanager.go
+++ b/sequencer/dbmanager.go
@@ -148,7 +148,7 @@ func (d *dbManager) addTxToWorker(tx pool.Transaction) error {
 			return d.txPool.UpdateTxWIPStatus(d.ctx, tx.Hash(), true)
 		}
 		if replacedTx != nil {
-			failedReason := "transaction replaced"
+			failedReason := "duplicated nonce"
 			return d.txPool.UpdateTxStatus(d.ctx, txTracker.Hash, pool.TxStatusFailed, false, &failedReason)
 		}
 	}

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -87,7 +87,7 @@ type workerInterface interface {
 	GetBestFittingTx(resources state.BatchResources) *TxTracker
 	UpdateAfterSingleSuccessfulTxExecution(from common.Address, touchedAddresses map[common.Address]*state.InfoReadWrite) []*TxTracker
 	UpdateTx(txHash common.Hash, from common.Address, ZKCounters state.ZKCounters)
-	AddTxTracker(ctx context.Context, txTracker *TxTracker) (dropReason error, isWIP bool)
+	AddTxTracker(ctx context.Context, txTracker *TxTracker) (replacedTx *TxTracker, dropReason error, isWIP bool)
 	MoveTxToNotReady(txHash common.Hash, from common.Address, actualNonce *uint64, actualBalance *big.Int) []*TxTracker
 	DeleteTx(txHash common.Hash, from common.Address)
 	HandleL2Reorg(txHashes []common.Hash)

--- a/sequencer/mock_worker.go
+++ b/sequencer/mock_worker.go
@@ -21,27 +21,36 @@ type WorkerMock struct {
 }
 
 // AddTxTracker provides a mock function with given fields: ctx, txTracker
-func (_m *WorkerMock) AddTxTracker(ctx context.Context, txTracker *TxTracker) (error, bool) {
+func (_m *WorkerMock) AddTxTracker(ctx context.Context, txTracker *TxTracker) (*TxTracker, error, bool) {
 	ret := _m.Called(ctx, txTracker)
 
-	var r0 error
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(context.Context, *TxTracker) (error, bool)); ok {
+	var r0 *TxTracker
+	var r1 error
+	var r2 bool
+	if rf, ok := ret.Get(0).(func(context.Context, *TxTracker) (*TxTracker, error, bool)); ok {
 		return rf(ctx, txTracker)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *TxTracker) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *TxTracker) *TxTracker); ok {
 		r0 = rf(ctx, txTracker)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*TxTracker)
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *TxTracker) bool); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *TxTracker) error); ok {
 		r1 = rf(ctx, txTracker)
 	} else {
-		r1 = ret.Get(1).(bool)
+		r1 = ret.Error(1)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, *TxTracker) bool); ok {
+		r2 = rf(ctx, txTracker)
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	return r0, r1, r2
 }
 
 // DeleteTx provides a mock function with given fields: txHash, from

--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -84,7 +84,7 @@ func (w *Worker) AddTxTracker(ctx context.Context, tx *TxTracker) (replacedTx *T
 	}
 
 	// Add the txTracker to Addr and get the newReadyTx and prevReadyTx
-	log.Infof("AddTx new tx(%s) nonce(%d) cost(%s) to addrQueue(%s)", tx.HashStr, tx.Nonce, tx.Cost.String(), tx.FromStr)
+	log.Infof("AddTx new tx(%s) nonce(%d) cost(%s) to addrQueue(%s) nonce(%d) balance(%d)", tx.HashStr, tx.Nonce, tx.Cost.String(), addr.fromStr, addr.currentNonce, addr.currentBalance)
 	var newReadyTx, prevReadyTx, repTx *TxTracker
 	newReadyTx, prevReadyTx, repTx, dropReason = addr.addTx(tx)
 	if dropReason != nil {

--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -45,7 +45,7 @@ func (w *Worker) NewTxTracker(tx types.Transaction, counters state.ZKCounters, i
 }
 
 // AddTxTracker adds a new Tx to the Worker
-func (w *Worker) AddTxTracker(ctx context.Context, tx *TxTracker) (dropReason error, isWIP bool) {
+func (w *Worker) AddTxTracker(ctx context.Context, tx *TxTracker) (replacedTx *TxTracker, dropReason error, isWIP bool) {
 	w.workerMutex.Lock()
 	defer w.workerMutex.Unlock()
 
@@ -59,19 +59,19 @@ func (w *Worker) AddTxTracker(ctx context.Context, tx *TxTracker) (dropReason er
 		if err != nil {
 			dropReason = fmt.Errorf("AddTx GetLastStateRoot error: %v", err)
 			log.Error(dropReason)
-			return dropReason, false
+			return nil, dropReason, false
 		}
 		nonce, err := w.state.GetNonceByStateRoot(ctx, tx.From, root)
 		if err != nil {
 			dropReason = fmt.Errorf("AddTx GetNonceByStateRoot error: %v", err)
 			log.Error(dropReason)
-			return dropReason, false
+			return nil, dropReason, false
 		}
 		balance, err := w.state.GetBalanceByStateRoot(ctx, tx.From, root)
 		if err != nil {
 			dropReason = fmt.Errorf("AddTx GetBalanceByStateRoot error: %v", err)
 			log.Error(dropReason)
-			return dropReason, false
+			return nil, dropReason, false
 		}
 
 		addr = newAddrQueue(tx.From, nonce.Uint64(), balance)
@@ -84,25 +84,29 @@ func (w *Worker) AddTxTracker(ctx context.Context, tx *TxTracker) (dropReason er
 	}
 
 	// Add the txTracker to Addr and get the newReadyTx and prevReadyTx
-	log.Infof("AddTx new tx(%s) nonce(%d) cost(%s) to addrQueue(%s)", tx.Hash.String(), tx.Nonce, tx.Cost.String(), tx.FromStr)
-	var newReadyTx, prevReadyTx *TxTracker
-	newReadyTx, prevReadyTx, dropReason = addr.addTx(tx)
+	log.Infof("AddTx new tx(%s) nonce(%d) cost(%s) to addrQueue(%s)", tx.HashStr, tx.Nonce, tx.Cost.String(), tx.FromStr)
+	var newReadyTx, prevReadyTx, repTx *TxTracker
+	newReadyTx, prevReadyTx, repTx, dropReason = addr.addTx(tx)
 	if dropReason != nil {
-		log.Infof("AddTx tx(%s) dropped from addrQueue(%s)", tx.Hash.String(), tx.FromStr)
-		return dropReason, false
+		log.Infof("AddTx tx(%s) dropped from addrQueue(%s)", tx.HashStr, tx.FromStr)
+		return repTx, dropReason, false
 	}
 
 	// Update the EfficiencyList (if needed)
 	if prevReadyTx != nil {
-		log.Infof("AddTx prevReadyTx(%s) nonce(%d) cost(%s) deleted from EfficiencyList", prevReadyTx.Hash.String(), prevReadyTx.Nonce, prevReadyTx.Cost.String())
+		log.Infof("AddTx prevReadyTx(%s) nonce(%d) cost(%s) deleted from EfficiencyList", prevReadyTx.HashStr, prevReadyTx.Nonce, prevReadyTx.Cost.String())
 		w.efficiencyList.delete(prevReadyTx)
 	}
 	if newReadyTx != nil {
-		log.Infof("AddTx newReadyTx(%s) nonce(%d) cost(%s) added to EfficiencyList", newReadyTx.Hash.String(), newReadyTx.Nonce, newReadyTx.Cost.String())
+		log.Infof("AddTx newReadyTx(%s) nonce(%d) cost(%s) added to EfficiencyList", newReadyTx.HashStr, newReadyTx.Nonce, newReadyTx.Cost.String())
 		w.efficiencyList.add(newReadyTx)
 	}
 
-	return nil, true
+	if repTx != nil {
+		log.Infof("AddTx replacedTx(%s) nonce(%d) cost(%s) has been replaced", repTx.HashStr, repTx.Nonce, repTx.Cost.String())
+	}
+
+	return repTx, nil, true
 }
 
 func (w *Worker) applyAddressUpdate(from common.Address, fromNonce *uint64, fromBalance *big.Int) (*TxTracker, *TxTracker, []*TxTracker) {

--- a/sequencer/worker_test.go
+++ b/sequencer/worker_test.go
@@ -61,7 +61,7 @@ func processWorkerAddTxTestCases(t *testing.T, worker *Worker, testCases []worke
 			tx.updateZKCounters(testCase.counters, worker.batchConstraints, worker.batchResourceWeights)
 			t.Logf("%s=%s", testCase.name, fmt.Sprintf("%.2f", tx.Efficiency))
 
-			err, _ := worker.AddTxTracker(ctx, &tx)
+			_, err, _ := worker.AddTxTracker(ctx, &tx)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes a problem when adding a tx to an AddrQueue and a tx with the same nonce already exists for this address. In this case the tx with best gasPrice is kept in memory (AddrQueue) and the other is "discarded". The problem is that this discarded tx is not updated in the db as "failed". This causes to have tx in the pool with "pending" state forever and never are processed

### Reviewers

Main reviewers:
- @Psykepro 
- @ARR552 