### PR TITLE
Update config params used in Prover v2.1.0

### DIFF
--- a/config/environments/mainnet/prover.config.json
+++ b/config/environments/mainnet/prover.config.json
@@ -110,7 +110,8 @@
     "maxExecutorThreads": 20,
     "maxProverThreads": 8,
     "maxHashDBThreads": 8,
-    "ECRecoverPrecalc": true,
-    "ECRecoverPrecalcNThreads": 16,
-    "stateManager": true
+    "ECRecoverPrecalc": false,
+    "ECRecoverPrecalcNThreads": 4,
+    "stateManager": true,
+    "useAssociativeCache" : false    
 }

--- a/config/environments/testnet/prover.config.json
+++ b/config/environments/testnet/prover.config.json
@@ -110,7 +110,8 @@
     "maxExecutorThreads": 20,
     "maxProverThreads": 8,
     "maxHashDBThreads": 8,
-    "ECRecoverPrecalc": true,
-    "ECRecoverPrecalcNThreads": 16,
-    "stateManager": true
+    "ECRecoverPrecalc": false,
+    "ECRecoverPrecalcNThreads": 4,
+    "stateManager": true,
+    "useAssociativeCache" : false
 }

--- a/test/config/test.permissionless.prover.config.json
+++ b/test/config/test.permissionless.prover.config.json
@@ -81,8 +81,9 @@
     "maxExecutorThreads": 20,
     "maxProverThreads": 8,
     "maxHashDBThreads": 8,
-    "ECRecoverPrecalc": true,
-    "ECRecoverPrecalcNThreads": 16,
-    "stateManager": true
+    "ECRecoverPrecalc": false,
+    "ECRecoverPrecalcNThreads": 4,
+    "stateManager": true,
+    "useAssociativeCache" : false
 }
 

--- a/test/config/test.prover.config.json
+++ b/test/config/test.prover.config.json
@@ -83,8 +83,9 @@
     "maxExecutorThreads": 20,
     "maxProverThreads": 8,
     "maxHashDBThreads": 8,
-    "ECRecoverPrecalc": true,
-    "ECRecoverPrecalcNThreads": 16,
-    "stateManager": true
+    "ECRecoverPrecalc": false,
+    "ECRecoverPrecalcNThreads": 4,
+    "stateManager": true,
+    "useAssociativeCache" : false
 }
 


### PR DESCRIPTION
### What does this PR do?

Updates config params used in Prover v2.1.0:

>"ECRecoverPrecalc": false,
>"ECRecoverPrecalcNThreads": 4,
>"stateManager": true,
>"useAssociativeCache" : false

**NOTE:** ECRecoverPrecalc and useAssociativeCache params are disable since these features are not working fine in prover v2.1.0

### Reviewers

Main reviewers:
@ToniRamirezM 
@ARR552 
@tclemos 