### PR TITLE
new block endpoints and improvements to batch endpoint

### DIFF
--- a/docs/json-rpc-endpoints.md
+++ b/docs/json-rpc-endpoints.md
@@ -4,15 +4,16 @@ Here you will find the list of all supported JSON RPC endpoints and any differen
 
 If the endpoint is not in the list below, it means this specific endpoint is not supported yet, feel free to open an issue requesting it to be added and please explain the reason why you need it. 
 
-<!-- DEBUG -->
 > Warning: debug endpoints are considered experimental as they have not been deeply tested yet
+<!-- DEBUG -->
 - `debug_traceBlockByHash`
 - `debug_traceBlockByNumber`
 - `debug_traceTransaction`
+- `debug_traceBatchByNumber`
 
 <!-- ETH -->
 - `eth_blockNumber`
-- `eth_call` 
+- `eth_call`
   - _doesn't support state override at the moment and pending block. Will be implemented [#1990](https://github.com/0xPolygonHermez/zkevm-node/issues/1990)_ 
   - _doesn't support `from` values that are smart contract addresses. Will be implemented [#2017](https://github.com/0xPolygonHermez/zkevm-node/issues/2017)_  
 - `eth_chainId`
@@ -62,6 +63,8 @@ If the endpoint is not in the list below, it means this specific endpoint is not
 - `zkevm_batchNumberByBlockNumber`
 - `zkevm_consolidatedBlockNumber`
 - `zkevm_getBatchByNumber`
+- `zkevm_getFullBlockByHash`
+- `zkevm_getFullBlockByNumber`
 - `zkevm_isBlockConsolidated`
 - `zkevm_isBlockVirtualized`
 - `zkevm_verifiedBatchNumber`

--- a/jsonrpc/endpoints_eth.go
+++ b/jsonrpc/endpoints_eth.go
@@ -269,7 +269,20 @@ func (e *EthEndpoints) GetBlockByHash(hash types.ArgHash, fullTx bool) (interfac
 			return RPCErrorResponse(types.DefaultErrorCode, "failed to get block by hash from state", err)
 		}
 
-		rpcBlock := types.NewBlock(block, fullTx)
+		txs := block.Transactions()
+		receipts := make([]ethTypes.Receipt, 0, len(txs))
+		for _, tx := range txs {
+			receipt, err := e.state.GetTransactionReceipt(ctx, tx.Hash(), dbTx)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load receipt for tx %v", tx.Hash().String()), err)
+			}
+			receipts = append(receipts, *receipt)
+		}
+
+		rpcBlock, err := types.NewBlock(block, receipts, fullTx, false)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build block response for block by hash %v", hash.Hash()), err)
+		}
 
 		return rpcBlock, nil
 	})
@@ -289,7 +302,10 @@ func (e *EthEndpoints) GetBlockByNumber(number types.BlockNumber, fullTx bool) (
 			header.TxHash = ethTypes.EmptyRootHash
 			header.UncleHash = ethTypes.EmptyUncleHash
 			block := ethTypes.NewBlockWithHeader(header)
-			rpcBlock := types.NewBlock(block, fullTx)
+			rpcBlock, err := types.NewBlock(block, nil, fullTx, false)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, "couldn't build the pending block response", err)
+			}
 
 			return rpcBlock, nil
 		}
@@ -306,7 +322,20 @@ func (e *EthEndpoints) GetBlockByNumber(number types.BlockNumber, fullTx bool) (
 			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load block from state by number %v", blockNumber), err)
 		}
 
-		rpcBlock := types.NewBlock(block, fullTx)
+		txs := block.Transactions()
+		receipts := make([]ethTypes.Receipt, 0, len(txs))
+		for _, tx := range txs {
+			receipt, err := e.state.GetTransactionReceipt(ctx, tx.Hash(), dbTx)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load receipt for tx %v", tx.Hash().String()), err)
+			}
+			receipts = append(receipts, *receipt)
+		}
+
+		rpcBlock, err := types.NewBlock(block, receipts, fullTx, false)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build block response for block by number %v", blockNumber), err)
+		}
 
 		return rpcBlock, nil
 	})
@@ -501,8 +530,12 @@ func (e *EthEndpoints) GetTransactionByBlockHashAndIndex(hash types.ArgHash, ind
 			return RPCErrorResponse(types.DefaultErrorCode, "failed to get transaction receipt", err)
 		}
 
-		txIndex := uint64(receipt.TransactionIndex)
-		return types.NewTransaction(*tx, receipt.BlockNumber, &receipt.BlockHash, &txIndex), nil
+		res, err := types.NewTransaction(*tx, receipt, false)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, "failed to build transaction response", err)
+		}
+
+		return res, nil
 	})
 }
 
@@ -530,8 +563,12 @@ func (e *EthEndpoints) GetTransactionByBlockNumberAndIndex(number *types.BlockNu
 			return RPCErrorResponse(types.DefaultErrorCode, "failed to get transaction receipt", err)
 		}
 
-		txIndex := uint64(receipt.TransactionIndex)
-		return types.NewTransaction(*tx, receipt.BlockNumber, &receipt.BlockHash, &txIndex), nil
+		res, err := types.NewTransaction(*tx, receipt, false)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, "failed to build transaction response", err)
+		}
+
+		return res, nil
 	})
 }
 
@@ -551,8 +588,12 @@ func (e *EthEndpoints) GetTransactionByHash(hash types.ArgHash) (interface{}, ty
 				return RPCErrorResponse(types.DefaultErrorCode, "failed to load transaction receipt from state", err)
 			}
 
-			txIndex := uint64(receipt.TransactionIndex)
-			return types.NewTransaction(*tx, receipt.BlockNumber, &receipt.BlockHash, &txIndex), nil
+			res, err := types.NewTransaction(*tx, receipt, false)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, "failed to build transaction response", err)
+			}
+
+			return res, nil
 		}
 
 		// if the tx does not exist in the state, look for it in the pool
