### PR TITLE
Add `uniswap-transfers` Benchmark Script to `zkevm-node`

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -258,6 +258,26 @@ benchmark-sequencer-erc20-transfers: stop
  	touch ./results/out.dat ; \
 	go test -bench=. -timeout=600m | tee ./results/out.dat ;
 
+
+.PHONY: benchmark-sequencer-uniswap-transfers
+benchmark-sequencer-uniswap-transfers: stop
+	$(RUNL1NETWORK)
+	$(RUNSTATEDB)
+	$(RUNPOOLDB)
+	$(RUNEVENTDB)
+	sleep 5
+	$(RUNZKPROVER)
+	$(RUNSYNC)
+	sleep 2
+	$(RUNL2GASPRICER)
+	$(RUNJSONRPC)
+	docker ps -a
+	docker logs $(DOCKERCOMPOSEZKPROVER)
+	@ cd benchmarks/sequencer/e2e/uniswap-transfers ; \
+ 	mkdir -p results ; \
+ 	touch ./results/out.dat ; \
+	go test -bench=. -timeout=600m | tee ./results/out.dat ;
+
 .PHONY: run-db
 run-db: ## Runs the node database
 	$(RUNSTATEDB)

--- a/test/Makefile
+++ b/test/Makefile
@@ -234,7 +234,7 @@ benchmark-sequencer-eth-transfers: stop
 	$(RUNJSONRPC)
 	docker ps -a
 	docker logs $(DOCKERCOMPOSEZKPROVER)
-	@ cd benchmarks/sequencer/eth-transfers ; \
+	@ cd benchmarks/sequencer/e2e/eth-transfers ; \
  	mkdir -p results ; \
  	touch ./results/out.dat ; \
 	go test -bench=. -timeout=600m | tee ./results/out.dat ;
@@ -253,7 +253,7 @@ benchmark-sequencer-erc20-transfers: stop
 	$(RUNJSONRPC)
 	docker ps -a
 	docker logs $(DOCKERCOMPOSEZKPROVER)
-	@ cd benchmarks/sequencer/erc20-transfers ; \
+	@ cd benchmarks/sequencer/e2e/erc20-transfers ; \
  	mkdir -p results ; \
  	touch ./results/out.dat ; \
 	go test -bench=. -timeout=600m | tee ./results/out.dat ;

--- a/test/benchmarks/sequencer/common/params/constants.go
+++ b/test/benchmarks/sequencer/common/params/constants.go
@@ -12,5 +12,5 @@ const (
 	// PrometheusPort is the port where prometheus is running
 	PrometheusPort = 9092
 	// NumberOfOperations is the number of transactions to send
-	NumberOfOperations = 10
+	NumberOfOperations = 300
 )

--- a/test/benchmarks/sequencer/common/params/constants.go
+++ b/test/benchmarks/sequencer/common/params/constants.go
@@ -11,6 +11,6 @@ const (
 	MaxCumulativeGasUsed = 80000000000
 	// PrometheusPort is the port where prometheus is running
 	PrometheusPort = 9092
-	// NumberOfTxs is the number of transactions to send
-	NumberOfTxs = 1000
+	// NumberOfOperations is the number of transactions to send
+	NumberOfOperations = 10
 )

--- a/test/benchmarks/sequencer/e2e/erc20-transfers/pool_processing_erc20_test.go
+++ b/test/benchmarks/sequencer/e2e/erc20-transfers/pool_processing_erc20_test.go
@@ -46,7 +46,7 @@ func BenchmarkSequencerERC20TransfersPoolProcess(b *testing.B) {
 	}
 	initialCount, err := pl.CountTransactionsByStatus(params.Ctx, pool.TxStatusSelected)
 	require.NoError(b, err)
