### PR TITLE
Refactor: avoid delete addrQueue if it has pending txs to store

### DIFF
--- a/sequencer/addrqueue.go
+++ b/sequencer/addrqueue.go
@@ -102,7 +102,7 @@ func (a *addrQueue) ExpireTransactions(maxTime time.Duration) ([]*TxTracker, *Tx
 		prevReadyTx = a.readyTx
 		txs = append(txs, a.readyTx)
 		a.readyTx = nil
-		log.Debugf("Deleting eadyTx %s from addrQueue %s", prevReadyTx.HashStr, a.fromStr)
+		log.Debugf("Deleting readyTx %s from addrQueue %s", prevReadyTx.HashStr, a.fromStr)
 	}
 
 	return txs, prevReadyTx

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -728,8 +728,6 @@ func (f *finalizer) handleForcedTxsProcessResp(ctx context.Context, request stat
 			}
 		}
 
-		oldStateRoot = txResp.StateRoot
-
 		txToStore := transactionToStore{
 			txTracker:     nil,
 			response:      txResp,
@@ -741,6 +739,8 @@ func (f *finalizer) handleForcedTxsProcessResp(ctx context.Context, request stat
 			isForcedBatch: true,
 			flushId:       result.FlushID,
 		}
+
+		oldStateRoot = txResp.StateRoot
 
 		f.updateLastPendingFlushID(result.FlushID)
 

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -1515,6 +1515,7 @@ func Test_processTransaction(t *testing.T) {
 			}
 			if tc.expectedErr == nil {
 				workerMock.On("UpdateAfterSingleSuccessfulTxExecution", tc.tx.From, tc.expectedResponse.ReadWriteAddresses).Return([]*TxTracker{}).Once()
+				workerMock.On("AddPendingTxToStore", tc.tx.Hash, tc.tx.From).Return().Once()
 			}
 
 			if tc.expectedUpdateTxStatus != "" {

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -294,6 +294,7 @@ func TestFinalizer_handleProcessTransactionResponse(t *testing.T) {
 				//dbManagerMock.On("GetGasPrices", ctx).Return(pool.GasPrices{L1GasPrice: 0, L2GasPrice: 0}, nilErr).Once()
 				workerMock.On("DeleteTx", txTracker.Hash, txTracker.From).Return().Once()
 				workerMock.On("UpdateAfterSingleSuccessfulTxExecution", txTracker.From, tc.executorResponse.ReadWriteAddresses).Return([]*TxTracker{}).Once()
+				workerMock.On("AddPendingTxToStore", txTracker.Hash, txTracker.From).Return().Once()
 			}
 			if tc.expectedUpdateTxStatus != "" {
 				dbManagerMock.On("UpdateTxStatus", ctx, txHash, tc.expectedUpdateTxStatus, false, mock.Anything).Return(nil).Once()

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -2447,7 +2447,6 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 		maxBreakEvenGasPriceDeviationPercentage: big.NewInt(10),
 		pendingTransactionsToStore:              make(chan transactionToStore, bc.MaxTxsPerBatch*pendingTxsBufferSizeMultiplier),
 		pendingTransactionsToStoreWG:            new(sync.WaitGroup),
-		pendingTransactionsToStoreMux:           new(sync.RWMutex),
 		storedFlushID:                           0,
 		storedFlushIDCond:                       sync.NewCond(new(sync.Mutex)),
 		proverID:                                "",

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -90,6 +90,8 @@ type workerInterface interface {
 	AddTxTracker(ctx context.Context, txTracker *TxTracker) (replacedTx *TxTracker, dropReason error)
 	MoveTxToNotReady(txHash common.Hash, from common.Address, actualNonce *uint64, actualBalance *big.Int) []*TxTracker
 	DeleteTx(txHash common.Hash, from common.Address)
+	AddPendingTxToStore(txHash common.Hash, addr common.Address)
+	DeletePendingTxToStore(txHash common.Hash, addr common.Address)
 	HandleL2Reorg(txHashes []common.Hash)
 	NewTxTracker(tx types.Transaction, counters state.ZKCounters, ip string) (*TxTracker, error)
 }

--- a/sequencer/mock_worker.go
+++ b/sequencer/mock_worker.go
@@ -20,6 +20,11 @@ type WorkerMock struct {
 	mock.Mock
 }
 
+// AddPendingTxToStore provides a mock function with given fields: txHash, addr
+func (_m *WorkerMock) AddPendingTxToStore(txHash common.Hash, addr common.Address) {
+	_m.Called(txHash, addr)
+}
+
 // AddTxTracker provides a mock function with given fields: ctx, txTracker
 func (_m *WorkerMock) AddTxTracker(ctx context.Context, txTracker *TxTracker) (*TxTracker, error) {
 	ret := _m.Called(ctx, txTracker)
@@ -44,6 +49,11 @@ func (_m *WorkerMock) AddTxTracker(ctx context.Context, txTracker *TxTracker) (*
 	}
 
 	return r0, r1
+}
+
+// DeletePendingTxToStore provides a mock function with given fields: txHash, addr
+func (_m *WorkerMock) DeletePendingTxToStore(txHash common.Hash, addr common.Address) {
+	_m.Called(txHash, addr)
 }
 
 // DeleteTx provides a mock function with given fields: txHash, from


### PR DESCRIPTION
### What does this PR do?

Refactors the implementation to avoid delete an addrQueue (ExpireTransactions) if it has pending txs to be stored in the DB

### Reviewers

Main reviewers:
- @ToniRamirezM 
- @ARR552 
