### PR TITLE
Fix "nil ponter reference" when storing a forced batch tx

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -207,8 +207,10 @@ func (f *finalizer) storePendingTransactions(ctx context.Context) {
 			// Now f.storedFlushID >= tx.flushId, we can store tx
 			f.storeProcessedTx(ctx, tx)
 
-			// Delete the txTracker from the pending list in the worker (addrQueue)
-			f.worker.DeletePendingTxToStore(tx.txTracker.Hash, tx.txTracker.From)
+			if tx.txTracker != nil {
+				// Delete the txTracker from the pending list in the worker (addrQueue)
+				f.worker.DeletePendingTxToStore(tx.txTracker.Hash, tx.txTracker.From)
+			}
 
 			f.pendingTransactionsToStoreWG.Done()
 		case <-ctx.Done():


### PR DESCRIPTION
### What does this PR do?

Fix "nil ponter reference" in function storePendingTransactions when storing a forced batch txs (txTracker == nil)

### Reviewers

Main reviewers:
@ToniRamirezM 