### PR TITLE
patch: adding print for X-Real-IP in JSON-RPC

### DIFF
--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -803,6 +803,10 @@ func (e *EthEndpoints) SendRawTransaction(httpRequest *http.Request, input strin
 		ip := ""
 		ips := httpRequest.Header.Get("X-Forwarded-For")
 
+		// TODO: this is temporary patch remove this log
+		realIp := httpRequest.Header.Get("X-Real-IP")
+		log.Infof("X-Forwarded-For: %s, X-Real-IP: %s", ips, realIp)
+
 		if ips != "" {
 			ip = strings.Split(ips, ",")[0]
 		}


### PR DESCRIPTION
Related to #2284.

### What does this PR do?

Add print for `X-Real-IP` HTTP Header in JSON-RPC.

### Reviewers
- @agnusmor 
- @ARR552 