### PR TITLE
Added nodes last synced batch number

### DIFF
--- a/synchronizer/metrics/metrics.go
+++ b/synchronizer/metrics/metrics.go
@@ -93,6 +93,7 @@ func Register() {
 	metrics.RegisterHistograms(histograms...)
 }
 
+// LastSyncedBatchNumber observes latest synced batch number
 func LastSyncedBatchNumber(batchNum float64) {
 	metrics.GaugeSet(LastSyncedBatchNumberName, batchNum)
 }

--- a/synchronizer/metrics/metrics.go
+++ b/synchronizer/metrics/metrics.go
@@ -37,10 +37,19 @@ const (
 
 	// ProcessTrustedBatchTimeName is the name of the label to process trusted batch.
 	ProcessTrustedBatchTimeName = Prefix + "process_trusted_batch_time"
+
+	// LastSyncedBatchNumberName is the name of tha lable to get latest synced batch number
+	LastSyncedBatchNumberName = Prefix + "latest_synced_batch_number"
 )
 
 // Register the metrics for the synchronizer package.
 func Register() {
+	gauges := []prometheus.GaugeOpts{
+		{
+			Name: LastSyncedBatchNumberName,
+			Help: "[SYNCHRONIZER] last synced batch number",
+		},
+	}
 	histograms := []prometheus.HistogramOpts{
 		{
 			Name: InitializationTimeName,
@@ -80,7 +89,12 @@ func Register() {
 		},
 	}
 
+	metrics.RegisterGauges(gauges...)
 	metrics.RegisterHistograms(histograms...)
+}
+
+func LastSyncedBatchNumber(batchNum float64) {
+	metrics.GaugeSet(LastSyncedBatchNumberName, batchNum)
 }
 
 // InitializationTime observes the time initializing the synchronizer on the histogram.

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -264,6 +264,7 @@ func (s *ClientSynchronizer) Sync() error {
 				continue
 			}
 			latestSyncedBatch, err := s.state.GetLastBatchNumber(s.ctx, nil)
+			metrics.LastSyncedBatchNumber(float64(latestSyncedBatch))
 			if err != nil {
 				log.Warn("error getting latest batch synced in the db. Error: ", err)
 				continue


### PR DESCRIPTION
### What does this PR do?
Due to repeatedly sync issues (#2495, #2341) it's crucial to monitor sync progress.
This PR adds additional metric `synchronizer_latest_synced_batch_number` that displays latest synced batch number. Anyone can alert on this metric rate not changing for a period of time with the following PromQL query: `rate(synchronizer_latest_synced_batch_number[5m]) == 0` and receive alert that the node is stuck.

During last 3 weeks I faced 4 times that my node running latest version `v0.3.1` stuck with the hash mismatched error, unfortunately I discovered it after a few hours of the node being stuck. This metric will really make the deal and help to receive on-time alert


