### PR TITLE
Fix Makefile: should start synchronizer before eth-tx-manager

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -292,9 +292,9 @@ stop-db: ## Stops the node database
 
 .PHONY: run-node
 run-node: ## Runs the node
-	$(RUNETHTXMANAGER)
 	$(RUNSYNC)
 	sleep 2
+	$(RUNETHTXMANAGER)
 	$(RUNSEQUENCER)
 	$(RUNSEQUENCESENDER)
 	$(RUNL2GASPRICER)

--- a/test/Makefile
+++ b/test/Makefile
@@ -293,7 +293,7 @@ stop-db: ## Stops the node database
 .PHONY: run-node
 run-node: ## Runs the node
 	$(RUNSYNC)
-	sleep 2
+	sleep 4
 	$(RUNETHTXMANAGER)
 	$(RUNSEQUENCER)
 	$(RUNSEQUENCESENDER)
@@ -463,7 +463,7 @@ run: ## Runs a full node
 	$(RUNAPPROVE)
 	sleep 3
 	$(RUNSYNC)
-	sleep 2
+	sleep 4
 	$(RUNETHTXMANAGER)
 	$(RUNSEQUENCER)
 	$(RUNSEQUENCESENDER)


### PR DESCRIPTION
### What does this PR do?

If `eth-tx-manager` is started before `synchronizer`, you will see error in docker logs and the container will exit:

>  relation "public.gorp_migration" does not exist

([code pointer](https://github.com/0xPolygonHermez/zkevm-node/blob/77cf95b602ac9447fe7b967480f79de5e8568a98/cmd/run.go#L69))

Also, in the same Makefile, we can see code:

```
.PHONY: run
run: ## Runs a full node
	...
	sleep 3
	$(RUNSYNC)
	sleep 2
	$(RUNETHTXMANAGER)
	...
```

which runs the services in the right order.

I am also gonna increase the sleep seconds from 2 to 4 to fix https://github.com/0xPolygonHermez/zkevm-node/issues/2463

### Reviewers

Main reviewers:

- @ToniRamirezM
- @agnusmor
- @tclemos
