### PR TITLE
Feature/2362 state use field batch l2data of processing context v2

### DIFF
--- a/state/batch.go
+++ b/state/batch.go
@@ -482,7 +482,7 @@ func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx Pr
 		StateRoot:     processedBatch.NewStateRoot,
 		LocalExitRoot: processedBatch.NewLocalExitRoot,
 		AccInputHash:  processedBatch.NewAccInputHash,
-		BatchL2Data:   *processingCtx.BatchL2Data,
+		BatchL2Data:   *BatchL2Data,
 	}, dbTx)
 }
 

--- a/state/batch.go
+++ b/state/batch.go
@@ -410,10 +410,16 @@ func (s *State) CloseBatch(ctx context.Context, receipt ProcessingReceipt, dbTx 
 // ProcessAndStoreClosedBatch is used by the Synchronizer to add a closed batch into the data base. Values returned are the new stateRoot,
 // the flushID (incremental value returned by executor),
 // the ProverID (executor running ID) the result of closing the batch.
-func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx ProcessingContext, encodedTxs []byte, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error) {
+func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx ProcessingContext, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error) {
+	BatchL2Data := processingCtx.BatchL2Data
+	if BatchL2Data == nil {
+		log.Warnf("Batch %v: ProcessAndStoreClosedBatch: processingCtx.BatchL2Data is nil, assuming is empty", processingCtx.BatchNumber)
+		var BatchL2DataEmpty []byte
+		BatchL2Data = &BatchL2DataEmpty
+	}
 	// Decode transactions
 	forkID := s.GetForkIDByBatchNumber(processingCtx.BatchNumber)
-	decodedTransactions, _, _, err := DecodeTxs(encodedTxs, forkID)
+	decodedTransactions, _, _, err := DecodeTxs(*BatchL2Data, forkID)
 	if err != nil && !errors.Is(err, ErrInvalidData) {
 		log.Debugf("error decoding transactions: %v", err)
 		return common.Hash{}, noFlushID, noProverID, err
@@ -426,7 +432,7 @@ func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx Pr
 	if err := s.OpenBatch(ctx, processingCtx, dbTx); err != nil {
 		return common.Hash{}, noFlushID, noProverID, err
 	}
-	processed, err := s.processBatch(ctx, processingCtx.BatchNumber, encodedTxs, caller, dbTx)
+	processed, err := s.processBatch(ctx, processingCtx.BatchNumber, *BatchL2Data, caller, dbTx)
 	if err != nil {
 		return common.Hash{}, noFlushID, noProverID, err
 	}
@@ -476,7 +482,7 @@ func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx Pr
 		StateRoot:     processedBatch.NewStateRoot,
 		LocalExitRoot: processedBatch.NewLocalExitRoot,
 		AccInputHash:  processedBatch.NewAccInputHash,
-		BatchL2Data:   encodedTxs,
+		BatchL2Data:   *processingCtx.BatchL2Data,
 	}, dbTx)
 }
 

--- a/state/batch.go
+++ b/state/batch.go
@@ -429,6 +429,8 @@ func (s *State) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx Pr
 	if dbTx == nil {
 		return common.Hash{}, noFlushID, noProverID, ErrDBTxNil
 	}
