### PR TITLE
fix log format

### DIFF
--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -197,7 +197,7 @@ func (s *SequenceSender) getSequencesToSend(ctx context.Context) ([]types.Sequen
 
 		//Check if the current batch is the last before a change to a new forkid, in this case we need to close and send the sequence to L1
 		if (s.cfg.ForkUpgradeBatchNumber != 0) && (currentBatchNumToSequence == (s.cfg.ForkUpgradeBatchNumber)) {
-			log.Info("sequence should be sent to L1, as we have reached the batch %d from which a new forkid is applied (upgrade)", s.cfg.ForkUpgradeBatchNumber)
+			log.Infof("sequence should be sent to L1, as we have reached the batch %d from which a new forkid is applied (upgrade)", s.cfg.ForkUpgradeBatchNumber)
 			return sequences, nil
 		}
 


### PR DESCRIPTION
### What does this PR do?

Fix log in SequenceSender that was not showing the batch number (it was using log.Info instead of log.Infof)

### Reviewers

Main reviewers:
@ToniRamirezM 
@ARR552 