### PR TITLE
Store batchL2Data when the batch is opened

### DIFF
--- a/state/batch.go
+++ b/state/batch.go
@@ -44,6 +44,7 @@ type ProcessingContext struct {
 	Timestamp      time.Time
 	GlobalExitRoot common.Hash
 	ForcedBatchNum *uint64
+	BatchL2Data    *[]byte
 }
 
 // ClosingReason represents the reason why a batch is closed.

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -964,7 +964,7 @@ func (p *PostgresStorage) storeGenesisBatch(ctx context.Context, batch Batch, db
 // in this batch yet. In other words it's the creation of a WIP batch.
 // Note that this will add a batch with batch number N + 1, where N it's the greatest batch number on the state.
 func (p *PostgresStorage) openBatch(ctx context.Context, batchContext ProcessingContext, dbTx pgx.Tx) error {
-	const openBatchSQL = "INSERT INTO state.batch (batch_num, global_exit_root, timestamp, coinbase, forced_batch_num) VALUES ($1, $2, $3, $4, $5)"
+	const openBatchSQL = "INSERT INTO state.batch (batch_num, global_exit_root, timestamp, coinbase, forced_batch_num, raw_txs_data) VALUES ($1, $2, $3, $4, $5, $6)"
 
 	e := p.getExecQuerier(dbTx)
 	_, err := e.Exec(
@@ -974,6 +974,7 @@ func (p *PostgresStorage) openBatch(ctx context.Context, batchContext Processing
 		batchContext.Timestamp.UTC(),
 		batchContext.Coinbase.String(),
 		batchContext.ForcedBatchNum,
+		batchContext.BatchL2Data,
 	)
 	return err
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -1455,11 +1455,13 @@ func (s *ClientSynchronizer) processAndStoreTxs(trustedBatch *types.Batch, reque
 
 func (s *ClientSynchronizer) openBatch(trustedBatch *types.Batch, dbTx pgx.Tx) error {
 	log.Debugf("Opening batch %d", trustedBatch.Number)
+	var batchL2Data []byte = trustedBatch.BatchL2Data
 	processCtx := state.ProcessingContext{
 		BatchNumber:    uint64(trustedBatch.Number),
 		Coinbase:       common.HexToAddress(trustedBatch.Coinbase.String()),
 		Timestamp:      time.Unix(int64(trustedBatch.Timestamp), 0),
 		GlobalExitRoot: trustedBatch.GlobalExitRoot,
+		BatchL2Data:    &batchL2Data,
 	}
 	if trustedBatch.ForcedBatchNumber != nil {
 		fb := uint64(*trustedBatch.ForcedBatchNumber)

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -697,6 +697,7 @@ func expectedCallsForsyncTrustedState(t *testing.T, m *mocks, sync *ClientSynchr
 		Coinbase:       common.HexToAddress(batchInTrustedNode.Coinbase.String()),
 		Timestamp:      time.Unix(int64(batchInTrustedNode.Timestamp), 0),
 		GlobalExitRoot: batchInTrustedNode.GlobalExitRoot,
+		BatchL2Data:    (*[]byte)(&batchInTrustedNode.BatchL2Data),
 	}
 	m.State.
 		On("OpenBatch", sync.ctx, processCtx, m.DbTx).


### PR DESCRIPTION
Closes #2357

### What does this PR do?

Stores the batchL2Data when the batch is open and contains txs

### Reviewers

- @joanestebanr 
- @ToniRamirezM 