### PR TITLE
[Rehashing] Check logs order and fix blockhash and blockNumber in the log conversion

### DIFF
--- a/state/converters.go
+++ b/state/converters.go
@@ -198,10 +198,8 @@ func convertToLog(protoLogs []*pb.Log) []*types.Log {
 		log.Address = common.HexToAddress(protoLog.Address)
 		log.Topics = convertToTopics(protoLog.Topics)
 		log.Data = protoLog.Data
-		log.BlockNumber = protoLog.BatchNumber
 		log.TxHash = common.BytesToHash(protoLog.TxHash)
 		log.TxIndex = uint(protoLog.TxIndex)
-		log.BlockHash = common.BytesToHash(protoLog.BatchHash)
 		log.Index = uint(protoLog.Index)
 		logs = append(logs, log)
 	}

--- a/state/helper.go
+++ b/state/helper.go
@@ -338,6 +338,7 @@ func toPostgresInterval(duration string) (string, error) {
 	return fmt.Sprintf("%s %s", duration[:len(duration)-1], pgUnit), nil
 }
 
+// CheckLogOrder checks the order of the logs. The order should be incremental
 func CheckLogOrder(logs []*types.Log) bool {
 	logsAux := make([]*types.Log, len(logs))
 	copy(logsAux, logs)

--- a/state/helper.go
+++ b/state/helper.go
@@ -3,6 +3,7 @@ package state
 import (
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 
 	"github.com/0xPolygonHermez/zkevm-node/hex"
@@ -335,4 +336,22 @@ func toPostgresInterval(duration string) (string, error) {
 	}
 
 	return fmt.Sprintf("%s %s", duration[:len(duration)-1], pgUnit), nil
+}
+
+func CheckLogOrder(logs []*types.Log) bool {
+	logsAux := make([]*types.Log, len(logs))
+	copy(logsAux, logs)
+	sort.Slice(logsAux, func(i, j int) bool {
+		return logsAux[i].Index < logsAux[j].Index
+	})
+	if len(logs) != len(logsAux) {
+		return false
+	}
+	for i := range logs {
+		if logsAux[i].Index != logs[i].Index {
+			log.Debug("Array index: ", i, ". Index of log on each array: ", logsAux[i].Index, logs[i].Index)
+			return false
+		}
+	}
+	return true
 }

--- a/state/helper_test.go
+++ b/state/helper_test.go
@@ -212,35 +212,35 @@ func TestMaliciousTransaction(t *testing.T) {
 }
 
 func TestCheckLogOrder(t *testing.T) {
-	log1:= types.Log {
-		Index: 4,
+	log1 := types.Log{
+		Index:   4,
 		Address: common.HexToAddress("0x04"),
 	}
-	log2:= types.Log {
-		Index: 0,
+	log2 := types.Log{
+		Index:   0,
 		Address: common.HexToAddress("0x00"),
 	}
-	log3:= types.Log {
-		Index: 3,
+	log3 := types.Log{
+		Index:   3,
 		Address: common.HexToAddress("0x03"),
 	}
-	log4:= types.Log {
-		Index: 5,
+	log4 := types.Log{
+		Index:   5,
 		Address: common.HexToAddress("0x05"),
 	}
-	log5:= types.Log {
-		Index: 1,
+	log5 := types.Log{
+		Index:   1,
 		Address: common.HexToAddress("0x01"),
 	}
-	log6:= types.Log {
-		Index: 2,
+	log6 := types.Log{
+		Index:   2,
 		Address: common.HexToAddress("0x02"),
 	}
-	logs := []*types.Log {&log1,&log2,&log3,&log4,&log5,&log6}
+	logs := []*types.Log{&log1, &log2, &log3, &log4, &log5, &log6}
 	ok := state.CheckLogOrder(logs)
 	assert.Equal(t, false, ok)
 
-	logs = []*types.Log {&log2,&log5,&log6,&log3,&log1,&log4}
+	logs = []*types.Log{&log2, &log5, &log6, &log3, &log1, &log4}
 	ok = state.CheckLogOrder(logs)
 	assert.Equal(t, true, ok)
 }

--- a/state/helper_test.go
+++ b/state/helper_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/state"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,4 +209,38 @@ func TestMaliciousTransaction(t *testing.T) {
 	_, _, _, err = state.DecodeTxs(b, forkID4)
 	require.Error(t, err)
 	require.Equal(t, err, state.ErrInvalidData)
+}
+
+func TestCheckLogOrder(t *testing.T) {
+	log1:= types.Log {
+		Index: 4,
+		Address: common.HexToAddress("0x04"),
+	}
+	log2:= types.Log {
+		Index: 0,
+		Address: common.HexToAddress("0x00"),
+	}
+	log3:= types.Log {
+		Index: 3,
+		Address: common.HexToAddress("0x03"),
+	}
+	log4:= types.Log {
+		Index: 5,
+		Address: common.HexToAddress("0x05"),
+	}
+	log5:= types.Log {
+		Index: 1,
+		Address: common.HexToAddress("0x01"),
+	}
+	log6:= types.Log {
+		Index: 2,
+		Address: common.HexToAddress("0x02"),
+	}
+	logs := []*types.Log {&log1,&log2,&log3,&log4,&log5,&log6}
+	ok := state.CheckLogOrder(logs)
+	assert.Equal(t, false, ok)
+
+	logs = []*types.Log {&log2,&log5,&log6,&log3,&log1,&log4}
+	ok = state.CheckLogOrder(logs)
+	assert.Equal(t, true, ok)
 }

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -174,6 +174,9 @@ func (s *State) StoreTransactions(ctx context.Context, batchNumber uint64, proce
 		transactions := []*types.Transaction{&processedTx.Tx}
 
 		receipt := generateReceipt(header.Number, processedTx)
+		if !CheckLogOrder(receipt.Logs) {
+			return fmt.Errorf("error: logs received from executor are not in order")
+		}
 		receipts := []*types.Receipt{receipt}
 
 		// Create block to be able to calculate its hash


### PR DESCRIPTION
Closes #2279

### What does this PR do?

This PR fixes a problem with the blockhash and the blocknumber in the log struct before adding the tx to db.
Also adds a check to identify if the logs received from the executor are ordered. If not error

### Reviewers

- @agnusmor 
- @Psykepro 
- @ToniRamirezM 