@@ -567,7 +608,11 @@ func (e *EthEndpoints) GetTransactionByHash(hash types.ArgHash) (interface{}, ty
 		}
 		if poolTx.Status == pool.TxStatusPending {
 			tx = &poolTx.Transaction
-			return types.NewTransaction(*tx, nil, nil, nil), nil
+			res, err := types.NewTransaction(*tx, nil, false)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, "failed to build transaction response", err)
+			}
+			return res, nil
 		}
 		return nil, nil
 	})
@@ -980,8 +1025,12 @@ func (e *EthEndpoints) onNewL2Block(event state.NewL2BlockEvent) {
 		log.Errorf("failed to get all block filters with web sockets connections: %v", err)
 	} else {
 		for _, filter := range blockFilters {
-			b := types.NewBlock(&event.Block, false)
-			e.sendSubscriptionResponse(filter, b)
+			b, err := types.NewBlock(&event.Block, nil, false, false)
+			if err != nil {
+				log.Errorf("failed to build block response to subscription: %v", err)
+			} else {
+				e.sendSubscriptionResponse(filter, b)
+			}
 		}
 	}
 

--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -1006,6 +1006,13 @@ func TestGetL2BlockByHash(t *testing.T) {
 					On("GetL2BlockByHash", context.Background(), tc.Hash, m.DbTx).
 					Return(block, nil).
 					Once()
+
+				for _, tx := range tc.ExpectedResult.Transactions() {
+					m.State.
+						On("GetTransactionReceipt", context.Background(), tx.Hash(), m.DbTx).
+						Return(ethTypes.NewReceipt([]byte{}, false, uint64(0)), nil).
+						Once()
+				}
 			},
 		},
 	}
@@ -1132,6 +1139,13 @@ func TestGetL2BlockByNumber(t *testing.T) {
 					On("GetL2BlockByNumber", context.Background(), tc.ExpectedResult.Number().Uint64(), m.DbTx).
 					Return(tc.ExpectedResult, nil).
 					Once()
+
+				for _, tx := range tc.ExpectedResult.Transactions() {
+					m.State.
+						On("GetTransactionReceipt", context.Background(), tx.Hash(), m.DbTx).
+						Return(ethTypes.NewReceipt([]byte{}, false, uint64(0)), nil).
+						Once()
+				}
 			},
 		},
 		{

--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -1106,6 +1106,13 @@ func TestGetL2BlockByNumber(t *testing.T) {
 					On("GetL2BlockByNumber", context.Background(), tc.Number.Uint64(), m.DbTx).
 					Return(block, nil).
 					Once()
+
+				for _, tx := range tc.ExpectedResult.Transactions() {
+					m.State.
+						On("GetTransactionReceipt", context.Background(), tx.Hash(), m.DbTx).
+						Return(ethTypes.NewReceipt([]byte{}, false, uint64(0)), nil).
+						Once()
+				}
 			},
 		},
 		{
@@ -1946,12 +1953,20 @@ func TestGetTransactionL2onByBlockHashAndIndex(t *testing.T) {
 		SetupMocks     func(m *mocksWrapper, tc testCase)
 	}
 
+	tx := ethTypes.NewTransaction(1, common.HexToAddress("0x111"), big.NewInt(2), 3, big.NewInt(4), []byte{5, 6, 7, 8})
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
+	require.NoError(t, err)
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
 	testCases := []testCase{
 		{
 			Name:           "Get Tx Successfully",
 			Hash:           common.HexToHash("0x999"),
 			Index:          uint(1),
-			ExpectedResult: ethTypes.NewTransaction(1, common.HexToAddress("0x111"), big.NewInt(2), 3, big.NewInt(4), []byte{5, 6, 7, 8}),
+			ExpectedResult: signedTx,
 			ExpectedError:  nil,
 			SetupMocks: func(m *mocksWrapper, tc testCase) {
 				tx := tc.ExpectedResult
@@ -2125,12 +2140,20 @@ func TestGetTransactionByBlockNumberAndIndex(t *testing.T) {
 		SetupMocks     func(m *mocksWrapper, tc testCase)
 	}
 
+	tx := ethTypes.NewTransaction(1, common.HexToAddress("0x111"), big.NewInt(2), 3, big.NewInt(4), []byte{5, 6, 7, 8})
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
+	require.NoError(t, err)
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
 	testCases := []testCase{
 		{
 			Name:           "Get Tx Successfully",
 			BlockNumber:    "0x1",
 			Index:          uint(0),
-			ExpectedResult: ethTypes.NewTransaction(1, common.HexToAddress("0x111"), big.NewInt(2), 3, big.NewInt(4), []byte{5, 6, 7, 8}),
+			ExpectedResult: signedTx,
 			ExpectedError:  nil,
 			SetupMocks: func(m *mocksWrapper, tc testCase) {
 				tx := tc.ExpectedResult
@@ -2339,12 +2362,20 @@ func TestGetTransactionByHash(t *testing.T) {
 		SetupMocks      func(m *mocksWrapper, tc testCase)
 	}
 
+	tx := ethTypes.NewTransaction(1, common.HexToAddress("0x111"), big.NewInt(2), 3, big.NewInt(4), []byte{5, 6, 7, 8})
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
+	require.NoError(t, err)
+	signedTx, err := auth.Signer(auth.From, tx)
+	require.NoError(t, err)
+
 	testCases := []testCase{
 		{
 			Name:            "Get TX Successfully from state",
 			Hash:            common.HexToHash("0x123"),
 			ExpectedPending: false,
-			ExpectedResult:  ethTypes.NewTransaction(1, common.Address{}, big.NewInt(1), 1, big.NewInt(1), []byte{}),
+			ExpectedResult:  signedTx,
 			ExpectedError:   nil,
 			SetupMocks: func(m *mocksWrapper, tc testCase) {
 				m.DbTx.

--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/0xPolygonHermez/zkevm-node/hex"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
@@ -174,10 +175,92 @@ func (z *ZKEVMEndpoints) GetBatchByNumber(batchNumber types.BatchNumber, fullTx 
 		}
 
 		batch.Transactions = txs
-		rpcBatch, err := types.NewBatch(batch, virtualBatch, verifiedBatch, blocks, receipts, fullTx, ger)
+		rpcBatch, err := types.NewBatch(batch, virtualBatch, verifiedBatch, blocks, receipts, fullTx, true, ger)
 		if err != nil {
 			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build the batch %v response", batchNumber), err)
 		}
 		return rpcBatch, nil
+	})
+}
+
+// GetFullBlockByNumber returns information about a block by block number
+func (z *ZKEVMEndpoints) GetFullBlockByNumber(number types.BlockNumber, fullTx bool) (interface{}, types.Error) {
+	return z.txMan.NewDbTxScope(z.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, types.Error) {
+		if number == types.PendingBlockNumber {
+			lastBlock, err := z.state.GetLastL2Block(ctx, dbTx)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, "couldn't load last block from state to compute the pending block", err)
+			}
+			header := ethTypes.CopyHeader(lastBlock.Header())
+			header.ParentHash = lastBlock.Hash()
+			header.Number = big.NewInt(0).SetUint64(lastBlock.Number().Uint64() + 1)
+			header.TxHash = ethTypes.EmptyRootHash
+			header.UncleHash = ethTypes.EmptyUncleHash
+			block := ethTypes.NewBlockWithHeader(header)
+			rpcBlock, err := types.NewBlock(block, nil, fullTx, true)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, "couldn't build the pending block response", err)
+			}
+
+			return rpcBlock, nil
+		}
+		var err error
+		blockNumber, rpcErr := number.GetNumericBlockNumber(ctx, z.state, dbTx)
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+
+		block, err := z.state.GetL2BlockByNumber(ctx, blockNumber, dbTx)
+		if errors.Is(err, state.ErrNotFound) {
+			return nil, nil
+		} else if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load block from state by number %v", blockNumber), err)
+		}
+
+		txs := block.Transactions()
+		receipts := make([]ethTypes.Receipt, 0, len(txs))
+		for _, tx := range txs {
+			receipt, err := z.state.GetTransactionReceipt(ctx, tx.Hash(), dbTx)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load receipt for tx %v", tx.Hash().String()), err)
+			}
+			receipts = append(receipts, *receipt)
+		}
+
+		rpcBlock, err := types.NewBlock(block, receipts, fullTx, true)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build block response for block by number %v", blockNumber), err)
+		}
+
+		return rpcBlock, nil
+	})
+}
+
+// GetFullBlockByHash returns information about a block by hash
+func (z *ZKEVMEndpoints) GetFullBlockByHash(hash types.ArgHash, fullTx bool) (interface{}, types.Error) {
+	return z.txMan.NewDbTxScope(z.state, func(ctx context.Context, dbTx pgx.Tx) (interface{}, types.Error) {
+		block, err := z.state.GetL2BlockByHash(ctx, hash.Hash(), dbTx)
+		if errors.Is(err, state.ErrNotFound) {
+			return nil, nil
+		} else if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, "failed to get block by hash from state", err)
+		}
+
+		txs := block.Transactions()
+		receipts := make([]ethTypes.Receipt, 0, len(txs))
+		for _, tx := range txs {
+			receipt, err := z.state.GetTransactionReceipt(ctx, tx.Hash(), dbTx)
+			if err != nil {
+				return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load receipt for tx %v", tx.Hash().String()), err)
+			}
+			receipts = append(receipts, *receipt)
+		}
+
+		rpcBlock, err := types.NewBlock(block, receipts, fullTx, true)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build block response for block by hash %v", hash.Hash()), err)
+		}
+
+		return rpcBlock, nil
 	})
 }

