### PR TITLE
L1 parallel sync: avoid get stuck when there are a lot of errors

### DIFF
--- a/synchronizer/l1_rollup_info_consumer_test.go
+++ b/synchronizer/l1_rollup_info_consumer_test.go
@@ -23,7 +23,7 @@ func TestGivenConsumerWhenReceiveAFullSyncAndChannelIsEmptyThenStopOk(t *testing
 	data := setupConsumerTest(t)
 	defer cancel()
 	data.ch <- *newL1SyncMessageControl(eventProducerIsFullySynced)
-	err := data.sut.Start(ctxTimeout)
+	err := data.sut.Start(ctxTimeout, nil)
 	require.NoError(t, err)
 }
 func TestGivenConsumerWhenReceiveAFullSyncAndChannelIsNotEmptyThenDontStop(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGivenConsumerWhenReceiveAFullSyncAndChannelIsNotEmptyThenDontStop(t *te
 
 	data.ch <- *newL1SyncMessageControl(eventProducerIsFullySynced)
 	data.ch <- *newL1SyncMessageControl(eventNone)
-	err := data.sut.Start(ctxTimeout)
+	err := data.sut.Start(ctxTimeout, nil)
 	require.Error(t, err)
 	require.Equal(t, errContextCanceled, err)
 }
@@ -57,7 +57,7 @@ func TestGivenConsumerWhenFailsToProcessRollupThenDontKnownLastEthBlock(t *testi
 		Once()
 	data.ch <- *newL1SyncMessageData(&responseRollupInfoByBlockRange)
 	data.ch <- *newL1SyncMessageControl(eventProducerIsFullySynced)
-	err := data.sut.Start(ctxTimeout)
+	err := data.sut.Start(ctxTimeout, nil)
 	require.Error(t, err)
 	_, ok := data.sut.GetLastEthBlockSynced()
 	require.False(t, ok)

--- a/synchronizer/l1_sync_orchestration_test.go
+++ b/synchronizer/l1_sync_orchestration_test.go
@@ -26,12 +26,12 @@ func TestGivenOrquestrationWhenHappyPathThenReturnsBlockAndNoErrorAndProducerIsR
 	})
 	block := state.Block{}
 	mocks.consumer.On("GetLastEthBlockSynced").Return(block, true)
-	mocks.consumer.On("Start", mock.Anything).Return(func(context.Context) error {
+	mocks.consumer.On("Start", mock.Anything, mock.Anything).Return(func(context.Context, *state.Block) error {
 		time.Sleep(time.Millisecond * 100)
 		return nil
 	})
 	sut.reset(123)
-	returnedBlock, err := sut.start()
+	returnedBlock, err := sut.start(&block)
 	require.NoError(t, err)
 	require.Equal(t, block, *returnedBlock)
 	require.Equal(t, true, sut.producerRunning)

--- a/synchronizer/l1_worker_etherman.go
+++ b/synchronizer/l1_worker_etherman.go
@@ -161,9 +161,15 @@ func (w *workerEtherman) asyncRequestRollupInfoByBlockRange(ctx contextWithCance
 			case <-time.After(sleepBefore):
 			}
 		}
+
+		// Uncomment these lines to respond with a nil result to generate fast responses (just for develop!)
+		//w.setStatus(ethermanIdle)
+		//ch <- newResponseRollupInfo(nil, time.Second, typeRequestRollupInfo, &rollupInfoByBlockRangeResult{blockRange, nil, nil, nil})
+
 		now := time.Now()
 		fromBlock := blockRange.fromBlock
 		toBlock := blockRange.toBlock
+
 		blocks, order, err := w.etherman.GetRollupInfoByBlockRange(ctx.ctx, fromBlock, &toBlock)
 		var lastBlock *types.Block = nil
 		if err == nil && len(blocks) == 0 {
@@ -181,6 +187,7 @@ func (w *workerEtherman) asyncRequestRollupInfoByBlockRange(ctx contextWithCance
 	go launch()
 	return nil
 }
+
 func (w *workerEtherman) requestLastBlock(ctx context.Context) responseL1LastBlock {
 	w.mutex.Lock()
 	if w.isBusyUnsafe() {

--- a/synchronizer/mock_l1_rollup_consumer_interface.go
+++ b/synchronizer/mock_l1_rollup_consumer_interface.go
@@ -38,13 +38,13 @@ func (_m *l1RollupConsumerInterfaceMock) GetLastEthBlockSynced() (state.Block, b
 	return r0, r1
 }
 
-// Start provides a mock function with given fields: ctx
-func (_m *l1RollupConsumerInterfaceMock) Start(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// Start provides a mock function with given fields: ctx, lastEthBlockSynced
+func (_m *l1RollupConsumerInterfaceMock) Start(ctx context.Context, lastEthBlockSynced *state.Block) error {
+	ret := _m.Called(ctx, lastEthBlockSynced)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, *state.Block) error); ok {
+		r0 = rf(ctx, lastEthBlockSynced)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -355,7 +355,7 @@ func (s *ClientSynchronizer) syncBlocksParallel(lastEthBlockSynced *state.Block)
 		s.l1SyncOrchestration.producer.Reset(lastEthBlockSynced.BlockNumber)
 	}
 	log.Infof("Starting L1 sync orchestrator in parallel")
-	return s.l1SyncOrchestration.start()
+	return s.l1SyncOrchestration.start(lastEthBlockSynced)
 }
 
 // This function syncs the node from a specific block to the latest


### PR DESCRIPTION
…consumer checks that the rollupinfo is the expected or ignore it

Closes #2371


Main reviewers:

@ARR552 


