### PR TITLE
bugfix: fixing finalizer's `lastPendingFlushId` handling."

### DIFF
--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -2487,6 +2487,6 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 		storedFlushIDCond:                       sync.NewCond(new(sync.Mutex)),
 		proverID:                                "",
 		lastPendingFlushID:                      0,
-		pendingFlushIDCond:                      sync.NewCond(new(sync.Mutex)),
+		pendingFlushIDChan:                      make(chan uint64, bc.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
 	}
 }


### PR DESCRIPTION
Related #2343

### What does this PR do?

Fixing finalizer's `lastPendingFlushId` handling. By replacing the `sync.Cond` with a channel. And improving some logs.
 
### Reviewers
- @ToniRamirezM 
