### PR TITLE
bugifx: adding missing tx.BreakEvenGasPrice nil check

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -578,7 +578,7 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker) (errW
 
 		effectivePercentage := state.MaxEffectivePercentage
 
-		if tx.BreakEvenGasPrice.Uint64() != 0 {
+		if tx.BreakEvenGasPrice != nil && tx.BreakEvenGasPrice.Uint64() != 0 {
 			// If the tx gas price is lower than the break even gas price, we process the tx with the user gas price (100%)
 			if tx.GasPrice.Cmp(tx.BreakEvenGasPrice) <= 0 {
 				tx.IsEffectiveGasPriceFinalExecution = true


### PR DESCRIPTION
Closes #2451.

### What does this PR do?

Adding missing `tx.BreakEvenGasPrice` nil check

### Reviewers
- @ToniRamirezM 
- @agnusmor 

Codeowner reviewers:
- @ToniRamirezM 