--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -168,8 +168,16 @@ func (z *ZKEVMEndpoints) GetBatchByNumber(batchNumber types.BatchNumber, fullTx 
 			ger = &state.GlobalExitRoot{}
 		}
 
+		blocks, err := z.state.GetL2BlocksByBatchNumber(ctx, batchNumber, dbTx)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't load blocks associated to the batch %v", batchNumber), err)
+		}
+
 		batch.Transactions = txs
-		rpcBatch := types.NewBatch(batch, virtualBatch, verifiedBatch, receipts, fullTx, ger)
+		rpcBatch, err := types.NewBatch(batch, virtualBatch, verifiedBatch, blocks, receipts, fullTx, ger)
+		if err != nil {
+			return RPCErrorResponse(types.DefaultErrorCode, fmt.Sprintf("couldn't build the batch %v response", batchNumber), err)
+		}
 		return rpcBatch, nil
 	})
 }

--- a/jsonrpc/endpoints_zkevm.openrpc.json
+++ b/jsonrpc/endpoints_zkevm.openrpc.json
@@ -273,6 +273,58 @@
           }
         }
       ]
+    },
+    {
+      "name": "zkevm_getFullBlockByNumber",
+      "summary": "Gets a block with extra information for a given number",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/BlockNumber"
+        },
+        {
+          "name": "includeTransactions",
+          "description": "If `true` it returns the full transaction objects, if `false` only the hashes of the transactions.",
+          "required": true,
+          "schema": {
+            "title": "isTransactionsIncluded",
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "getBlockByNumberResult",
+        "schema": {
+          "$ref": "#/components/schemas/FullBlockOrNull"
+        }
+      }
+    },
+    {
+      "name": "zkevm_getFullBlockByHash",
+      "summary": "Gets a block with extra information for a given hash",
+      "params": [
+        {
+          "name": "blockHash",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BlockHash"
+          }
+        },
+        {
+          "name": "includeTransactions",
+          "description": "If `true` it returns the full transaction objects, if `false` only the hashes of the transactions.",
+          "required": true,
+          "schema": {
+            "title": "isTransactionsIncluded",
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "getBlockByHashResult",
+        "schema": {
+          "$ref": "#/components/schemas/FullBlockOrNull"
+        }
+      }
     }
   ],
   "components": {
@@ -313,6 +365,14 @@
         "schema": {
           "$ref": "#/components/schemas/Batch"
         }
+      },
+      "Block": {
+        "name": "block",
+        "summary": "A block",
+        "description": "A block object",
+        "schema": {
+          "$ref": "#/components/schemas/Block"
+        }
       }
     },
     "schemas": {
@@ -347,11 +407,28 @@
         "type": "string",
         "pattern": "^0x[a-fA-F\\d]{40}$"
       },
