### PR TITLE
Remove prover ports (aggregator) from docker-compose

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -340,8 +340,6 @@ services:
     container_name: zkevm-prover
     image: hermeznetwork/zkevm-prover:v2.2.0
     ports:
-      # - 50051:50051 # Prover
-      - 50052:50052 # Mock prover
       - 50061:50061 # MT
       - 50071:50071 # Executor
     volumes:


### PR DESCRIPTION
Closes #2518.

### What does this PR do?

The prover doesn't expose ports anymore, since now it connects (as client) to the aggregator, and not the other way arround.

### Reviewers

Main reviewers:

@arnaubennassar 
@ToniRamirezM 