### PR TITLE
Increment gas price with at least 10%

### DIFF
--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -24,7 +24,7 @@ const (
 	// maxHistorySize           = 10
 
 	// The minimum factor by which we must increase gas price in a replacement transaction.
-	minGasPriceIncreaseNumerator = 11
+	minGasPriceIncreaseNumerator   = 11
 	minGasPriceIncreaseDenominator = 10
 	// A small buffer, in WEI, added to the gas price after increasing by minGasPriceIncrease, to
 	// offset rounding errors.


### PR DESCRIPTION
Many RPC and miner implementations automatically discard replacement transactions where the gas price is not increased by at least 10%. If this happens, the ethtxmanager can end up adding transactions to the history of a monitored transaction that have no effect, until the history size limit is quickly reached and the monitored transaction is considered failed.