+      "BlockHash": {
+        "title": "blockHash",
+        "type": "string",
+        "pattern": "^0x[a-fA-F\\d]{64}$",
+        "description": "The hex representation of the Keccak 256 of the RLP encoded block"
+      },
       "BlockNumber": {
         "title": "blockNumber",
         "type": "string",
         "description": "The hex representation of the block's height",
         "$ref": "#/components/schemas/Integer"
+      },
+      "FullBlockOrNull": {
+        "title": "fullBlockOrNull",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FullBlock"
+          },
+          {
+            "$ref": "#/components/schemas/Null"
+          }
+        ]
       },
       "BatchNumber": {
         "title": "batchNumber",
@@ -364,6 +441,18 @@
         "type": "string",
         "description": "Keccak 256 Hash of the RLP encoding of a transaction",
         "$ref": "#/components/schemas/Keccak"
+      },
+      "NonceOrNull": {
+        "title": "nonceOrNull",
+        "description": "Randomly selected number to satisfy the proof-of-work or null when its the pending block",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Nonce"
+          },
+          {
+            "$ref": "#/components/schemas/Null"
+          }
+        ]
       },
       "Nonce": {
         "title": "nonce",
@@ -392,6 +481,17 @@
         "oneOf": [
           {
             "$ref": "#/components/schemas/Integer"
+          },
+          {
+            "$ref": "#/components/schemas/Null"
+          }
+        ]
+      },
+      "AddressOrNull": {
+        "title": "addressOrNull",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Address"
           },
           {
             "$ref": "#/components/schemas/Null"
@@ -439,22 +539,6 @@
           "number": {
             "$ref": "#/components/schemas/BlockNumber"
           },
-          "transactions": {
-            "title": "transactionsOrHashes",
-            "description": "Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter",
-            "type": "array",
-            "items": {
-              "title": "transactionOrTransactionHash",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Transaction"
-                },
-                {
-                  "$ref": "#/components/schemas/TransactionHash"
-                }
-              ]
-            }
-          },
           "globalExitRoot": {
             "$ref": "#/components/schemas/Keccak"
           },
@@ -476,11 +560,264 @@
           "verifyBatchTxHash": {
             "$ref": "#/components/schemas/TransactionHash"
           },
