### PR TITLE
Check flushID != 0 in Sequencer

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -239,6 +239,9 @@ func (f *finalizer) updateProverIdAndFlushId(ctx context.Context) {
 			if err != nil {
 				log.Errorf("failed to get stored flush id, Err: %v", err)
 			} else {
+				if storedFlushID == 0 {
+					log.Fatal("storedFlushID is 0. Please check that prover/executor config parameter dbReadOnly is false")
+				}
 				if storedFlushID != f.storedFlushID {
 					// Check if prover/Executor has been restarted
 					f.checkIfProverRestarted(proverID)

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -240,7 +240,7 @@ func (f *finalizer) updateProverIdAndFlushId(ctx context.Context) {
 				log.Errorf("failed to get stored flush id, Err: %v", err)
 			} else {
 				if storedFlushID == 0 {
-					log.Fatal("storedFlushID is 0. Please check that prover/executor config parameter dbReadOnly is false")
+					f.halt(ctx, fmt.Errorf("storedFlushID is 0. Please check that prover/executor config parameter dbReadOnly is false"))					
 				}
 				if storedFlushID != f.storedFlushID {
 					// Check if prover/Executor has been restarted

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -240,7 +240,7 @@ func (f *finalizer) updateProverIdAndFlushId(ctx context.Context) {
 				log.Errorf("failed to get stored flush id, Err: %v", err)
 			} else {
 				if storedFlushID == 0 {
-					f.halt(ctx, fmt.Errorf("storedFlushID is 0. Please check that prover/executor config parameter dbReadOnly is false"))					
+					f.halt(ctx, fmt.Errorf("storedFlushID is 0. Please check that prover/executor config parameter dbReadOnly is false"))
 				}
 				if storedFlushID != f.storedFlushID {
 					// Check if prover/Executor has been restarted


### PR DESCRIPTION
### What does this PR do?

Adds a check to detect if the flushID received from the executor is 0. It should never be 0 for the Sequencer. If it is 0 it means the executor probably is running in readonly mode (the HashDB is not updated). If the flushid is 0 the Sequencer will stop showing a log.Fatal message

### Reviewers

Main reviewers:
@ToniRamirezM 
@Psykepro 
@ARR552 