### PR TITLE
review code owners to match with the current team structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@ jsonrpc/                @tclemos @Psykepro
 merkletree/             @ToniRamirezM
 pool/                   @tclemos @Psykepro
 proto/                  @ToniRamirezM
-sequencer/              @ToniRamirezM @Psykepro
-sequencersender/        @ToniRamirezM @Psykepro
+sequencer/              @ToniRamirezM @Psykepro @agnusmor
+sequencersender/        @ToniRamirezM @Psykepro @agnusmor
 state/                  @ToniRamirezM @tclemos
 synchronizer/           @ARR552 @joanestebanr
 test/                   @tclemos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ merkletree/             @ToniRamirezM
 pool/                   @tclemos @Psykepro
 proto/                  @ToniRamirezM
 sequencer/              @ToniRamirezM @Psykepro @agnusmor
-sequencersender/        @ToniRamirezM @Psykepro @agnusmor
+sequencesender/        @ToniRamirezM @Psykepro @agnusmor
 state/                  @ToniRamirezM @tclemos
 synchronizer/           @ARR552 @joanestebanr
 test/                   @tclemos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,19 @@
-*.md                    @arnaubennassar
-aggregator/             @Mikelle @KonradIT
-cmd/                    @tclemos
-db/                     @Mikelle @tclemos
-docs/                   @arnaubennassar
-etherman/               @ARR552 @cool-develope
-jsonrpc/                @tclemos @KonradIT
-pool/                   @Mikelle @tclemos @KonradIT
-sequencer/              @Mikelle @ToniRamirezM @KonradIT
+*.md                    @agnusmor
+aggregator/             @agnusmor
+ci/                     @agnusmor @tclemos @ToniRamirezM @ARR552
+cmd/                    @tclemos @ToniRamirezM @ARR552
+config/                 @agnusmor @tclemos @ToniRamirezM @ARR552
+db/                     @tclemos @ToniRamirezM @ARR552
+docs/                   @agnusmor @joanestebanr
+etherman/               @ARR552 @joanestebanr
+ethtxmanager/           @tclemos
+gasprice/               @ARR552
+jsonrpc/                @tclemos @Psykepro
+merkletree/             @ToniRamirezM
+pool/                   @tclemos @Psykepro
+proto/                  @ToniRamirezM
+sequencer/              @ToniRamirezM @Psykepro
+sequencersender/        @ToniRamirezM @Psykepro
 state/                  @ToniRamirezM @tclemos
-synchronizer/           @ARR552 @cool-develope
+synchronizer/           @ARR552 @joanestebanr
 test/                   @tclemos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ merkletree/             @ToniRamirezM
 pool/                   @tclemos @Psykepro
 proto/                  @ToniRamirezM
 sequencer/              @ToniRamirezM @Psykepro @agnusmor
-sequencesender/        @ToniRamirezM @Psykepro @agnusmor
+sequencesender/         @ToniRamirezM @Psykepro @agnusmor
 state/                  @ToniRamirezM @tclemos
 synchronizer/           @ARR552 @joanestebanr
 test/                   @tclemos


### PR DESCRIPTION
Closes #2434.

### What does this PR do?

Adjust CODEOWNERS file to match with the current node team structure