+          "closed": {
+            "title": "closed",
+            "type": "boolean",
+            "description": "True if the batch is already closed, otherwise false"
+          },
+          "blocks": {
+            "title": "blocksOrHashes",
+            "description": "Array of block objects, or 32 Bytes block hashes depending on the last given parameter",
+            "type": "array",
+            "items": {
+              "title": "blockOrBlockHash",
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Block"
+                },
+                {
+                  "$ref": "#/components/schemas/BlockHash"
+                }
+              ]
+            }
+          },
+          "transactions": {
+            "title": "transactionsOrHashes",
+            "description": "Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter",
+            "type": "array",
+            "items": {
+              "title": "transactionOrTransactionHash",
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Transaction"
+                },
+                {
+                  "$ref": "#/components/schemas/TransactionHash"
+                }
+              ]
+            }
+          },
           "stateRoot": {
             "$ref": "#/components/schemas/Keccak"
           },
           "coinbase": {
             "$ref": "#/components/schemas/Address"
+          }
+        }
+      },
+      "Block": {
+        "title": "Block",
+        "type": "object",
+        "properties": {
+          "number": {
+            "$ref": "#/components/schemas/BlockNumberOrNull"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/BlockHashOrNull"
+          },
+          "parentHash": {
+            "$ref": "#/components/schemas/BlockHash"
+          },
+          "nonce": {
+            "$ref": "#/components/schemas/NonceOrNull"
+          },
+          "sha3Uncles": {
+            "title": "blockShaUncles",
+            "description": "Keccak hash of the uncles data in the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "logsBloom": {
+            "title": "blockLogsBloom",
+            "type": "string",
+            "description": "The bloom filter for the logs of the block or null when its the pending block",
+            "pattern": "^0x[a-fA-F\\d]+$"
+          },
+          "transactionsRoot": {
+            "title": "blockTransactionsRoot",
+            "description": "The root of the transactions trie of the block.",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "stateRoot": {
+            "title": "blockStateRoot",
+            "description": "The root of the final state trie of the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "receiptsRoot": {
+            "title": "blockReceiptsRoot",
+            "description": "The root of the receipts trie of the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "miner": {
+            "$ref": "#/components/schemas/AddressOrNull"
+          },
+          "difficulty": {
+            "title": "blockDifficulty",
+            "type": "string",
+            "description": "Integer of the difficulty for this block"
+          },
+          "totalDifficulty": {
+            "title": "blockTotalDifficulty",
+            "description": "Integer of the total difficulty of the chain until this block",
+            "$ref": "#/components/schemas/IntegerOrNull"
+          },
+          "extraData": {
+            "title": "blockExtraData",
+            "type": "string",
+            "description": "The 'extra data' field of this block"
+          },
+          "size": {
+            "title": "blockSize",
+            "type": "string",
+            "description": "Integer the size of this block in bytes"
+          },
+          "gasLimit": {
+            "title": "blockGasLimit",
+            "type": "string",
+            "description": "The maximum gas allowed in this block"
+          },
+          "gasUsed": {
+            "title": "blockGasUsed",
+            "type": "string",
+            "description": "The total used gas by all transactions in this block"
+          },
+          "timestamp": {
+            "title": "blockTimeStamp",
+            "type": "string",
+            "description": "The unix timestamp for when the block was collated"
+          },
+          "transactions": {
+            "title": "transactionsOrHashes",
+            "description": "Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter",
+            "type": "array",
+            "items": {
+              "title": "transactionOrTransactionHash",
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Transaction"
+                },
+                {
+                  "$ref": "#/components/schemas/TransactionHash"
+                }
+              ]
+            }
+          },
+          "uncles": {
+            "title": "uncleHashes",
+            "description": "Array of uncle hashes",
+            "type": "array",
+            "items": {
+              "title": "uncleHash",
+              "description": "Block hash of the RLP encoding of an uncle block",
+              "$ref": "#/components/schemas/Keccak"
+            }
+          }
+        }
+      },
+      "FullBlock": {
+        "title": "fullBlock",
+        "type": "object",
+        "properties": {
+          "number": {
+            "$ref": "#/components/schemas/BlockNumberOrNull"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/BlockHashOrNull"
+          },
+          "parentHash": {
+            "$ref": "#/components/schemas/BlockHash"
+          },
+          "nonce": {
+            "$ref": "#/components/schemas/NonceOrNull"
+          },
+          "sha3Uncles": {
+            "title": "blockShaUncles",
+            "description": "Keccak hash of the uncles data in the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "logsBloom": {
+            "title": "blockLogsBloom",
+            "type": "string",
+            "description": "The bloom filter for the logs of the block or null when its the pending block",
+            "pattern": "^0x[a-fA-F\\d]+$"
+          },
+          "transactionsRoot": {
+            "title": "blockTransactionsRoot",
+            "description": "The root of the transactions trie of the block.",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "stateRoot": {
+            "title": "blockStateRoot",
+            "description": "The root of the final state trie of the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "receiptsRoot": {
+            "title": "blockReceiptsRoot",
+            "description": "The root of the receipts trie of the block",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "miner": {
+            "$ref": "#/components/schemas/AddressOrNull"
+          },
+          "difficulty": {
+            "title": "blockDifficulty",
+            "type": "string",
+            "description": "Integer of the difficulty for this block"
+          },
+          "totalDifficulty": {
+            "title": "blockTotalDifficulty",
+            "description": "Integer of the total difficulty of the chain until this block",
+            "$ref": "#/components/schemas/IntegerOrNull"
+          },
+          "extraData": {
+            "title": "blockExtraData",
+            "type": "string",
+            "description": "The 'extra data' field of this block"
+          },
+          "size": {
+            "title": "blockSize",
+            "type": "string",
+            "description": "Integer the size of this block in bytes"
+          },
+          "gasLimit": {
+            "title": "blockGasLimit",
+            "type": "string",
+            "description": "The maximum gas allowed in this block"
+          },
+          "gasUsed": {
+            "title": "blockGasUsed",
+            "type": "string",
+            "description": "The total used gas by all transactions in this block"
+          },
+          "timestamp": {
+            "title": "blockTimeStamp",
+            "type": "string",
+            "description": "The unix timestamp for when the block was collated"
+          },
+          "transactions": {
+            "title": "transactionsOrHashes",
+            "description": "Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter",
+            "type": "array",
+            "items": {
+              "title": "transactionOrTransactionHash",
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FullTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/TransactionHash"
+                }
+              ]
+            }
+          },
+          "uncles": {
+            "title": "uncleHashes",
+            "description": "Array of uncle hashes",
+            "type": "array",
+            "items": {
+              "title": "uncleHash",
+              "description": "Block hash of the RLP encoding of an uncle block",
+              "$ref": "#/components/schemas/Keccak"
+            }
           }
         }
       },
@@ -553,6 +890,78 @@
           }
         }
       },
