### PR TITLE
cherry-pick: fixing L2 Reorg check.

### DIFF
--- a/sequencer/dbmanager.go
+++ b/sequencer/dbmanager.go
@@ -107,6 +107,7 @@ func (d *dbManager) checkIfReorg() {
 	numberOfReorgs, err := d.state.CountReorgs(d.ctx, nil)
 	if err != nil {
 		log.Error("failed to get number of reorgs: %v", err)
+		return
 	}
 
 	if numberOfReorgs != d.numberOfReorgs {


### PR DESCRIPTION
Related  #2586.

### What does this PR do?

Change L2 Reorg Count fetch check a non-fatal error

### Reviewers

- @ToniRamirezM 
- @tclemos 