### PR TITLE
updated docker compose command in Makefile for testing

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-DOCKERCOMPOSE := docker-compose -f docker-compose.yml
+DOCKERCOMPOSE := docker compose -f docker-compose.yml
 DOCKERCOMPOSEAPPSEQ := zkevm-sequencer
 DOCKERCOMPOSEAPPSEQSENDER := zkevm-sequence-sender
 DOCKERCOMPOSEAPPL2GASP := zkevm-l2gaspricer


### PR DESCRIPTION
### What does this PR do?
The Makefile in the test folder uses the old calling convention of docker compose see with a dash, the pull request fixes this see: https://docs.docker.com/compose/migrate/ 


### Main reviewers:
    @ToniRamirezM 
    @ARR552 