+      "FullTransaction": {
+        "title": "fullTransaction",
+        "type": "object",
+        "required": [
+          "gas",
+          "gasPrice",
+          "nonce"
+        ],
+        "properties": {
+          "blockHash": {
+            "$ref": "#/components/schemas/BlockHashOrNull"
+          },
+          "blockNumber": {
+            "$ref": "#/components/schemas/BlockNumberOrNull"
+          },
+          "from": {
+            "$ref": "#/components/schemas/From"
+          },
+          "gas": {
+            "title": "transactionGas",
+            "type": "string",
+            "description": "The gas limit provided by the sender in Wei"
+          },
+          "gasPrice": {
+            "title": "transactionGasPrice",
+            "type": "string",
+            "description": "The gas price willing to be paid by the sender in Wei"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/TransactionHash"
+          },
+          "input": {
+            "title": "transactionInput",
+            "type": "string",
+            "description": "The data field sent with the transaction"
+          },
+          "nonce": {
+            "title": "transactionNonce",
+            "description": "The total number of prior transactions made by the sender",
+            "$ref": "#/components/schemas/Nonce"
+          },
+          "to": {
+            "$ref": "#/components/schemas/To"
+          },
+          "transactionIndex": {
+            "$ref": "#/components/schemas/TransactionIndex"
+          },
+          "value": {
+            "title": "transactionValue",
+            "description": "Value of Ether being transferred in Wei",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "v": {
+            "title": "transactionSigV",
+            "type": "string",
+            "description": "ECDSA recovery id"
+          },
+          "r": {
+            "title": "transactionSigR",
+            "type": "string",
+            "description": "ECDSA signature r"
+          },
+          "s": {
+            "title": "transactionSigS",
+            "type": "string",
+            "description": "ECDSA signature s"
+          },
+          "receipt": {
+            "$ref": "#/components/schemas/Receipt"
+          }
+        }
+      },
       "Transactions": {
         "title": "transactions",
         "description": "An array of transactions",
@@ -560,6 +969,152 @@
         "items": {
           "$ref": "#/components/schemas/Transaction"
         }
+      },
+      "Receipt": {
+        "title": "receipt",
+        "type": "object",
+        "description": "The receipt of a transaction",
+        "required": [
+          "blockHash",
+          "blockNumber",
+          "contractAddress",
+          "cumulativeGasUsed",
+          "from",
+          "gasUsed",
+          "logs",
+          "logsBloom",
+          "to",
+          "transactionHash",
+          "transactionIndex"
+        ],
+        "properties": {
+          "blockHash": {
+            "$ref": "#/components/schemas/BlockHash"
+          },
+          "blockNumber": {
+            "$ref": "#/components/schemas/BlockNumber"
+          },
+          "contractAddress": {
+            "title": "ReceiptContractAddress",
+            "description": "The contract address created, if the transaction was a contract creation, otherwise null",
+            "$ref": "#/components/schemas/AddressOrNull"
+          },
+          "cumulativeGasUsed": {
+            "title": "ReceiptCumulativeGasUsed",
+            "description": "The gas units used by the transaction",
+            "$ref": "#/components/schemas/Integer"
+          },
+          "from": {
+            "$ref": "#/components/schemas/From"
+          },
+          "gasUsed": {
+            "title": "ReceiptGasUsed",
+            "description": "The total gas used by the transaction",
+            "$ref": "#/components/schemas/Integer"
+          },
+          "logs": {
+            "title": "logs",
+            "type": "array",
+            "description": "An array of all the logs triggered during the transaction",
+            "items": {
+              "$ref": "#/components/schemas/Log"
+            }
+          },
+          "logsBloom": {
+            "$ref": "#/components/schemas/BloomFilter"
+          },
+          "to": {
+            "$ref": "#/components/schemas/To"
+          },
+          "transactionHash": {
+            "$ref": "#/components/schemas/TransactionHash"
+          },
+          "transactionIndex": {
+            "$ref": "#/components/schemas/TransactionIndex"
+          },
+          "postTransactionState": {
+            "title": "ReceiptPostTransactionState",
+            "description": "The intermediate stateRoot directly after transaction execution.",
+            "$ref": "#/components/schemas/Keccak"
+          },
+          "status": {
+            "title": "ReceiptStatus",
+            "description": "Whether or not the transaction threw an error.",
+            "type": "boolean"
+          }
+        }
+      },
+      "BloomFilter": {
+        "title": "bloomFilter",
+        "type": "string",
+        "description": "A 2048 bit bloom filter from the logs of the transaction. Each log sets 3 bits though taking the low-order 11 bits of each of the first three pairs of bytes in a Keccak 256 hash of the log's byte series"
+      },
+      "Log": {
+        "title": "log",
+        "type": "object",
+        "description": "An indexed event generated during a transaction",
+        "properties": {
+          "address": {
+            "title": "LogAddress",
+            "description": "Sender of the transaction",
+            "$ref": "#/components/schemas/Address"
+          },
+          "blockHash": {
+            "$ref": "#/components/schemas/BlockHash"
+          },
+          "blockNumber": {
+            "$ref": "#/components/schemas/BlockNumber"
+          },
+          "data": {
+            "title": "LogData",
+            "description": "The data/input string sent along with the transaction",
+            "$ref": "#/components/schemas/Bytes"
+          },
+          "logIndex": {
+            "title": "LogIndex",
+            "description": "The index of the event within its transaction, null when its pending",
+            "$ref": "#/components/schemas/Integer"
+          },
+          "removed": {
+            "title": "logIsRemoved",
+            "description": "Whether or not the log was orphaned off the main chain",
+            "type": "boolean"
+          },
+          "topics": {
+            "$ref": "#/components/schemas/Topics"
+          },
+          "transactionHash": {
+            "$ref": "#/components/schemas/TransactionHash"
+          },
+          "transactionIndex": {
+            "$ref": "#/components/schemas/TransactionIndex"
+          }
+        }
+      },
+      "Topics": {
+        "title": "LogTopics",
+        "description": "Topics are order-dependent. Each topic can also be an array of DATA with 'or' options.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Topic"
+        }
+      },
+      "Topic": {
+        "title": "topic",
+        "description": "32 Bytes DATA of indexed log arguments. (In solidity: The first topic is the hash of the signature of the event (e.g. Deposit(address,bytes32,uint256))",
+        "$ref": "#/components/schemas/DataWord"
+      },
+      "DataWord": {
+        "title": "dataWord",
+        "type": "string",
+        "description": "Hex representation of a 256 bit unit of data",
+        "pattern": "^0x([a-fA-F\\d]{64})?$"
+      },
+      "Bytes": {
+        "title": "bytes",
+        "type": "string",
+        "description": "Hex representation of a variable length byte array",
+        "pattern": "^0x([a-fA-F0-9]?)+$"
       }
     }
   }

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -831,7 +831,6 @@ func TestGetBatchByNumber(t *testing.T) {
 
 					batchTxs = append(batchTxs, *tx)
 					effectivePercentages = append(effectivePercentages, state.MaxEffectivePercentage)
-
 				}
 				batchL2Data, err := state.EncodeTransactions(batchTxs, effectivePercentages, forkID5)
 				require.NoError(t, err)

--- a/jsonrpc/mocks/mock_state.go
+++ b/jsonrpc/mocks/mock_state.go
@@ -391,6 +391,32 @@ func (_m *StateMock) GetL2BlockTransactionCountByNumber(ctx context.Context, blo
 	return r0, r1
 }
 
