### PR TITLE
improve: adding check to skip appending effectivePercentage if current forkId is under 5.

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	oneHundred                     = 100
-	pendingTxsBufferSizeMultiplier = 10
+	oneHundred                            = 100
+	pendingTxsBufferSizeMultiplier        = 10
+	forkId5                        uint64 = 5
 )
 
 var (
@@ -554,7 +555,6 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker) (errW
 				}
 			}
 		}
-
 		log.Infof("calculated breakEvenGasPrice: %d, gasPrice: %d, effectivePercentage: %d for tx: %s", tx.BreakEvenGasPrice, tx.GasPrice, effectivePercentage, tx.HashStr)
 
 		// If EGP is disabled we use tx GasPrice (MaxEffectivePercentage=255)
@@ -568,7 +568,10 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker) (errW
 			return nil, err
 		}
 
-		f.processRequest.Transactions = append(f.processRequest.Transactions, effectivePercentageAsDecodedHex...)
+		forkId := f.dbManager.GetForkIDByBatchNumber(f.processRequest.BatchNumber)
+		if forkId >= forkId5 {
+			f.processRequest.Transactions = append(f.processRequest.Transactions, effectivePercentageAsDecodedHex...)
+		}
 	} else {
 		f.processRequest.Transactions = []byte{}
 	}

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -1511,6 +1511,7 @@ func Test_processTransaction(t *testing.T) {
 			executorMock.On("ProcessBatch", tc.ctx, mock.Anything, true).Return(tc.expectedResponse, tc.executorErr).Once()
 			if tc.executorErr == nil {
 				workerMock.On("DeleteTx", tc.tx.Hash, tc.tx.From).Return().Once()
+				dbManagerMock.On("GetForkIDByBatchNumber", mock.Anything).Return(forkId5)
 			}
 			if tc.expectedErr == nil {
 				workerMock.On("UpdateAfterSingleSuccessfulTxExecution", tc.tx.From, tc.expectedResponse.ReadWriteAddresses).Return([]*TxTracker{}).Once()


### PR DESCRIPTION
Closes #2274 

### What does this PR do?
Adding check to skip appending effectivePercentage if current forkId is under 5.

### Reviewers

Main reviewers:
- @agnusmor 
- @ARR552 