### PR TITLE
only RPC component will refresh blocked addresses

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -195,6 +195,7 @@ func start(cliCtx *cli.Context) error {
 				// Needed for rejecting transactions with too low gas price
 				poolInstance.StartPollingMinSuggestedGasPrice(cliCtx.Context)
 			}
+			poolInstance.StartRefreshingBlockedAddressesPeriodically()
 			apis := map[string]bool{}
 			for _, a := range cliCtx.StringSlice(config.FlagHTTPAPI) {
 				apis[a] = true

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -80,14 +80,6 @@ func NewPool(cfg Config, batchConstraintsCfg state.BatchConstraintsCfg, s storag
 		gasPricesMux:            new(sync.RWMutex),
 	}
 
-	p.refreshBlockedAddresses()
-	go func(cfg *Config, p *Pool) {
-		for {
-			time.Sleep(cfg.IntervalToRefreshBlockedAddresses.Duration)
-			p.refreshBlockedAddresses()
-		}
-	}(&cfg, p)
-
 	go func(cfg *Config, p *Pool) {
 		for {
 			p.refreshGasPrices()
@@ -109,6 +101,19 @@ func (p *Pool) refreshGasPrices() {
 	p.gasPricesMux.Lock()
 	p.gasPrices = gasPrices
 	p.gasPricesMux.Unlock()
+}
+
+// StartRefreshingBlockedAddressesPeriodically will make this instance of the pool
+// to check periodically(accordingly to the configuration) for updates regarding
+// the blocked address and update the in memory blocked addresses
+func (p *Pool) StartRefreshingBlockedAddressesPeriodically() {
+	p.refreshBlockedAddresses()
+	go func(p *Pool) {
+		for {
+			time.Sleep(p.cfg.IntervalToRefreshBlockedAddresses.Duration)
+			p.refreshBlockedAddresses()
+		}
+	}(p)
 }
 
 // refreshBlockedAddresses refreshes the list of blocked addresses for the provided instance of pool

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1396,6 +1396,7 @@ func Test_BlockedAddress(t *testing.T) {
 	}
 
 	p := setupPool(t, cfg, bc, s, st, chainID.Uint64(), ctx, eventLog)
+	p.StartRefreshingBlockedAddressesPeriodically()
 
 	gasPrices, err := p.GetGasPrices(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #2175.

### What does this PR do?

removes the logic from the creation of the pool to allow only the RPC component to start refreshing blocked addresses