### PR TITLE
remove need of decoded txs to process a batch response

### DIFF
--- a/state/converters.go
+++ b/state/converters.go
@@ -32,12 +32,12 @@ func ConvertToCounters(resp *executor.ProcessBatchResponse) ZKCounters {
 }
 
 // TestConvertToProcessBatchResponse for test purposes
-func (s *State) TestConvertToProcessBatchResponse(txs []types.Transaction, response *executor.ProcessBatchResponse) (*ProcessBatchResponse, error) {
-	return s.convertToProcessBatchResponse(txs, response)
+func (s *State) TestConvertToProcessBatchResponse(response *executor.ProcessBatchResponse) (*ProcessBatchResponse, error) {
+	return s.convertToProcessBatchResponse(response)
 }
 
-func (s *State) convertToProcessBatchResponse(txs []types.Transaction, response *executor.ProcessBatchResponse) (*ProcessBatchResponse, error) {
-	responses, err := s.convertToProcessTransactionResponse(txs, response.Responses)
+func (s *State) convertToProcessBatchResponse(response *executor.ProcessBatchResponse) (*ProcessBatchResponse, error) {
+	responses, err := s.convertToProcessTransactionResponse(response.Responses)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +123,9 @@ func convertToReadWriteAddresses(addresses map[string]*executor.InfoReadWrite) (
 	return results, nil
 }
 
-func (s *State) convertToProcessTransactionResponse(txs []types.Transaction, responses []*executor.ProcessTransactionResponse) ([]*ProcessTransactionResponse, error) {
+func (s *State) convertToProcessTransactionResponse(responses []*executor.ProcessTransactionResponse) ([]*ProcessTransactionResponse, error) {
 	results := make([]*ProcessTransactionResponse, 0, len(responses))
-	for i, response := range responses {
+	for _, response := range responses {
 		trace, err := convertToStructLogArray(response.ExecutionTrace)
 		if err != nil {
 			return nil, err
@@ -151,9 +151,8 @@ func (s *State) convertToProcessTransactionResponse(txs []types.Transaction, res
 		result.CallTrace = *callTrace
 		result.EffectiveGasPrice = response.EffectiveGasPrice
 		result.EffectivePercentage = response.EffectivePercentage
-		result.Tx = txs[i]
 
-		_, err = DecodeTx(common.Bytes2Hex(response.GetRlpTx()))
+		tx, err := DecodeTx(common.Bytes2Hex(response.GetRlpTx()))
 		if err != nil {
 			timestamp := time.Now()
 			log.Errorf("error decoding rlp returned by executor %v at %v", err, timestamp)
@@ -171,6 +170,8 @@ func (s *State) convertToProcessTransactionResponse(txs []types.Transaction, res
 				log.Errorf("error storing payload: %v", err)
 			}
 		}
+
+		result.Tx = *tx
 
 		results = append(results, result)
 

--- a/state/converters.go
+++ b/state/converters.go
@@ -169,6 +169,8 @@ func (s *State) convertToProcessTransactionResponse(responses []*executor.Proces
 			if err != nil {
 				log.Errorf("error storing payload: %v", err)
 			}
+
+			return nil, err
 		}
 
 		result.Tx = *tx

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1071,7 +1071,7 @@ func TestExecutorTransfer(t *testing.T) {
 	require.Equal(t, "21002", data.Balance)
 
 	// Read Modified Addresses from converted response
-	converted, err := testState.TestConvertToProcessBatchResponse([]types.Transaction{*signedTx}, processBatchResponse)
+	converted, err := testState.TestConvertToProcessBatchResponse(processBatchResponse)
 	require.NoError(t, err)
 	convertedData := converted.ReadWriteAddresses[receiverAddress]
 	require.Equal(t, uint64(21002), convertedData.Balance.Uint64())
@@ -2037,7 +2037,7 @@ func TestExecutorEstimateGas(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, "", processBatchResponse.Responses[0].Error)
 
-	convertedResponse, err := testState.TestConvertToProcessBatchResponse([]types.Transaction{*signedTx0, *signedTx1}, processBatchResponse)
+	convertedResponse, err := testState.TestConvertToProcessBatchResponse(processBatchResponse)
 	require.NoError(t, err)
 	log.Debugf("%v", len(convertedResponse.Responses))
 
@@ -2411,7 +2411,7 @@ func TestExecutorGasEstimationMultisig(t *testing.T) {
 	require.Equal(t, uint64(1000000000), balance.Uint64())
 
 	// Preparation to be able to estimate gas
-	convertedResponse, err := testState.TestConvertToProcessBatchResponse(transactions, processBatchResponse)
+	convertedResponse, err := testState.TestConvertToProcessBatchResponse(processBatchResponse)
 	require.NoError(t, err)
 	log.Debugf("%v", len(convertedResponse.Responses))
 

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -300,7 +300,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 		return nil, err
 	}
 
-	// Transaction are decoded only for logging purposes
+	// Transactions are decoded only for logging purposes
 	// as they are not longer needed in the convertToProcessBatchResponse function
 	txs, _, _, err := DecodeTxs(batchL2Data, forkId)
 	if err != nil && !errors.Is(err, ErrInvalidData) {

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -300,6 +300,8 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 		return nil, err
 	}
 
+	// Transaction are decoded only for logging purposes
+	// as they are not longer needed in the convertToProcessBatchResponse function
 	txs, _, _, err := DecodeTxs(batchL2Data, forkId)
 	if err != nil && !errors.Is(err, ErrInvalidData) {
 		return nil, err
@@ -309,7 +311,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 		log.Debugf(tx.Hash().String())
 	}
 
-	convertedResponse, err := s.convertToProcessBatchResponse(txs, processBatchResponse)
+	convertedResponse, err := s.convertToProcessBatchResponse(processBatchResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +880,7 @@ func (s *State) internalProcessUnsignedTransaction(ctx context.Context, tx *type
 		return nil, err
 	}
 
-	response, err := s.convertToProcessBatchResponse([]types.Transaction{*tx}, processBatchResponse)
+	response, err := s.convertToProcessBatchResponse(processBatchResponse)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Removes the need for decoded transaction in order to process and convert a process batch response from the executor.

### Reviewers

Main reviewers:

- @Psykepro 
- @agnusmor 
- @ARR552 