+// GetL2BlocksByBatchNumber provides a mock function with given fields: ctx, batchNumber, dbTx
+func (_m *StateMock) GetL2BlocksByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]coretypes.Block, error) {
+	ret := _m.Called(ctx, batchNumber, dbTx)
+
+	var r0 []coretypes.Block
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) ([]coretypes.Block, error)); ok {
+		return rf(ctx, batchNumber, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) []coretypes.Block); ok {
+		r0 = rf(ctx, batchNumber, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]coretypes.Block)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, batchNumber, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLastBatchNumber provides a mock function with given fields: ctx, dbTx
 func (_m *StateMock) GetLastBatchNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error) {
 	ret := _m.Called(ctx, dbTx)

--- a/jsonrpc/types/interfaces.go
+++ b/jsonrpc/types/interfaces.go
@@ -64,4 +64,5 @@ type StateInterface interface {
 	GetVirtualBatch(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.VirtualBatch, error)
 	GetVerifiedBatch(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.VerifiedBatch, error)
 	GetExitRootByGlobalExitRoot(ctx context.Context, ger common.Hash, dbTx pgx.Tx) (*state.GlobalExitRoot, error)
+	GetL2BlocksByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]types.Block, error)
 }

--- a/jsonrpc/types/types.go
+++ b/jsonrpc/types/types.go
@@ -262,7 +262,7 @@ type Block struct {
 }
 
 // NewBlock creates a Block instance
