### PR TITLE
`Worker`'s `AddTxTracker` Bug Fix

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -60,14 +60,15 @@ type finalizer struct {
 	maxBreakEvenGasPriceDeviationPercentage *big.Int
 	defaultMinGasPriceAllowed               uint64
 	// Processed txs
-	pendingTransactionsToStore    chan transactionToStore
-	pendingTransactionsToStoreWG  *sync.WaitGroup
-	pendingTransactionsToStoreMux *sync.RWMutex
-	storedFlushID                 uint64
-	storedFlushIDCond             *sync.Cond
-	proverID                      string
-	lastPendingFlushID            uint64
-	pendingFlushIDCond            *sync.Cond
+	pendingTxsToStore            chan transactionToStore
+	pendingTxsToStoreWG          *sync.WaitGroup
+	pendingTxsToStoreMux         *sync.RWMutex
+	pendingTxsPerAddressTrackers map[common.Address]*pendingTxPerAddressTracker
+	storedFlushID                uint64
+	storedFlushIDCond            *sync.Cond
+	proverID                     string
+	lastPendingFlushID           uint64
+	pendingFlushIDCond           *sync.Cond
 }
 
 type transactionToStore struct {
@@ -113,7 +114,8 @@ func newFinalizer(
 	closingSignalCh ClosingSignalCh,
 	batchConstraints batchConstraints,
 	eventLog *event.EventLog,
-	pendingTransactionsToStoreWG *sync.WaitGroup,
+	pendingTxsToStoreMux *sync.RWMutex,
+	pendingTxsPerAddressTrackers map[common.Address]*pendingTxPerAddressTracker,
 ) *finalizer {
 	return &finalizer{
 		cfg:                  cfg,
@@ -140,9 +142,10 @@ func newFinalizer(
 		// event log
 		eventLog:                                eventLog,
 		maxBreakEvenGasPriceDeviationPercentage: new(big.Int).SetUint64(effectiveGasPriceCfg.MaxBreakEvenGasPriceDeviationPercentage),
-		pendingTransactionsToStore:              make(chan transactionToStore, batchConstraints.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
-		pendingTransactionsToStoreWG:            pendingTransactionsToStoreWG,
-		pendingTransactionsToStoreMux:           &sync.RWMutex{},
+		pendingTxsToStore:                       make(chan transactionToStore, batchConstraints.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
+		pendingTxsToStoreWG:                     new(sync.WaitGroup),
+		pendingTxsToStoreMux:                    pendingTxsToStoreMux,
+		pendingTxsPerAddressTrackers:            pendingTxsPerAddressTrackers,
 		storedFlushID:                           0,
 		// Mutex is unlocked when the condition is broadcasted
 		storedFlushIDCond:  sync.NewCond(&sync.Mutex{}),
@@ -396,7 +399,7 @@ func (f *finalizer) checkProverIDAndUpdateStoredFlushID(storedFlushID uint64, pr
 func (f *finalizer) storePendingTransactions(ctx context.Context) {
 	for {
 		select {
-		case tx, ok := <-f.pendingTransactionsToStore:
+		case tx, ok := <-f.pendingTxsToStore:
 			if !ok {
 				// Channel is closed
 				return
@@ -416,10 +419,19 @@ func (f *finalizer) storePendingTransactions(ctx context.Context) {
 
 			// Now f.storedFlushID >= tx.flushId, you can store tx
 			f.storeProcessedTx(ctx, tx)
-			f.pendingTransactionsToStoreWG.Done()
+			f.pendingTxsToStoreMux.Lock()
+			f.pendingTxsToStoreWG.Done()
+			f.pendingTxsPerAddressTrackers[tx.txTracker.From].wg.Done()
+			f.pendingTxsPerAddressTrackers[tx.txTracker.From].count--
+			// Needed to avoid memory leaks
+			if f.pendingTxsPerAddressTrackers[tx.txTracker.From].count == 0 {
+				delete(f.pendingTxsPerAddressTrackers, tx.txTracker.From)
+			}
+			f.pendingTxsToStoreMux.Unlock()
+
 		case <-ctx.Done():
 			// The context was cancelled from outside, Wait for all goroutines to finish, cleanup and exit
-			f.pendingTransactionsToStoreWG.Wait()
+			f.pendingTxsToStoreWG.Wait()
 			return
 		default:
 			time.Sleep(100 * time.Millisecond) //nolint:gomnd
@@ -434,7 +446,7 @@ func (f *finalizer) newWIPBatch(ctx context.Context) (*WipBatch, error) {
 
 	// Wait until all processed transactions are saved
 	startWait := time.Now()
-	f.pendingTransactionsToStoreWG.Wait()
+	f.pendingTxsToStoreWG.Wait()
 	endWait := time.Now()
 
 	log.Info("waiting for pending transactions to be stored took: ", endWait.Sub(startWait).String())
@@ -673,18 +685,18 @@ func (f *finalizer) handleProcessTransactionResponse(ctx context.Context, tx *Tx
 		flushId:       result.FlushID,
 	}
 
-	f.pendingTransactionsToStoreMux.Lock()
-	f.pendingTransactionsToStoreWG.Add(1)
+	f.pendingTxsToStoreMux.Lock()
+	f.pendingTxsToStoreWG.Add(1)
 	if result.FlushID > f.lastPendingFlushID {
 		f.lastPendingFlushID = result.FlushID
 		f.pendingFlushIDCond.Broadcast()
 	}
-	f.pendingTransactionsToStoreMux.Unlock()
+	f.pendingTxsToStoreMux.Unlock()
 	select {
-	case f.pendingTransactionsToStore <- processedTransaction:
+	case f.pendingTxsToStore <- processedTransaction:
 	case <-ctx.Done():
 		// If context is cancelled before we can send to the channel, we must decrement the WaitGroup count
-		f.pendingTransactionsToStoreWG.Done()
+		f.pendingTxsToStoreWG.Done()
 	}
 
 	f.batch.countOfTxs++
@@ -722,26 +734,35 @@ func (f *finalizer) handleForcedTxsProcessResp(ctx context.Context, request stat
 			flushId:       result.FlushID,
 		}
 
-		f.pendingTransactionsToStoreMux.Lock()
-		f.pendingTransactionsToStoreWG.Add(1)
+		f.pendingTxsToStoreMux.Lock()
+		f.pendingTxsToStoreWG.Add(1)
 		if result.FlushID > f.lastPendingFlushID {
 			f.lastPendingFlushID = result.FlushID
 			f.pendingFlushIDCond.Broadcast()
 		}
-		f.pendingTransactionsToStoreMux.Unlock()
+		f.pendingTxsToStoreMux.Unlock()
 		oldStateRoot = txResp.StateRoot
 
 		select {
-		case f.pendingTransactionsToStore <- processedTransaction:
+		case f.pendingTxsToStore <- processedTransaction:
 		case <-ctx.Done():
 			// If context is cancelled before we can send to the channel, we must decrement the WaitGroup count
-			f.pendingTransactionsToStoreWG.Done()
+			f.pendingTxsToStoreWG.Done()
 		}
 	}
 }
 
 // storeProcessedTx stores the processed transaction in the database.
 func (f *finalizer) storeProcessedTx(ctx context.Context, txToStore transactionToStore) {
+	f.pendingTxsToStoreMux.Lock()
+	if _, ok := f.pendingTxsPerAddressTrackers[txToStore.txTracker.From]; !ok {
+		f.pendingTxsPerAddressTrackers[txToStore.txTracker.From] = new(pendingTxPerAddressTracker)
+		f.pendingTxsPerAddressTrackers[txToStore.txTracker.From].wg = &sync.WaitGroup{}
+	}
+	f.pendingTxsPerAddressTrackers[txToStore.txTracker.From].wg.Add(1)
+	f.pendingTxsPerAddressTrackers[txToStore.txTracker.From].count++
+	f.pendingTxsToStoreMux.Unlock()
+
 	if txToStore.response != nil {
 		log.Infof("storeProcessedTx: storing processed txToStore: %s", txToStore.response.TxHash.String())
 	} else {

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -113,6 +113,7 @@ func newFinalizer(
 	closingSignalCh ClosingSignalCh,
 	batchConstraints batchConstraints,
 	eventLog *event.EventLog,
+	pendingTransactionsToStoreWG *sync.WaitGroup,
 ) *finalizer {
 	return &finalizer{
 		cfg:                  cfg,
@@ -140,7 +141,7 @@ func newFinalizer(
 		eventLog:                                eventLog,
 		maxBreakEvenGasPriceDeviationPercentage: new(big.Int).SetUint64(effectiveGasPriceCfg.MaxBreakEvenGasPriceDeviationPercentage),
 		pendingTransactionsToStore:              make(chan transactionToStore, batchConstraints.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
-		pendingTransactionsToStoreWG:            new(sync.WaitGroup),
+		pendingTransactionsToStoreWG:            pendingTransactionsToStoreWG,
 		pendingTransactionsToStoreMux:           &sync.RWMutex{},
 		storedFlushID:                           0,
 		// Mutex is unlocked when the condition is broadcasted

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -118,7 +118,8 @@ func TestNewFinalizer(t *testing.T) {
 	dbManagerMock.On("GetLastSentFlushID", context.Background()).Return(uint64(0), nil)
 
 	// arrange and act
-	f = newFinalizer(cfg, effectiveGasPriceCfg, workerMock, dbManagerMock, executorMock, seqAddr, isSynced, closingSignalCh, bc, eventLog)
+	pendingTxsToStore := new(sync.WaitGroup)
+	f = newFinalizer(cfg, effectiveGasPriceCfg, workerMock, dbManagerMock, executorMock, seqAddr, isSynced, closingSignalCh, bc, eventLog, pendingTxsToStore)
 
 	// assert
 	assert.NotNil(t, f)

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -118,8 +118,9 @@ func TestNewFinalizer(t *testing.T) {
 	dbManagerMock.On("GetLastSentFlushID", context.Background()).Return(uint64(0), nil)
 
 	// arrange and act
-	pendingTxsToStore := new(sync.WaitGroup)
-	f = newFinalizer(cfg, effectiveGasPriceCfg, workerMock, dbManagerMock, executorMock, seqAddr, isSynced, closingSignalCh, bc, eventLog, pendingTxsToStore)
+	pendingTxsToStoreMux := new(sync.RWMutex)
+	pendingTxsPerAddressTrackers := make(map[common.Address]*pendingTxPerAddressTracker)
+	f = newFinalizer(cfg, effectiveGasPriceCfg, workerMock, dbManagerMock, executorMock, seqAddr, isSynced, closingSignalCh, bc, eventLog, pendingTxsToStoreMux, pendingTxsPerAddressTrackers)
 
 	// assert
 	assert.NotNil(t, f)
@@ -269,14 +270,14 @@ func TestFinalizer_handleProcessTransactionResponse(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			storedTxs := make([]transactionToStore, 0)
-			f.pendingTransactionsToStore = make(chan transactionToStore)
+			f.pendingTxsToStore = make(chan transactionToStore)
 
 			if tc.expectedStoredTx.batchResponse != nil {
 				done = make(chan bool) // init a new done channel
 				go func() {
-					for tx := range f.pendingTransactionsToStore {
+					for tx := range f.pendingTxsToStore {
 						storedTxs = append(storedTxs, tx)
-						f.pendingTransactionsToStoreWG.Done()
+						f.pendingTxsToStoreWG.Done()
 					}
 					done <- true // signal that the goroutine is done
 				}()
@@ -312,9 +313,9 @@ func TestFinalizer_handleProcessTransactionResponse(t *testing.T) {
 			}
 
 			if tc.expectedStoredTx.batchResponse != nil {
-				close(f.pendingTransactionsToStore) // close the channel
-				<-done                              // wait for the goroutine to finish
-				f.pendingTransactionsToStoreWG.Wait()
+				close(f.pendingTxsToStore) // close the channel
+				<-done                     // wait for the goroutine to finish
+				f.pendingTxsToStoreWG.Wait()
 				require.Len(t, storedTxs, 1)
 				actualTx := storedTxs[0]
 				assertEqualTransactionToStore(t, tc.expectedStoredTx, actualTx)
@@ -894,13 +895,13 @@ func TestFinalizer_processForcedBatches(t *testing.T) {
 			var newStateRoot common.Hash
 			stateRoot := oldHash
 			storedTxs := make([]transactionToStore, 0)
-			f.pendingTransactionsToStore = make(chan transactionToStore)
+			f.pendingTxsToStore = make(chan transactionToStore)
 			if tc.expectedStoredTx != nil && len(tc.expectedStoredTx) > 0 {
 				done = make(chan bool) // init a new done channel
 				go func() {
-					for tx := range f.pendingTransactionsToStore {
+					for tx := range f.pendingTxsToStore {
 						storedTxs = append(storedTxs, tx)
-						f.pendingTransactionsToStoreWG.Done()
+						f.pendingTxsToStoreWG.Done()
 					}
 					done <- true // signal that the goroutine is done
 				}()
@@ -958,9 +959,9 @@ func TestFinalizer_processForcedBatches(t *testing.T) {
 				assert.EqualError(t, err, tc.expectedErr.Error())
 			} else {
 				if tc.expectedStoredTx != nil && len(tc.expectedStoredTx) > 0 {
-					close(f.pendingTransactionsToStore) // ensure the channel is closed
-					<-done                              // wait for the goroutine to finish
-					f.pendingTransactionsToStoreWG.Wait()
+					close(f.pendingTxsToStore) // ensure the channel is closed
+					<-done                     // wait for the goroutine to finish
+					f.pendingTxsToStoreWG.Wait()
 					for i := range tc.expectedStoredTx {
 						require.Equal(t, tc.expectedStoredTx[i], storedTxs[i])
 					}
@@ -1495,13 +1496,13 @@ func Test_processTransaction(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			storedTxs := make([]transactionToStore, 0)
-			f.pendingTransactionsToStore = make(chan transactionToStore, 1)
+			f.pendingTxsToStore = make(chan transactionToStore, 1)
 			if tc.expectedStoredTx.batchResponse != nil {
 				done = make(chan bool) // init a new done channel
 				go func() {
-					for tx := range f.pendingTransactionsToStore {
+					for tx := range f.pendingTxsToStore {
 						storedTxs = append(storedTxs, tx)
-						f.pendingTransactionsToStoreWG.Done()
+						f.pendingTxsToStoreWG.Done()
 					}
 					done <- true // signal that the goroutine is done
 				}()
@@ -1524,9 +1525,9 @@ func Test_processTransaction(t *testing.T) {
 			errWg, err := f.processTransaction(tc.ctx, tc.tx)
 
 			if tc.expectedStoredTx.batchResponse != nil {
-				close(f.pendingTransactionsToStore) // ensure the channel is closed
-				<-done                              // wait for the goroutine to finish
-				f.pendingTransactionsToStoreWG.Wait()
+				close(f.pendingTxsToStore) // ensure the channel is closed
+				<-done                     // wait for the goroutine to finish
+				f.pendingTxsToStoreWG.Wait()
 				require.Equal(t, tc.expectedStoredTx, storedTxs[0])
 			}
 			if tc.expectedErr != nil {
@@ -1680,19 +1681,19 @@ func Test_handleForcedTxsProcessResp(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			storedTxs := make([]transactionToStore, 0)
-			f.pendingTransactionsToStore = make(chan transactionToStore)
+			f.pendingTxsToStore = make(chan transactionToStore)
 
 			// Mock storeProcessedTx to store txs into the storedTxs slice
 			go func() {
-				for tx := range f.pendingTransactionsToStore {
+				for tx := range f.pendingTxsToStore {
 					storedTxs = append(storedTxs, tx)
-					f.pendingTransactionsToStoreWG.Done()
+					f.pendingTxsToStoreWG.Done()
 				}
 			}()
 
 			f.handleForcedTxsProcessResp(ctx, tc.request, tc.result, tc.oldStateRoot)
 
-			f.pendingTransactionsToStoreWG.Wait()
+			f.pendingTxsToStoreWG.Wait()
 			require.Nil(t, err)
 			require.Equal(t, len(tc.expectedStoredTxs), len(storedTxs))
 			for i := 0; i < len(tc.expectedStoredTxs); i++ {
@@ -1734,6 +1735,9 @@ func TestFinalizer_storeProcessedTx(t *testing.T) {
 				response: &state.ProcessTransactionResponse{
 					TxHash: txHash,
 				},
+				txTracker: &TxTracker{
+					From: senderAddr,
+				},
 				isForcedBatch: false,
 			},
 		},
@@ -1756,6 +1760,9 @@ func TestFinalizer_storeProcessedTx(t *testing.T) {
 					TxHash: txHash2,
 				},
 				isForcedBatch: true,
+				txTracker: &TxTracker{
+					From: senderAddr,
+				},
 			},
 		},
 	}
@@ -2446,9 +2453,10 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 		handlingL2Reorg:                         false,
 		eventLog:                                eventLog,
 		maxBreakEvenGasPriceDeviationPercentage: big.NewInt(10),
-		pendingTransactionsToStore:              make(chan transactionToStore, bc.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
-		pendingTransactionsToStoreWG:            new(sync.WaitGroup),
-		pendingTransactionsToStoreMux:           new(sync.RWMutex),
+		pendingTxsToStore:                       make(chan transactionToStore, bc.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
+		pendingTxsToStoreWG:                     new(sync.WaitGroup),
+		pendingTxsToStoreMux:                    new(sync.RWMutex),
+		pendingTxsPerAddressTrackers:            make(map[common.Address]*pendingTxPerAddressTracker),
 		storedFlushID:                           0,
 		storedFlushIDCond:                       sync.NewCond(new(sync.Mutex)),
 		proverID:                                "",

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -68,6 +68,12 @@ type ClosingSignalCh struct {
 	L2ReorgCh     chan L2ReorgEvent
 }
 
+// pendingTxPerAddressTracker is a struct that tracks the number of pending transactions per address
+type pendingTxPerAddressTracker struct {
+	wg    *sync.WaitGroup
+	count uint
+}
+
 // New init sequencer
 func New(cfg Config, txPool txPool, state stateInterface, etherman etherman, manager ethTxManager, eventLog *event.EventLog) (*Sequencer, error) {
 	addr, err := etherman.TrustedSequencer()
@@ -128,14 +134,14 @@ func (s *Sequencer) Start(ctx context.Context) {
 	if err != nil {
 		log.Fatalf("failed to mark WIP txs as pending, err: %v", err)
 	}
+	pendingTxsToStoreMux := new(sync.RWMutex)
+	pendingTxTrackerPerAddress := make(map[common.Address]*pendingTxPerAddressTracker)
 
-	pendingTxsToStoreWg := new(sync.WaitGroup)
-
-	worker := NewWorker(s.cfg.Worker, s.state, batchConstraints, batchResourceWeights, pendingTxsToStoreWg)
+	worker := NewWorker(s.cfg.Worker, s.state, batchConstraints, batchResourceWeights, pendingTxsToStoreMux, pendingTxTrackerPerAddress)
 	dbManager := newDBManager(ctx, s.cfg.DBManager, s.pool, s.state, worker, closingSignalCh, batchConstraints)
 	go dbManager.Start()
 
-	finalizer := newFinalizer(s.cfg.Finalizer, s.cfg.EffectiveGasPrice, worker, dbManager, s.state, s.address, s.isSynced, closingSignalCh, batchConstraints, s.eventLog, pendingTxsToStoreWg)
+	finalizer := newFinalizer(s.cfg.Finalizer, s.cfg.EffectiveGasPrice, worker, dbManager, s.state, s.address, s.isSynced, closingSignalCh, batchConstraints, s.eventLog, pendingTxsToStoreMux, pendingTxTrackerPerAddress)
 	currBatch, processingReq := s.bootstrap(ctx, dbManager, finalizer)
 	go finalizer.Start(ctx, currBatch, processingReq)
 

--- a/sequencer/worker_test.go
+++ b/sequencer/worker_test.go
@@ -308,7 +308,9 @@ func TestWorkerGetBestTx(t *testing.T) {
 }
 
 func initWorker(stateMock *StateMock, rcMax batchConstraints, rcWeigth batchResourceWeights) *Worker {
-	pendingTxsToStore := new(sync.WaitGroup)
-	worker := NewWorker(workerCfg, stateMock, rcMax, rcWeigth, pendingTxsToStore)
+	pendingTxsToStoreMux := new(sync.RWMutex)
+	pendingTxsPerAddressTrackers := make(map[common.Address]*pendingTxPerAddressTracker)
+	worker := NewWorker(workerCfg, stateMock, rcMax, rcWeigth, pendingTxsToStoreMux, pendingTxsPerAddressTrackers)
+
 	return worker
 }

--- a/sequencer/worker_test.go
+++ b/sequencer/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/state"
@@ -307,6 +308,7 @@ func TestWorkerGetBestTx(t *testing.T) {
 }
 
 func initWorker(stateMock *StateMock, rcMax batchConstraints, rcWeigth batchResourceWeights) *Worker {
-	worker := NewWorker(workerCfg, stateMock, rcMax, rcWeigth)
+	pendingTxsToStore := new(sync.WaitGroup)
+	worker := NewWorker(workerCfg, stateMock, rcMax, rcWeigth, pendingTxsToStore)
 	return worker
 }

--- a/synchronizer/mock_state.go
+++ b/synchronizer/mock_state.go
@@ -711,12 +711,13 @@ func (_m *stateMock) UpdateForkIDIntervals(intervals []state.ForkIDInterval) {
 	_m.Called(intervals)
 }
 
-// newStateMock creates a new instance of stateMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-// The first argument is typically a *testing.T value.
-func newStateMock(t interface {
+type mockConstructorTestingTnewStateMock interface {
 	mock.TestingT
 	Cleanup(func())
-}) *stateMock {
+}
+
+// newStateMock creates a new instance of stateMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+func newStateMock(t mockConstructorTestingTnewStateMock) *stateMock {
 	mock := &stateMock{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
Closes #2342. Related #2342 

### What does this PR do?

This PR resolves a bug in the `Worker`'s `AddTxTracker` function, which leads to disruptions in the transaction sequences and can cause data inconsistencies.

Previously, an `AddrQueue` for an address was created right after its transactions had expired, but before pending transactions were stored. This incorrect initialization of `AddrQueue` was the root cause of the issue.

To address this issue, instead of sharing `pendingTransactionsToStoreWG`, a new shared `pendingTxsPerAddressTrackers map[common.Address]*pendingTxPerAddressTracker` has been created to keep track of the pending transactions per address. This way, we ensure to wait only for the transactions to a particular address before initiating a new `AddrQueue`. The structure `pendingTxPerAddressTracker` includes a WaitGroup (`wg`) and a counter (`count`) to track the number of pending transactions per address and delete the tracker when not needed, preventing any potential memory leaks.

The `pendingTxPerAddressTracker` struct is defined as:
```go
type pendingTxPerAddressTracker struct {
	wg    *sync.WaitGroup
	count uint
}
```
### Reviewers
- @ToniRamirezM 
- @agnusmor 