-	err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, erc20SC, nil, TxSender)
+	_, err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, erc20SC, nil, TxSender)
 	require.NoError(b, err)
 
 	var (

--- a/test/benchmarks/sequencer/e2e/erc20-transfers/pool_processing_erc20_test.go
+++ b/test/benchmarks/sequencer/e2e/erc20-transfers/pool_processing_erc20_test.go
@@ -46,7 +46,7 @@ func BenchmarkSequencerERC20TransfersPoolProcess(b *testing.B) {
 	}
 	initialCount, err := pl.CountTransactionsByStatus(params.Ctx, pool.TxStatusSelected)
 	require.NoError(b, err)
-	err = transactions.SendAndWait(params.Ctx, auth, client, pl.CountTransactionsByStatus, params.NumberOfTxs, erc20SC, TxSender)
+	err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, erc20SC, nil, TxSender)
 	require.NoError(b, err)
 
 	var (
@@ -54,9 +54,9 @@ func BenchmarkSequencerERC20TransfersPoolProcess(b *testing.B) {
 		prometheusResponse *http.Response
 	)
 
-	b.Run(fmt.Sprintf("sequencer_selecting_%d_txs", params.NumberOfTxs), func(b *testing.B) {
+	b.Run(fmt.Sprintf("sequencer_selecting_%d_txs", params.NumberOfOperations), func(b *testing.B) {
 		// Wait all txs to be selected by the sequencer
-		err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfTxs)
+		err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfOperations)
 		require.NoError(b, err)
 		elapsed = time.Since(start)
 		log.Infof("Total elapsed time: %s", elapsed)
@@ -77,7 +77,7 @@ func BenchmarkSequencerERC20TransfersPoolProcess(b *testing.B) {
 		elapsed,
 		deployMetricsValues.SequencerTotalProcessingTime,
 		deployMetricsValues.ExecutorTotalProcessingTime,
-		params.NumberOfTxs,
+		params.NumberOfOperations,
 	)
 	timeForFetchAndPrintMetrics := time.Since(startMetrics)
 	log.Infof("########################################")

--- a/test/benchmarks/sequencer/e2e/erc20-transfers/tx_sender.go
+++ b/test/benchmarks/sequencer/e2e/erc20-transfers/tx_sender.go
@@ -6,6 +6,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/params"
 	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
+	uniswap "github.com/0xPolygonHermez/zkevm-node/test/scripts/uniswap/pkg"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
@@ -22,7 +23,7 @@ var (
 )
 
 // TxSender sends ERC20 transfer to the sequencer
-func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20) error {
+func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) error {
 	log.Debugf("sending tx num: %d nonce: %d", countTxs, nonce)
 	auth.Nonce = new(big.Int).SetUint64(nonce)
 	var actualTransferAmount *big.Int

--- a/test/benchmarks/sequencer/e2e/erc20-transfers/tx_sender.go
+++ b/test/benchmarks/sequencer/e2e/erc20-transfers/tx_sender.go
@@ -3,6 +3,8 @@ package erc20_transfers
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/params"
 	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
@@ -23,7 +25,7 @@ var (
 )
 
 // TxSender sends ERC20 transfer to the sequencer
-func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) error {
+func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) ([]*types.Transaction, error) {
 	log.Debugf("sending tx num: %d nonce: %d", countTxs, nonce)
 	auth.Nonce = new(big.Int).SetUint64(nonce)
 	var actualTransferAmount *big.Int
@@ -32,10 +34,10 @@ func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth 
 	} else {
 		actualTransferAmount = big.NewInt(0).Add(transferAmountBig, auth.Nonce)
 	}
-	_, err := erc20SC.Transfer(auth, params.To, actualTransferAmount)
+	tx, err := erc20SC.Transfer(auth, params.To, actualTransferAmount)
 	if err == nil {
 		countTxs += 1
 	}
 
-	return err
+	return []*types.Transaction{tx}, err
 }

--- a/test/benchmarks/sequencer/e2e/eth-transfers/pool_processing_eth_test.go
+++ b/test/benchmarks/sequencer/e2e/eth-transfers/pool_processing_eth_test.go
@@ -27,7 +27,7 @@ func BenchmarkSequencerEthTransfersPoolProcess(b *testing.B) {
 	require.NoError(b, err)
 	timeForSetup := time.Since(start)
 	setup.BootstrapSequencer(b, opsman)
-	err = transactions.SendAndWait(params.Ctx, auth, client, pl.CountTransactionsByStatus, params.NumberOfTxs, nil, TxSender)
+	err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, nil, nil, TxSender)
 	require.NoError(b, err)
 
 	var (
@@ -35,8 +35,8 @@ func BenchmarkSequencerEthTransfersPoolProcess(b *testing.B) {
 		prometheusResponse *http.Response
 	)
 
-	b.Run(fmt.Sprintf("sequencer_selecting_%d_txs", params.NumberOfTxs), func(b *testing.B) {
-		err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfTxs)
+	b.Run(fmt.Sprintf("sequencer_selecting_%d_txs", params.NumberOfOperations), func(b *testing.B) {
+		err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfOperations)
 		require.NoError(b, err)
 		elapsed = time.Since(start)
 		log.Infof("Total elapsed time: %s", elapsed)
@@ -51,7 +51,7 @@ func BenchmarkSequencerEthTransfersPoolProcess(b *testing.B) {
 		require.NoError(b, err)
 	}
 
-	metrics.CalculateAndPrint(prometheusResponse, profilingResult, elapsed, 0, 0, params.NumberOfTxs)
+	metrics.CalculateAndPrint(prometheusResponse, profilingResult, elapsed, 0, 0, params.NumberOfOperations)
 	fmt.Printf("%s\n", profilingResult)
 	timeForFetchAndPrintMetrics := time.Since(startMetrics)
 	log.Infof("Time for setup: %s", timeForSetup)

--- a/test/benchmarks/sequencer/e2e/eth-transfers/pool_processing_eth_test.go
+++ b/test/benchmarks/sequencer/e2e/eth-transfers/pool_processing_eth_test.go
@@ -27,7 +27,7 @@ func BenchmarkSequencerEthTransfersPoolProcess(b *testing.B) {
 	require.NoError(b, err)
 	timeForSetup := time.Since(start)
 	setup.BootstrapSequencer(b, opsman)
-	err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, nil, nil, TxSender)
+	_, err = transactions.SendAndWait(auth, client, pl.GetTxsByStatus, params.NumberOfOperations, nil, nil, TxSender)
 	require.NoError(b, err)
 
 	var (

--- a/test/benchmarks/sequencer/e2e/eth-transfers/tx_sender.go
+++ b/test/benchmarks/sequencer/e2e/eth-transfers/tx_sender.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/params"
 	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
+	uniswap "github.com/0xPolygonHermez/zkevm-node/test/scripts/uniswap/pkg"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -22,7 +23,7 @@ var (
 )
 
 // TxSender sends eth transfer to the sequencer
-func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20) error {
+func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) error {
 	log.Debugf("sending tx num: %d nonce: %d", countTxs, nonce)
 	auth.Nonce = big.NewInt(int64(nonce))
 	tx := types.NewTransaction(nonce, params.To, ethAmount, uint64(gasLimit), gasPrice, nil)

--- a/test/benchmarks/sequencer/e2e/eth-transfers/tx_sender.go
+++ b/test/benchmarks/sequencer/e2e/eth-transfers/tx_sender.go
@@ -23,13 +23,20 @@ var (
 )
 
 // TxSender sends eth transfer to the sequencer
-func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) error {
+func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) ([]*types.Transaction, error) {
 	log.Debugf("sending tx num: %d nonce: %d", countTxs, nonce)
-	auth.Nonce = big.NewInt(int64(nonce))
-	tx := types.NewTransaction(nonce, params.To, ethAmount, uint64(gasLimit), gasPrice, nil)
+	auth.Nonce = new(big.Int).SetUint64(nonce)
+	tx := types.NewTx(&types.LegacyTx{
+		GasPrice: gasPrice,
+		Nonce:    nonce,
+		Gas:      uint64(gasLimit),
+		To:       &params.To,
+		Value:    ethAmount,
+		Data:     nil,
+	})
 	signedTx, err := auth.Signer(auth.From, tx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = l2Client.SendTransaction(params.Ctx, signedTx)
@@ -44,5 +51,5 @@ func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth 
 		countTxs += 1
 	}
 
-	return err
+	return []*types.Transaction{signedTx}, err
 }

--- a/test/benchmarks/sequencer/e2e/uniswap-transfers/tx_sender.go
+++ b/test/benchmarks/sequencer/e2e/uniswap-transfers/tx_sender.go
@@ -1,0 +1,41 @@
+package uniswap_transfers
+
+import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/state"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
+	uniswap "github.com/0xPolygonHermez/zkevm-node/test/scripts/uniswap/pkg"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var (
+	gasLimit  = 21000
+	sleepTime = 5 * time.Second
+	countTxs  = 0
+	txTimeout = 60 * time.Second
+)
+
+// TxSender sends eth transfer to the sequencer
+func TxSender(l2Client *ethclient.Client, gasPrice *big.Int, nonce uint64, auth *bind.TransactOpts, erc20SC *ERC20.ERC20, uniswapDeployments *uniswap.Deployments) error {
+	log.Debugf("swap number: %d", countTxs, nonce)
+	var err error
+
+	uniswap.SwapTokens(l2Client, auth, *uniswapDeployments)
+	if errors.Is(err, state.ErrStateNotSynchronized) || errors.Is(err, state.ErrInsufficientFunds) {
+		for errors.Is(err, state.ErrStateNotSynchronized) || errors.Is(err, state.ErrInsufficientFunds) {
+			time.Sleep(sleepTime)
+			uniswap.SwapTokens(l2Client, auth, *uniswapDeployments)
+		}
+	}
+
+	if err == nil {
+		countTxs += 1
+	}
+
+	return err
+}

--- a/test/benchmarks/sequencer/scripts/common/environment/init.go
+++ b/test/benchmarks/sequencer/scripts/common/environment/init.go
@@ -22,7 +22,7 @@ var (
 )
 
 // Init sets up the environment for the benchmark
-func Init() (context.Context, *pgpoolstorage.PostgresPoolStorage, *state.PostgresStorage, *ethclient.Client, *bind.TransactOpts) {
+func Init() (*pgpoolstorage.PostgresPoolStorage, *state.PostgresStorage, *ethclient.Client, *bind.TransactOpts) {
 	ctx := context.Background()
 	pl, err := pgpoolstorage.NewPostgresPoolStorage(db.Config{
 		Name:      poolDbName,
@@ -93,5 +93,5 @@ func Init() (context.Context, *pgpoolstorage.PostgresPoolStorage, *state.Postgre
 	stateStorage := state.NewPostgresStorage(stateDb)
 	auth.Nonce = new(big.Int).SetUint64(senderNonce)
 
-	return ctx, pl, stateStorage, l2Client, auth
+	return pl, stateStorage, l2Client, auth
 }

--- a/test/benchmarks/sequencer/scripts/common/results/print.go
+++ b/test/benchmarks/sequencer/scripts/common/results/print.go
@@ -1,28 +1,56 @@
 package results
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/params"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 // Print prints the results of the benchmark
-func Print(elapsed time.Duration) {
+func Print(client *ethclient.Client, elapsed time.Duration, txs []*types.Transaction) {
+	// calculate the total gas used
+	var totalGas uint64
+	for _, tx := range txs {
+		// Fetch the transaction receipt
+		receipt, err := client.TransactionReceipt(params.Ctx, tx.Hash())
+		if err != nil {
+			log.Error("Unable to fetch transaction receipt", "error", err)
+			continue
+		}
+
+		totalGas += receipt.GasUsed
+	}
+
+	// calculate the average gas used per transaction
+	var avgGas uint64
+	if len(txs) > 0 {
+		avgGas = totalGas / uint64(len(txs))
+	}
+
+	// calculate the gas per second
+	gasPerSecond := float64(len(txs)*int(avgGas)) / elapsed.Seconds()
+
 	// Print results
-	log.Info("##########")
-	log.Info("# Result #")
-	log.Info("##########")
-	log.Infof("Total time took for the sequencer to select all txs from the pool: %v", elapsed)
-	log.Infof("Number of txs sent: %d", params.NumberOfOperations)
-	log.Infof("Txs per second: %f", float64(params.NumberOfOperations)/elapsed.Seconds())
+	fmt.Println("##########")
+	fmt.Println("# Result #")
+	fmt.Println("##########")
+	fmt.Printf("Total time took for the sequencer to select all txs from the pool: %v\n", elapsed)
+	fmt.Printf("Number of operations sent: %d\n", params.NumberOfOperations)
+	fmt.Printf("Txs per second: %f\n", float64(params.NumberOfOperations)/elapsed.Seconds())
+	fmt.Printf("Average gas used per transaction: %d\n", avgGas)
+	fmt.Printf("Total Gas: %d\n", totalGas)
+	fmt.Printf("Gas per second: %f\n", gasPerSecond)
 }
 
 func PrintUniswapDeployments(deployments time.Duration, count uint64) {
-	log.Info("#######################")
-	log.Info("# Uniswap Deployments #")
-	log.Info("#######################")
-	log.Infof("Total time took for the sequencer to deploy all contracts: %v", deployments)
-	log.Infof("Number of txs sent: %d", count)
-	log.Infof("Txs per second: %f", float64(count)/deployments.Seconds())
+	fmt.Println("#######################")
+	fmt.Println("# Uniswap Deployments #")
+	fmt.Println("#######################")
+	fmt.Printf("Total time took for the sequencer to deploy all contracts: %v\n", deployments)
+	fmt.Printf("Number of txs sent: %d\n", count)
+	fmt.Printf("Txs per second: %f\n", float64(count)/deployments.Seconds())
 }

--- a/test/benchmarks/sequencer/scripts/common/results/print.go
+++ b/test/benchmarks/sequencer/scripts/common/results/print.go
@@ -14,6 +14,15 @@ func Print(elapsed time.Duration) {
 	log.Info("# Result #")
 	log.Info("##########")
 	log.Infof("Total time took for the sequencer to select all txs from the pool: %v", elapsed)
-	log.Infof("Number of txs sent: %d", params.NumberOfTxs)
-	log.Infof("Txs per second: %f", float64(params.NumberOfTxs)/elapsed.Seconds())
+	log.Infof("Number of txs sent: %d", params.NumberOfOperations)
+	log.Infof("Txs per second: %f", float64(params.NumberOfOperations)/elapsed.Seconds())
+}
+
+func PrintUniswapDeployments(deployments time.Duration, count uint64) {
+	log.Info("#######################")
+	log.Info("# Uniswap Deployments #")
+	log.Info("#######################")
+	log.Infof("Total time took for the sequencer to deploy all contracts: %v", deployments)
+	log.Infof("Number of txs sent: %d", count)
+	log.Infof("Txs per second: %f", float64(count)/deployments.Seconds())
 }

--- a/test/benchmarks/sequencer/scripts/erc20-transfers/main.go
+++ b/test/benchmarks/sequencer/scripts/erc20-transfers/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/pool"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/params"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/common/transactions"
-	erc20transfers "github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/erc20-transfers"
+	erc20transfers "github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/e2e/erc20-transfers"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/scripts/common/environment"
 	"github.com/0xPolygonHermez/zkevm-node/test/benchmarks/sequencer/scripts/common/results"
 	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
@@ -17,7 +17,7 @@ func main() {
 	var (
 		err error
 	)
-	ctx, pl, state, l2Client, auth := environment.Init()
+	pl, state, l2Client, auth := environment.Init()
 	initialCount, err := pl.CountTransactionsByStatus(params.Ctx, pool.TxStatusSelected)
 	if err != nil {
 		panic(err)
@@ -30,12 +30,12 @@ func main() {
 	}
 	// Send Txs
 	err = transactions.SendAndWait(
-		ctx,
 		auth,
 		l2Client,
-		pl.CountTransactionsByStatus,
-		params.NumberOfTxs,
+		pl.GetTxsByStatus,
+		params.NumberOfOperations,
 		erc20SC,
+		nil,
 		erc20transfers.TxSender,
 	)
 	if err != nil {
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	// Wait for Txs to be selected
-	err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfTxs)
+	err = transactions.WaitStatusSelected(pl.CountTransactionsByStatus, initialCount, params.NumberOfOperations)
 	if err != nil {
 		panic(err)
 	}

--- a/test/benchmarks/sequencer/scripts/erc20-transfers/main.go
+++ b/test/benchmarks/sequencer/scripts/erc20-transfers/main.go
@@ -29,7 +29,7 @@ func main() {
 		panic(err)
 	}
 	// Send Txs
-	err = transactions.SendAndWait(
+	allTxs, err := transactions.SendAndWait(
 		auth,
 		l2Client,
 		pl.GetTxsByStatus,
@@ -53,5 +53,5 @@ func main() {
 		panic(err)
 	}
 	elapsed := lastL2BlockTimestamp.Sub(start)
-	results.Print(elapsed)
+	results.Print(l2Client, elapsed, allTxs)
 }

--- a/test/benchmarks/sequencer/scripts/eth-transfers/main.go
+++ b/test/benchmarks/sequencer/scripts/eth-transfers/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/pool"
@@ -23,7 +24,7 @@ func main() {
 
 	start := time.Now()
 	// Send Txs
-	err = transactions.SendAndWait(
+	allTxs, err := transactions.SendAndWait(
 		auth,
 		l2Client,
 		pl.GetTxsByStatus,
@@ -33,6 +34,7 @@ func main() {
 		ethtransfers.TxSender,
 	)
 	if err != nil {
+		fmt.Println(auth.Nonce)
 		panic(err)
 	}
 
@@ -47,5 +49,5 @@ func main() {
 		panic(err)
 	}
 	elapsed := lastL2BlockTimestamp.Sub(start)
-	results.Print(elapsed)
+	results.Print(l2Client, elapsed, allTxs)
 }

--- a/test/benchmarks/sequencer/scripts/uniswap-transfers/main.go
+++ b/test/benchmarks/sequencer/scripts/uniswap-transfers/main.go
@@ -29,7 +29,7 @@ func main() {
 	elapsedTimeForDeployments := time.Since(start)
 
 	// Send Txs
-	err = transactions.SendAndWait(
+	allTxs, err := transactions.SendAndWait(
 		auth,
 		l2Client,
 		pl.GetTxsByStatus,
@@ -55,7 +55,7 @@ func main() {
 	}
 	elapsed := lastL2BlockTimestamp.Sub(start)
 	results.PrintUniswapDeployments(elapsedTimeForDeployments, deploymentTxsCount)
-	results.Print(elapsed)
+	results.Print(l2Client, elapsed, allTxs)
 
 	totalTxsCount := uniswap.GetExecutedTransactionsCount()
 	log.Info("##############################")

--- a/test/scripts/uniswap/main.go
+++ b/test/scripts/uniswap/main.go
@@ -3,275 +3,37 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/big"
-	"strings"
-	"time"
 
-	"github.com/0xPolygonHermez/zkevm-node/encoding"
 	"github.com/0xPolygonHermez/zkevm-node/log"
-	ERC20 "github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
-	WETH "github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/WETH"
-	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Factory"
-	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Pair"
-	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/interface/UniswapInterfaceMulticall"
-	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/periphery/UniswapV2Router02"
 	"github.com/0xPolygonHermez/zkevm-node/test/operations"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
+	uniswap "github.com/0xPolygonHermez/zkevm-node/test/scripts/uniswap/pkg"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 const (
 	// if you want to test using goerli network
 	// replace this by your goerli infura url
-	networkURL = "http://localhost:8123"
+	//networkURL = "http://localhost:8123"
+	networkURL = "http://localhost:8545"
 	// replace this by your account private key
-	pk        = "0xdfd01798f92667dbf91df722434e8fbe96af0211d4d1b82bbbbc8f1def7a814f"
-	txTimeout = 60 * time.Second
+	//pk = "0xdfd01798f92667dbf91df722434e8fbe96af0211d4d1b82bbbbc8f1def7a814f"
+	pk = operations.DefaultSequencerPrivateKey
 )
 
 func main() {
 	ctx := context.Background()
 	log.Infof("connecting to %v", networkURL)
 	client, err := ethclient.Dial(networkURL)
-	chkErr(err)
+	uniswap.ChkErr(err)
 	log.Infof("connected")
 	chainID, err := client.ChainID(ctx)
-	chkErr(err)
+	uniswap.ChkErr(err)
 	log.Infof("chainID: %v", chainID)
-	auth := getAuth(ctx, client, pk)
+	auth := uniswap.GetAuth(ctx, client, pk)
 	fmt.Println()
-	balance, err := client.BalanceAt(ctx, auth.From, nil)
-	chkErr(err)
-	log.Debugf("ETH Balance for %v: %v", auth.From, balance)
-	// Deploy ERC20 Tokens to be swapped
-	aCoinAddr, aCoin := deployERC20(auth, client, "A COIN", "ACO")
-	fmt.Println()
-	bCoinAddr, bCoin := deployERC20(auth, client, "B COIN", "BCO")
-	fmt.Println()
-	cCoinAddr, cCoin := deployERC20(auth, client, "C COIN", "CCO")
-	fmt.Println()
-	// Deploy wETH Token, it's required by uniswap to swap ETH by tokens
-	log.Debugf("Deploying wEth SC")
-	wEthAddr, tx, wethSC, err := WETH.DeployWETH(auth, client)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("wEth SC tx: %v", tx.Hash().Hex())
-	log.Debugf("wEth SC addr: %v", wEthAddr.Hex())
-	fmt.Println()
-	// Deploy Uniswap Factory
-	log.Debugf("Deploying Uniswap Factory")
-	factoryAddr, tx, factory, err := UniswapV2Factory.DeployUniswapV2Factory(auth, client, auth.From)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("Uniswap Factory SC tx: %v", tx.Hash().Hex())
-	log.Debugf("Uniswap Factory SC addr: %v", factoryAddr.Hex())
-	fmt.Println()
-	// Deploy Uniswap Router
-	log.Debugf("Deploying Uniswap Router")
-	routerAddr, tx, router, err := UniswapV2Router02.DeployUniswapV2Router02(auth, client, factoryAddr, wEthAddr)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("Uniswap Router SC tx: %v", tx.Hash().Hex())
-	log.Debugf("Uniswap Router SC addr: %v", routerAddr.Hex())
-	fmt.Println()
-	// Deploy Uniswap Interface Multicall
-	log.Debugf("Deploying Uniswap Multicall")
-	multicallAddr, tx, _, err := UniswapInterfaceMulticall.DeployUniswapInterfaceMulticall(auth, client)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("Uniswap Interface Multicall SC tx: %v", tx.Hash().Hex())
-	log.Debugf("Uniswap Interface Multicall SC addr: %v", multicallAddr.Hex())
-	fmt.Println()
-	// Mint balance to tokens
-	log.Debugf("Minting ERC20 Tokens")
-	aMintAmount := "1000000000000000000000"
-	tx = mintERC20(auth, client, aCoin, aMintAmount)
-	log.Debugf("Mint A Coin tx: %v", tx.Hash().Hex())
-	fmt.Println()
-	bMintAmount := "1000000000000000000000"
-	tx = mintERC20(auth, client, bCoin, bMintAmount)
-	log.Debugf("Mint B Coin tx: %v", tx.Hash().Hex())
-	fmt.Println()
-	cMintAmount := "1000000000000000000000"
-	tx = mintERC20(auth, client, cCoin, cMintAmount)
-	log.Debugf("Mint C Coin tx: %v", tx.Hash().Hex())
-	fmt.Println()
-	// wrapping eth
-	wethDepositoAmount := "20000000000000000"
-	log.Debugf("Depositing %v ETH for account %v on token wEth", wethDepositoAmount, auth.From)
-	wAuth := getAuth(ctx, client, pk)
-	wAuth.Value, _ = big.NewInt(0).SetString(wethDepositoAmount, encoding.Base10)
-	tx, err = wethSC.Deposit(auth)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	value, err := aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before allowance aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before allowance bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before allowance cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	// Add allowance
-	approveERC20(auth, client, aCoin, routerAddr, aMintAmount)
-	fmt.Println()
-	approveERC20(auth, client, bCoin, routerAddr, bMintAmount)
-	fmt.Println()
-	approveERC20(auth, client, cCoin, routerAddr, cMintAmount)
-	fmt.Println()
-	approveERC20(auth, client, wethSC, routerAddr, wethDepositoAmount)
-	fmt.Println()
-	const liquidityAmount = "10000000000000000000"
-	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity A, B aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity A, B bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity A, B cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	// Add liquidity to the pool
-	tx = addLiquidity(auth, client, router, aCoinAddr, bCoinAddr, liquidityAmount)
-	log.Debugf("Add Liquidity to Pair A <-> B tx: %v", tx.Hash().Hex())
-	fmt.Println()
-	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity B, C aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity B, C bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before adding liquidity B, C cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	tx = addLiquidity(auth, client, router, bCoinAddr, cCoinAddr, liquidityAmount)
-	log.Debugf("Add Liquidity to Pair B <-> C tx: %v", tx.Hash().Hex())
-	fmt.Println()
-	// Execute swaps
-	const swapExactAmountInNumber = 1000000000000000000
-	swapExactAmountIn := big.NewInt(swapExactAmountInNumber)
-	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before first swap aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before first swap bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("before first swap cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	log.Debugf("Swaping tokens from A <-> B")
-	swapExactTokensForTokens(auth, client, factory, router, aCoinAddr, bCoinAddr, swapExactAmountIn)
-	fmt.Println()
-	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("after first swap aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("after first swap bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
-	chkErr(err)
-	log.Debugf("after first swap cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
-	log.Debugf("Swaping tokens from B <-> C")
-	swapExactTokensForTokens(auth, client, factory, router, bCoinAddr, cCoinAddr, swapExactAmountIn)
-	fmt.Println()
-}
-func swapExactTokensForTokens(auth *bind.TransactOpts, client *ethclient.Client,
-	factory *UniswapV2Factory.UniswapV2Factory, router *UniswapV2Router02.UniswapV2Router02,
-	tokenA, tokenB common.Address, exactAmountIn *big.Int) {
-	ctx := context.Background()
-	logPrefix := fmt.Sprintf("swapExactTokensForTokens %v <-> %v", tokenA.Hex(), tokenB.Hex())
-	pairAddr, err := factory.GetPair(nil, tokenA, tokenB)
-	chkErr(err)
-	log.Debug(logPrefix, " pair: ", pairAddr.Hex())
-	pairSC, err := UniswapV2Pair.NewUniswapV2Pair(pairAddr, client)
-	chkErr(err)
-	pairReserves, err := pairSC.GetReserves(nil)
-	chkErr(err)
-	log.Debug(logPrefix, " reserves 0: ", pairReserves.Reserve0, " 1: ", pairReserves.Reserve1, " Block Timestamp: ", pairReserves.BlockTimestampLast)
-	amountOut, err := router.GetAmountOut(nil, exactAmountIn, pairReserves.Reserve0, pairReserves.Reserve1)
-	chkErr(err)
-	log.Debug(logPrefix, " exactAmountIn: ", exactAmountIn, " amountOut: ", amountOut)
-	tx, err := router.SwapExactTokensForTokens(auth, exactAmountIn, amountOut, []common.Address{tokenA, tokenB}, auth.From, getDeadline())
-	chkErr(err)
-	log.Debug(logPrefix, " tx: ", tx.Hash().Hex())
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-}
-func getAuth(ctx context.Context, client *ethclient.Client, pkHex string) *bind.TransactOpts {
-	chainID, err := client.ChainID(ctx)
-	chkErr(err)
-	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(pkHex, "0x"))
-	chkErr(err)
-	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
-	chkErr(err)
-	return auth
-}
-func deployERC20(auth *bind.TransactOpts, client *ethclient.Client, name, symbol string) (common.Address, *ERC20.ERC20) {
-	ctx := context.Background()
-	log.Debugf("Deploying ERC20 Token: [%v]%v", symbol, name)
-	addr, tx, instance, err := ERC20.DeployERC20(auth, client, name, symbol)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("%v SC tx: %v", name, tx.Hash().Hex())
-	log.Debugf("%v SC addr: %v", name, addr.Hex())
-	return addr, instance
-}
-func mintERC20(auth *bind.TransactOpts, client *ethclient.Client, erc20sc *ERC20.ERC20, amount string) *types.Transaction {
-	ctx := context.Background()
-	name, err := erc20sc.Name(nil)
-	chkErr(err)
-	log.Debugf("Minting %v tokens for account %v on token %v", amount, auth.From, name)
-	mintAmount, _ := big.NewInt(0).SetString(amount, encoding.Base10)
-	tx, err := erc20sc.Mint(auth, mintAmount)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	return tx
-}
-func approveERC20(auth *bind.TransactOpts, client *ethclient.Client,
-	sc interface {
-		Name(opts *bind.CallOpts) (string, error)
-		Approve(opts *bind.TransactOpts, spender common.Address, amount *big.Int) (*types.Transaction, error)
-	},
-	routerAddr common.Address,
-	amount string) {
-	ctx := context.Background()
-	name, err := sc.Name(nil)
-	chkErr(err)
-	a, _ := big.NewInt(0).SetString(amount, encoding.Base10)
-	log.Debugf("Approving %v tokens to be used by the router for %v on behalf of account %v", a.Text(encoding.Base10), name, auth.From)
-	tx, err := sc.Approve(auth, routerAddr, a)
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	log.Debugf("Approval %v tx: %v", name, tx.Hash().Hex())
-}
-func addLiquidity(auth *bind.TransactOpts, client *ethclient.Client, router *UniswapV2Router02.UniswapV2Router02, tokenA, tokenB common.Address, amount string) *types.Transaction {
-	ctx := context.Background()
-	a, _ := big.NewInt(0).SetString(amount, encoding.Base10)
-	log.Debugf("Adding liquidity(%v) for tokens A: %v, B:%v, Recipient: %v", amount, tokenA.Hex(), tokenB.Hex(), auth.From.Hex())
-	tx, err := router.AddLiquidity(auth, tokenA, tokenB, a, a, a, a, auth.From, getDeadline())
-	chkErr(err)
-	err = operations.WaitTxToBeMined(ctx, client, tx, txTimeout)
-	chkErr(err)
-	return tx
-}
-func getDeadline() *big.Int {
-	const deadLinelimit = 5 * time.Minute
-	return big.NewInt(time.Now().UTC().Add(deadLinelimit).Unix())
-}
-func chkErr(err error) {
-	if err != nil {
-		log.Fatal(err)
+	deployments := uniswap.DeployContractsAndAddLiquidity(client, auth)
+	for i := 0; i < 5; i++ {
+		uniswap.SwapTokens(client, auth, deployments)
 	}
+
 }

--- a/test/scripts/uniswap/pkg/setup.go
+++ b/test/scripts/uniswap/pkg/setup.go
@@ -1,0 +1,237 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/encoding"
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/WETH"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Factory"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/interface/UniswapInterfaceMulticall"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/periphery/UniswapV2Router02"
+	"github.com/0xPolygonHermez/zkevm-node/test/operations"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+const (
+	txTimeout = 60 * time.Second
+)
+
+var (
+	executedTransctionsCount uint64 = 0
+)
+
+func DeployContractsAndAddLiquidity(client *ethclient.Client, auth *bind.TransactOpts) Deployments {
+	ctx := context.Background()
+	fmt.Println()
+	balance, err := client.BalanceAt(ctx, auth.From, nil)
+	ChkErr(err)
+	log.Debugf("ETH Balance for %v: %v", auth.From, balance)
+	// Deploy ERC20 Tokens to be swapped
+	aCoinAddr, aCoin := deployERC20(auth, client, "A COIN", "ACO")
+	fmt.Println()
+	bCoinAddr, bCoin := deployERC20(auth, client, "B COIN", "BCO")
+	fmt.Println()
+	cCoinAddr, cCoin := deployERC20(auth, client, "C COIN", "CCO")
+	fmt.Println()
+	// Deploy wETH Token, it's required by uniswap to swap ETH by tokens
+	log.Debugf("Deploying wEth SC")
+	wEthAddr, tx, wethSC, err := WETH.DeployWETH(auth, client)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("wEth SC tx: %v", tx.Hash().Hex())
+	log.Debugf("wEth SC addr: %v", wEthAddr.Hex())
+	fmt.Println()
+	// Deploy Uniswap Factory
+	log.Debugf("Deploying Uniswap Factory")
+	factoryAddr, tx, factory, err := UniswapV2Factory.DeployUniswapV2Factory(auth, client, auth.From)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("Uniswap Factory SC tx: %v", tx.Hash().Hex())
+	log.Debugf("Uniswap Factory SC addr: %v", factoryAddr.Hex())
+	fmt.Println()
+	// Deploy Uniswap Router
+	log.Debugf("Deploying Uniswap Router")
+	routerAddr, tx, router, err := UniswapV2Router02.DeployUniswapV2Router02(auth, client, factoryAddr, wEthAddr)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("Uniswap Router SC tx: %v", tx.Hash().Hex())
+	log.Debugf("Uniswap Router SC addr: %v", routerAddr.Hex())
+	fmt.Println()
+	// Deploy Uniswap Interface Multicall
+	log.Debugf("Deploying Uniswap Multicall")
+	multicallAddr, tx, _, err := UniswapInterfaceMulticall.DeployUniswapInterfaceMulticall(auth, client)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("Uniswap Interface Multicall SC tx: %v", tx.Hash().Hex())
+	log.Debugf("Uniswap Interface Multicall SC addr: %v", multicallAddr.Hex())
+	fmt.Println()
+	// Mint balance to tokens
+	log.Debugf("Minting ERC20 Tokens")
+	aMintAmount := "1000000000000000000000"
+	tx = mintERC20(auth, client, aCoin, aMintAmount)
+	log.Debugf("Mint A Coin tx: %v", tx.Hash().Hex())
+	fmt.Println()
+	bMintAmount := "1000000000000000000000"
+	tx = mintERC20(auth, client, bCoin, bMintAmount)
+	log.Debugf("Mint B Coin tx: %v", tx.Hash().Hex())
+	fmt.Println()
+	cMintAmount := "1000000000000000000000"
+	tx = mintERC20(auth, client, cCoin, cMintAmount)
+	log.Debugf("Mint C Coin tx: %v", tx.Hash().Hex())
+	fmt.Println()
+	// wrapping eth
+	wethDepositoAmount := "10000000000000000"
+	log.Debugf("Depositing %v ETH for account %v on token wEth", wethDepositoAmount, auth.From)
+	auth.Value, _ = big.NewInt(0).SetString(wethDepositoAmount, encoding.Base10)
+	tx, err = wethSC.Deposit(auth)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	value, err := aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before allowance aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before allowance bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before allowance cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	// Add allowance
+	approveERC20(auth, client, aCoin, routerAddr, aMintAmount)
+	fmt.Println()
+	approveERC20(auth, client, bCoin, routerAddr, bMintAmount)
+	fmt.Println()
+	approveERC20(auth, client, cCoin, routerAddr, cMintAmount)
+	fmt.Println()
+	approveERC20(auth, client, wethSC, routerAddr, wethDepositoAmount)
+	fmt.Println()
+	const liquidityAmount = "10000000000000000000"
+	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity A, B aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity A, B bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity A, B cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	// Add liquidity to the pool
+	tx = addLiquidity(auth, client, router, aCoinAddr, bCoinAddr, liquidityAmount)
+	log.Debugf("Add Liquidity to Pair A <-> B tx: %v", tx.Hash().Hex())
+	fmt.Println()
+	value, err = aCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity B, C aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = bCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity B, C bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = cCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before adding liquidity B, C cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	tx = addLiquidity(auth, client, router, bCoinAddr, cCoinAddr, liquidityAmount)
+	log.Debugf("Add Liquidity to Pair B <-> C tx: %v", tx.Hash().Hex())
+	fmt.Println()
+
+	return Deployments{
+		ACoin:     aCoin,
+		ACoinAddr: aCoinAddr,
+		BCoin:     bCoin,
+		BCoinAddr: bCoinAddr,
+		CCoin:     cCoin,
+		CCoinAddr: cCoinAddr,
+		Router:    router,
+		Factory:   factory,
+	}
+}
+
+func WaitForTransactionAndIncrementNonce(l2Client *ethclient.Client, auth *bind.TransactOpts, err error, ctx context.Context, tx *types.Transaction) error {
+	ChkErr(err)
+	err = operations.WaitTxToBeMined(ctx, l2Client, tx, txTimeout)
+	ChkErr(err)
+	executedTransctionsCount++
+	auth.Nonce = nil
+	auth.Value = nil
+
+	return err
+}
+
+func GetAuth(ctx context.Context, client *ethclient.Client, pkHex string) *bind.TransactOpts {
+	chainID, err := client.ChainID(ctx)
+	ChkErr(err)
+	privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(pkHex, "0x"))
+	ChkErr(err)
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	ChkErr(err)
+	senderNonce, err := client.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		panic(err)
+	}
+	auth.Nonce = big.NewInt(int64(senderNonce))
+	return auth
+}
+
+func ChkErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func GetExecutedTransactionsCount() uint64 {
+	return executedTransctionsCount
+}
+
+func deployERC20(auth *bind.TransactOpts, client *ethclient.Client, name, symbol string) (common.Address, *ERC20.ERC20) {
+	ctx := context.Background()
+	log.Debugf("Deploying ERC20 Token: [%v]%v", symbol, name)
+	addr, tx, instance, err := ERC20.DeployERC20(auth, client, name, symbol)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("%v SC tx: %v", name, tx.Hash().Hex())
+	log.Debugf("%v SC addr: %v", name, addr.Hex())
+	return addr, instance
+}
+
+func mintERC20(auth *bind.TransactOpts, client *ethclient.Client, erc20sc *ERC20.ERC20, amount string) *types.Transaction {
+	ctx := context.Background()
+	name, err := erc20sc.Name(nil)
+	ChkErr(err)
+	log.Debugf("Minting %v tokens for account %v on token %v", amount, auth.From, name)
+	mintAmount, _ := big.NewInt(0).SetString(amount, encoding.Base10)
+	tx, err := erc20sc.Mint(auth, mintAmount)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	return tx
+}
+
+func approveERC20(auth *bind.TransactOpts, client *ethclient.Client,
+	sc interface {
+		Name(opts *bind.CallOpts) (string, error)
+		Approve(opts *bind.TransactOpts, spender common.Address, amount *big.Int) (*types.Transaction, error)
+	},
+	routerAddr common.Address,
+	amount string) {
+	ctx := context.Background()
+	name, err := sc.Name(nil)
+	ChkErr(err)
+	a, _ := big.NewInt(0).SetString(amount, encoding.Base10)
+	log.Debugf("Approving %v tokens to be used by the router for %v on behalf of account %v", a.Text(encoding.Base10), name, auth.From)
+	tx, err := sc.Approve(auth, routerAddr, a)
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	log.Debugf("Approval %v tx: %v", name, tx.Hash().Hex())
+}
+
+func addLiquidity(auth *bind.TransactOpts, client *ethclient.Client, router *UniswapV2Router02.UniswapV2Router02, tokenA, tokenB common.Address, amount string) *types.Transaction {
+	ctx := context.Background()
+	a, _ := big.NewInt(0).SetString(amount, encoding.Base10)
+	log.Debugf("Adding liquidity(%v) for tokens A: %v, B:%v, Recipient: %v", amount, tokenA.Hex(), tokenB.Hex(), auth.From.Hex())
+	tx, err := router.AddLiquidity(auth, tokenA, tokenB, a, a, a, a, auth.From, getDeadline())
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+	return tx
+}
+
+func getDeadline() *big.Int {
+	const deadLinelimit = 5 * time.Minute
+	return big.NewInt(time.Now().UTC().Add(deadLinelimit).Unix())
+}

--- a/test/scripts/uniswap/pkg/setup.go
+++ b/test/scripts/uniswap/pkg/setup.go
@@ -86,7 +86,7 @@ func DeployContractsAndAddLiquidity(client *ethclient.Client, auth *bind.Transac
 	log.Debugf("Mint C Coin tx: %v", tx.Hash().Hex())
 	fmt.Println()
 	// wrapping eth
-	wethDepositoAmount := "10000000000000000"
+	wethDepositoAmount := "0000000000000000"
 	log.Debugf("Depositing %v ETH for account %v on token wEth", wethDepositoAmount, auth.From)
 	auth.Value, _ = big.NewInt(0).SetString(wethDepositoAmount, encoding.Base10)
 	tx, err = wethSC.Deposit(auth)

--- a/test/scripts/uniswap/pkg/swap.go
+++ b/test/scripts/uniswap/pkg/swap.go
@@ -1,0 +1,66 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Factory"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Pair"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/periphery/UniswapV2Router02"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+func SwapTokens(client *ethclient.Client, auth *bind.TransactOpts, deployments Deployments) {
+	// Execute swaps
+	const swapExactAmountInNumber = 10
+	swapExactAmountIn := big.NewInt(swapExactAmountInNumber)
+	swapExactAmountIn2 := big.NewInt(swapExactAmountInNumber - 1)
+	value, err := deployments.ACoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before first swap aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = deployments.BCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before first swap bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = deployments.CCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("before first swap cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	log.Debugf("Swaping tokens from A <-> B")
+	SwapExactTokensForTokens(auth, client, deployments.Factory, deployments.Router, deployments.ACoinAddr, deployments.BCoinAddr, swapExactAmountIn)
+	fmt.Println()
+	value, err = deployments.ACoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("after first swap aCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = deployments.BCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("after first swap bCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	value, err = deployments.CCoin.BalanceOf(&bind.CallOpts{}, auth.From)
+	ChkErr(err)
+	log.Debugf("after first swap cCoin.balanceOf[%s]: %d", auth.From.Hex(), value)
+	log.Debugf("Swaping tokens from B <-> C")
+	SwapExactTokensForTokens(auth, client, deployments.Factory, deployments.Router, deployments.BCoinAddr, deployments.CCoinAddr, swapExactAmountIn2)
+	fmt.Println()
+}
+
+func SwapExactTokensForTokens(auth *bind.TransactOpts, client *ethclient.Client,
+	factory *UniswapV2Factory.UniswapV2Factory, router *UniswapV2Router02.UniswapV2Router02,
+	tokenA, tokenB common.Address, exactAmountIn *big.Int) {
+	ctx := context.Background()
+	logPrefix := fmt.Sprintf("SwapExactTokensForTokens %v <-> %v", tokenA.Hex(), tokenB.Hex())
+	pairAddr, err := factory.GetPair(nil, tokenA, tokenB)
+	ChkErr(err)
+	log.Debug(logPrefix, " pair: ", pairAddr.Hex())
+	pairSC, err := UniswapV2Pair.NewUniswapV2Pair(pairAddr, client)
+	ChkErr(err)
+	pairReserves, err := pairSC.GetReserves(nil)
+	ChkErr(err)
+	log.Debug(logPrefix, " reserves 0: ", pairReserves.Reserve0, " 1: ", pairReserves.Reserve1, " Block Timestamp: ", pairReserves.BlockTimestampLast)
+	amountOut, err := router.GetAmountOut(nil, exactAmountIn, pairReserves.Reserve0, pairReserves.Reserve1)
+	ChkErr(err)
+	log.Debug(logPrefix, " exactAmountIn: ", exactAmountIn, " amountOut: ", amountOut)
+	tx, err := router.SwapExactTokensForTokens(auth, exactAmountIn, amountOut, []common.Address{tokenA, tokenB}, auth.From, getDeadline())
+	err = WaitForTransactionAndIncrementNonce(client, auth, err, ctx, tx)
+}

--- a/test/scripts/uniswap/pkg/types.go
+++ b/test/scripts/uniswap/pkg/types.go
@@ -1,0 +1,19 @@
+package pkg
+
+import (
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/ERC20"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/core/UniswapV2Factory"
+	"github.com/0xPolygonHermez/zkevm-node/test/contracts/bin/uniswap/v2/periphery/UniswapV2Router02"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Deployments struct {
+	ACoin     *ERC20.ERC20
+	ACoinAddr common.Address
+	BCoin     *ERC20.ERC20
+	BCoinAddr common.Address
+	CCoin     *ERC20.ERC20
+	CCoinAddr common.Address
+	Router    *UniswapV2Router02.UniswapV2Router02
+	Factory   *UniswapV2Factory.UniswapV2Factory
+}


### PR DESCRIPTION
Closes #2355.

### What does this PR do?

This pull request introduces the `uniswap-transfers` benchmark script, which is designed to streamline various operations related to Uniswap smart contracts. Specifically, it will allow us to deploy, mint, approve, add liquidity, and perform swap cycles for Uniswap and ERC-20 tokens. The script also incorporates timing functionalities for operations before the swap cycles, and it uses the `NumberOfOperations` parameter to decide the number of swap cycles to perform.

#### Changes

1. **Deployment of Uniswap Smart Contracts:** The script facilitates the deployment of Uniswap smart contracts.

2. **Deployment of ERC-20 Tokens:** Enables the deployment of ERC-20 tokens using the benchmark script.

3. **Minting of ERC-20 Tokens:** Offers functionality to mint ERC-20 tokens.

4. **Approval of Amounts for Transactions:** Allows users to approve specific amounts for transactions.

5. **Liquidity Addition to the Uniswap Pool:** Provides a mechanism to add liquidity to the Uniswap pool.

6. **Performing Swap Cycles:** The script leverages the `NumberOfOperations` parameter to ascertain the number of swap cycles to execute.

7. **End-to-end Testing:** Moved all benchmark e2e tests under `e2e` directory. An end-to-end test has been added respectively to the new `e2e` directory as follows: `zkevm-node/test/benchmarks/e2e/uniswap-transfers`, which can be initiated using the `make` command: `benchmark-sequencer-uniswap-transfers`.

8. **Metrics Collection and Printing:** Added collection of `gasUsed` metrics during transactions and printing of the following metrics: `Average gas used per transaction`, `Total Gas`, and `Gas per second`.

### Objective:

By incorporating the `uniswap-transfers` benchmark script into our system, we enhance our ability to test, benchmark, and assess various operations associated with Uniswap and ERC-20 tokens.

### Reviewers

- @ToniRamirezM 
- @tclemos 