+	// Avoid writing twice to the DB the BatchL2Data that is going to be written also in the call closeBatch
+	processingCtx.BatchL2Data = nil
 	if err := s.OpenBatch(ctx, processingCtx, dbTx); err != nil {
 		return common.Hash{}, noFlushID, noProverID, err
 	}

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -40,7 +40,7 @@ type stateInterface interface {
 	AddVirtualBatch(ctx context.Context, virtualBatch *state.VirtualBatch, dbTx pgx.Tx) error
 	GetNextForcedBatches(ctx context.Context, nextForcedBatches int, dbTx pgx.Tx) ([]state.ForcedBatch, error)
 	AddVerifiedBatch(ctx context.Context, verifiedBatch *state.VerifiedBatch, dbTx pgx.Tx) error
-	ProcessAndStoreClosedBatch(ctx context.Context, processingCtx state.ProcessingContext, encodedTxs []byte, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error)
+	ProcessAndStoreClosedBatch(ctx context.Context, processingCtx state.ProcessingContext, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error)
 	SetGenesis(ctx context.Context, block state.Block, genesis state.Genesis, dbTx pgx.Tx) ([]byte, error)
 	OpenBatch(ctx context.Context, processingContext state.ProcessingContext, dbTx pgx.Tx) error
 	CloseBatch(ctx context.Context, receipt state.ProcessingReceipt, dbTx pgx.Tx) error

--- a/synchronizer/mock_state.go
+++ b/synchronizer/mock_state.go
@@ -516,39 +516,39 @@ func (_m *stateMock) OpenBatch(ctx context.Context, processingContext state.Proc
 	return r0
 }
 
-// ProcessAndStoreClosedBatch provides a mock function with given fields: ctx, processingCtx, encodedTxs, dbTx, caller
-func (_m *stateMock) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx state.ProcessingContext, encodedTxs []byte, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error) {
-	ret := _m.Called(ctx, processingCtx, encodedTxs, dbTx, caller)
+// ProcessAndStoreClosedBatch provides a mock function with given fields: ctx, processingCtx, dbTx, caller
+func (_m *stateMock) ProcessAndStoreClosedBatch(ctx context.Context, processingCtx state.ProcessingContext, dbTx pgx.Tx, caller metrics.CallerLabel) (common.Hash, uint64, string, error) {
+	ret := _m.Called(ctx, processingCtx, dbTx, caller)
 
 	var r0 common.Hash
 	var r1 uint64
 	var r2 string
 	var r3 error
-	if rf, ok := ret.Get(0).(func(context.Context, state.ProcessingContext, []byte, pgx.Tx, metrics.CallerLabel) (common.Hash, uint64, string, error)); ok {
-		return rf(ctx, processingCtx, encodedTxs, dbTx, caller)
+	if rf, ok := ret.Get(0).(func(context.Context, state.ProcessingContext, pgx.Tx, metrics.CallerLabel) (common.Hash, uint64, string, error)); ok {
+		return rf(ctx, processingCtx, dbTx, caller)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, state.ProcessingContext, []byte, pgx.Tx, metrics.CallerLabel) common.Hash); ok {
-		r0 = rf(ctx, processingCtx, encodedTxs, dbTx, caller)
+	if rf, ok := ret.Get(0).(func(context.Context, state.ProcessingContext, pgx.Tx, metrics.CallerLabel) common.Hash); ok {
+		r0 = rf(ctx, processingCtx, dbTx, caller)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, state.ProcessingContext, []byte, pgx.Tx, metrics.CallerLabel) uint64); ok {
-		r1 = rf(ctx, processingCtx, encodedTxs, dbTx, caller)
+	if rf, ok := ret.Get(1).(func(context.Context, state.ProcessingContext, pgx.Tx, metrics.CallerLabel) uint64); ok {
+		r1 = rf(ctx, processingCtx, dbTx, caller)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, state.ProcessingContext, []byte, pgx.Tx, metrics.CallerLabel) string); ok {
-		r2 = rf(ctx, processingCtx, encodedTxs, dbTx, caller)
+	if rf, ok := ret.Get(2).(func(context.Context, state.ProcessingContext, pgx.Tx, metrics.CallerLabel) string); ok {
+		r2 = rf(ctx, processingCtx, dbTx, caller)
 	} else {
 		r2 = ret.Get(2).(string)
 	}
 
-	if rf, ok := ret.Get(3).(func(context.Context, state.ProcessingContext, []byte, pgx.Tx, metrics.CallerLabel) error); ok {
-		r3 = rf(ctx, processingCtx, encodedTxs, dbTx, caller)
+	if rf, ok := ret.Get(3).(func(context.Context, state.ProcessingContext, pgx.Tx, metrics.CallerLabel) error); ok {
+		r3 = rf(ctx, processingCtx, dbTx, caller)
 	} else {
 		r3 = ret.Error(3)
 	}
@@ -711,13 +711,12 @@ func (_m *stateMock) UpdateForkIDIntervals(intervals []state.ForkIDInterval) {
 	_m.Called(intervals)
 }
 
-type mockConstructorTestingTnewStateMock interface {
+// newStateMock creates a new instance of stateMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func newStateMock(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// newStateMock creates a new instance of stateMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func newStateMock(t mockConstructorTestingTnewStateMock) *stateMock {
+}) *stateMock {
 	mock := &stateMock{}
 	mock.Mock.Test(t)
 

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -936,7 +936,6 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 				log.Errorf("error resetting trusted state. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, blockNumber, err)
 				return err
 			}
-			processCtx.BatchL2Data = &batch.BatchL2Data
 			_, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, processCtx, dbTx, stateMetrics.SynchronizerCallerLabel)
 			if err != nil {
 				log.Errorf("error storing trustedBatch. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, blockNumber, err)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -843,6 +843,7 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 			Timestamp:      batch.Timestamp,
 			GlobalExitRoot: batch.GlobalExitRoot,
 			ForcedBatchNum: batch.ForcedBatchNum,
+			BatchL2Data:    &batch.BatchL2Data,
 		}
 
 		var newRoot common.Hash
@@ -853,7 +854,7 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 			if errors.Is(err, state.ErrNotFound) || errors.Is(err, state.ErrStateNotSynchronized) {
 				log.Debugf("BatchNumber: %d, not found in trusted state. Storing it...", batch.BatchNumber)
 				// If it is not found, store batch
-				newStateRoot, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, processCtx, batch.BatchL2Data, dbTx, stateMetrics.SynchronizerCallerLabel)
+				newStateRoot, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, processCtx, dbTx, stateMetrics.SynchronizerCallerLabel)
 				if err != nil {
 					log.Errorf("error storing trustedBatch. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, blockNumber, err)
 					rollbackErr := dbTx.Rollback(s.ctx)
@@ -935,7 +936,8 @@ func (s *ClientSynchronizer) processSequenceBatches(sequencedBatches []etherman.
 				log.Errorf("error resetting trusted state. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, blockNumber, err)
 				return err
 			}
-			_, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, processCtx, batch.BatchL2Data, dbTx, stateMetrics.SynchronizerCallerLabel)
+			processCtx.BatchL2Data = &batch.BatchL2Data
+			_, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, processCtx, dbTx, stateMetrics.SynchronizerCallerLabel)
 			if err != nil {
 				log.Errorf("error storing trustedBatch. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, blockNumber, err)
 				rollbackErr := dbTx.Rollback(s.ctx)
@@ -1058,9 +1060,10 @@ func (s *ClientSynchronizer) processSequenceForceBatch(sequenceForceBatch []ethe
 			Timestamp:      block.ReceivedAt,
 			Coinbase:       fbatch.Coinbase,
 			ForcedBatchNum: &forcedBatches[i].ForcedBatchNumber,
+			BatchL2Data:    &forcedBatches[i].RawTxsData,
 		}
 		// Process batch
-		_, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, batch, forcedBatches[i].RawTxsData, dbTx, stateMetrics.SynchronizerCallerLabel)
+		_, flushID, proverID, err := s.state.ProcessAndStoreClosedBatch(s.ctx, batch, dbTx, stateMetrics.SynchronizerCallerLabel)
 		if err != nil {
 			log.Errorf("error processing batch in processSequenceForceBatch. BatchNumber: %d, BlockNumber: %d, error: %v", batch.BatchNumber, block.BlockNumber, err)
 			rollbackErr := dbTx.Rollback(s.ctx)

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -509,10 +509,11 @@ func TestSequenceForcedBatch(t *testing.T) {
 				Timestamp:      ethBlock.ReceivedAt,
 				GlobalExitRoot: sequencedForceBatch.GlobalExitRoot,
 				ForcedBatchNum: &f,
+				BatchL2Data:    &sequencedForceBatch.Transactions,
 			}
 
 			m.State.
-				On("ProcessAndStoreClosedBatch", ctx, processingContext, sequencedForceBatch.Transactions, m.DbTx, metrics.SynchronizerCallerLabel).
+				On("ProcessAndStoreClosedBatch", ctx, processingContext, m.DbTx, metrics.SynchronizerCallerLabel).
 				Return(common.Hash{}, uint64(1), cProverIDExecution, nil).
 				Once()
 


### PR DESCRIPTION
Closes #2362

This is fix for this[ PR](https://github.com/0xPolygonHermez/zkevm-node/pull/2363)  that have too many conflicts.

### What does this PR do?

`state.ProcessAndStoreClosedBatch` use `processingCtx.BatchL2Data` instead of `encodedTxs` parameter

### Reviewers
@ARR552 
@ToniRamirezM 