-func NewBlock(b *types.Block, fullTx bool) *Block {
+func NewBlock(b *types.Block, receipts []types.Receipt, fullTx, includeReceipts bool) (*Block, error) {
 	h := b.Header()
 
 	n := big.NewInt(0).SetUint64(h.Nonce.Uint64())
@@ -298,17 +298,28 @@ func NewBlock(b *types.Block, fullTx bool) *Block {
 		Uncles:          []common.Hash{},
 	}
 
-	for idx, txn := range b.Transactions() {
+	receiptsMap := make(map[common.Hash]types.Receipt, len(receipts))
+	for _, receipt := range receipts {
+		receiptsMap[receipt.TxHash] = receipt
+	}
+
+	for _, tx := range b.Transactions() {
 		if fullTx {
-			blockHash := b.Hash()
-			txIndex := uint64(idx)
-			tx := NewTransaction(*txn, b.Number(), &blockHash, &txIndex)
+			var receiptPtr *types.Receipt
+			if receipt, found := receiptsMap[tx.Hash()]; found {
+				receiptPtr = &receipt
+			}
+
+			rpcTx, err := NewTransaction(*tx, receiptPtr, includeReceipts)
+			if err != nil {
+				return nil, err
+			}
 			res.Transactions = append(
 				res.Transactions,
-				TransactionOrHash{Tx: tx},
+				TransactionOrHash{Tx: rpcTx},
 			)
 		} else {
-			h := txn.Hash()
+			h := tx.Hash()
 			res.Transactions = append(
 				res.Transactions,
 				TransactionOrHash{Hash: &h},
@@ -320,7 +331,7 @@ func NewBlock(b *types.Block, fullTx bool) *Block {
 		res.Uncles = append(res.Uncles, uncle.Hash())
 	}
 
-	return res
+	return res, nil
 }
 
 // Batch structure
@@ -337,15 +348,16 @@ type Batch struct {
 	Timestamp           ArgUint64           `json:"timestamp"`
 	SendSequencesTxHash *common.Hash        `json:"sendSequencesTxHash"`
 	VerifyBatchTxHash   *common.Hash        `json:"verifyBatchTxHash"`
+	Closed              bool                `json:"closed"`
 	Blocks              []BlockOrHash       `json:"blocks"`
 	Transactions        []TransactionOrHash `json:"transactions"`
-	Receipts            []Receipt           `json:"receipts"`
 	BatchL2Data         ArgBytes            `json:"batchL2Data"`
 }
 
 // NewBatch creates a Batch instance
-func NewBatch(batch *state.Batch, virtualBatch *state.VirtualBatch, verifiedBatch *state.VerifiedBatch, blocks []types.Block, receipts []types.Receipt, fullTx bool, ger *state.GlobalExitRoot) (*Batch, error) {
+func NewBatch(batch *state.Batch, virtualBatch *state.VirtualBatch, verifiedBatch *state.VerifiedBatch, blocks []types.Block, receipts []types.Receipt, fullTx, includeReceipts bool, ger *state.GlobalExitRoot) (*Batch, error) {
 	batchL2Data := batch.BatchL2Data
+	closed := batch.StateRoot.String() != state.ZeroHash.String() || batch.BatchNumber == 0
 	res := &Batch{
 		Number:          ArgUint64(batch.BatchNumber),
 		GlobalExitRoot:  batch.GlobalExitRoot,
@@ -357,6 +369,7 @@ func NewBatch(batch *state.Batch, virtualBatch *state.VirtualBatch, verifiedBatc
 		Coinbase:        batch.Coinbase,
 		LocalExitRoot:   batch.LocalExitRoot,
 		BatchL2Data:     ArgBytes(batchL2Data),
+		Closed:          closed,
 	}
 	if batch.ForcedBatchNum != nil {
 		fb := ArgUint64(*batch.ForcedBatchNum)
@@ -378,15 +391,15 @@ func NewBatch(batch *state.Batch, virtualBatch *state.VirtualBatch, verifiedBatc
 
 	for _, tx := range batch.Transactions {
 		if fullTx {
-			receipt := receiptsMap[tx.Hash()]
-			txIndex := uint64(receipt.TransactionIndex)
-			rpcTx := NewTransaction(tx, receipt.BlockNumber, &receipt.BlockHash, &txIndex)
-			res.Transactions = append(res.Transactions, TransactionOrHash{Tx: rpcTx})
-			rpcReceipt, err := NewReceipt(tx, &receipt)
+			var receiptPtr *types.Receipt
+			if receipt, found := receiptsMap[tx.Hash()]; found {
+				receiptPtr = &receipt
+			}
+			rpcTx, err := NewTransaction(tx, receiptPtr, includeReceipts)
 			if err != nil {
 				return nil, err
 			}
-			res.Receipts = append(res.Receipts, rpcReceipt)
+			res.Transactions = append(res.Transactions, TransactionOrHash{Tx: rpcTx})
 		} else {
 			h := tx.Hash()
 			res.Transactions = append(res.Transactions, TransactionOrHash{Hash: &h})
@@ -396,7 +409,10 @@ func NewBatch(batch *state.Batch, virtualBatch *state.VirtualBatch, verifiedBatc
 	for _, b := range blocks {
 		b := b
 		if fullTx {
-			block := NewBlock(&b, false)
+			block, err := NewBlock(&b, nil, false, false)
+			if err != nil {
+				return nil, err
+			}
 			res.Blocks = append(res.Blocks, BlockOrHash{Block: block})
 		} else {
 			h := b.Hash()
@@ -497,6 +513,7 @@ type Transaction struct {
 	TxIndex     *ArgUint64      `json:"transactionIndex"`
 	ChainID     ArgBig          `json:"chainId"`
 	Type        ArgUint64       `json:"type"`
+	Receipt     *Receipt        `json:"receipt,omitempty"`
 }
 
 // CoreTx returns a geth core type Transaction
@@ -516,44 +533,46 @@ func (t Transaction) CoreTx() *types.Transaction {
 
 // NewTransaction creates a transaction instance
 func NewTransaction(
-	t types.Transaction,
-	blockNumber *big.Int,
-	blockHash *common.Hash,
-	txIndex *uint64,
-) *Transaction {
-	v, r, s := t.RawSignatureValues()
+	tx types.Transaction,
+	receipt *types.Receipt,
+	includeReceipt bool,
+) (*Transaction, error) {
+	v, r, s := tx.RawSignatureValues()
 
-	from, _ := state.GetSender(t)
+	from, _ := state.GetSender(tx)
 
 	res := &Transaction{
-		Nonce:    ArgUint64(t.Nonce()),
-		GasPrice: ArgBig(*t.GasPrice()),
-		Gas:      ArgUint64(t.Gas()),
-		To:       t.To(),
-		Value:    ArgBig(*t.Value()),
-		Input:    t.Data(),
+		Nonce:    ArgUint64(tx.Nonce()),
+		GasPrice: ArgBig(*tx.GasPrice()),
+		Gas:      ArgUint64(tx.Gas()),
+		To:       tx.To(),
+		Value:    ArgBig(*tx.Value()),
+		Input:    tx.Data(),
 		V:        ArgBig(*v),
 		R:        ArgBig(*r),
 		S:        ArgBig(*s),
-		Hash:     t.Hash(),
+		Hash:     tx.Hash(),
 		From:     from,
-		ChainID:  ArgBig(*t.ChainId()),
-		Type:     ArgUint64(t.Type()),
+		ChainID:  ArgBig(*tx.ChainId()),
+		Type:     ArgUint64(tx.Type()),
 	}
 
-	if blockNumber != nil {
-		bn := ArgUint64(blockNumber.Uint64())
+	if receipt != nil {
+		bn := ArgUint64(receipt.BlockNumber.Uint64())
 		res.BlockNumber = &bn
-	}
-
-	res.BlockHash = blockHash
-
-	if txIndex != nil {
-		ti := ArgUint64(*txIndex)
+		res.BlockHash = &receipt.BlockHash
+		ti := ArgUint64(receipt.TransactionIndex)
 		res.TxIndex = &ti
+		rpcReceipt, err := NewReceipt(tx, receipt)
+		if err != nil {
+			return nil, err
+		}
+		if includeReceipt {
+			res.Receipt = &rpcReceipt
+		}
 	}
 
-	return res
+	return res, nil
 }
 
 // Receipt structure

--- a/state/l2block.go
+++ b/state/l2block.go
@@ -23,7 +23,7 @@ type NewL2BlockEvent struct {
 
 // PrepareWebSocket allows the RPC to prepare ws
 func (s *State) PrepareWebSocket() {
-	lastL2Block, err := s.PostgresStorage.GetLastL2Block(context.Background(), nil)
+	lastL2Block, err := s.GetLastL2Block(context.Background(), nil)
 	if errors.Is(err, ErrStateNotSynchronized) {
 		lastL2Block = types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
 	} else if err != nil {

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -1124,9 +1124,7 @@ func (p *PostgresStorage) GetL2BlockByNumber(ctx context.Context, blockNumber ui
 	q := p.getExecQuerier(dbTx)
 	row := q.QueryRow(ctx, query, blockNumber)
 	header, uncles, receivedAt, err := p.scanL2BlockInfo(ctx, row, dbTx)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrNotFound
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -1621,7 +1619,9 @@ func (p *PostgresStorage) GetLastL2Block(ctx context.Context, dbTx pgx.Tx) (*typ
 	q := p.getExecQuerier(dbTx)
 	row := q.QueryRow(ctx, query)
 	header, uncles, receivedAt, err := p.scanL2BlockInfo(ctx, row, dbTx)
-	if err != nil {
+	if errors.Is(err, ErrNotFound) {
+		return nil, ErrStateNotSynchronized
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -1706,9 +1706,7 @@ func (p *PostgresStorage) GetL2BlockByHash(ctx context.Context, hash common.Hash
 	q := p.getExecQuerier(dbTx)
 	row := q.QueryRow(ctx, query, hash.String())
 	header, uncles, receivedAt, err := p.scanL2BlockInfo(ctx, row, dbTx)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrNotFound
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes #2410.

### What does this PR do?

Add two new endpoints to provide the receipt to the block transactions response:
- `zkevm_getFullBlockByNumber`
- `zkevm_getFullBlockByHash`

enrich `zkevm_getBatchByNumber` to provide blocks and receipts in a single request, this aims to reduce the requests needed in order for an explorer to synchronize the network information.

These are the current endpoints needed to be called when reading the network:
- eth_blockByNumber - to get the block and transactions
- eth_transactionReceipt - to get the tx receipt for each tx in the block
- eth_getBatchByNumber - to get the batch details

Now, calling only the `zkevm_getBatchByNumber` the response will contain:
- all the batch information
- all the blocks information associated with this batch
- all the transactions associated with this batch and blocks
- all the receipts for all transactions in this batch

### Reviewers

@agnusmor 
@ToniRamirezM