### PR TITLE
add LDFLAGS to goreleaser to include in the binary the right, version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir -p testnet/db/scripts
           cp config/environments/testnet/* testnet/config/environments/testnet
           cp docker-compose.yml testnet
-          sed -i 's/\/config\/environments\/${ZKEVM_NETWORK}/\/config\/environments\/testnet/g' mainnet/docker-compose.yml
+          sed -i 's/\/config\/environments\/${ZKEVM_NETWORK}/\/config\/environments\/testnet/g' testnet/docker-compose.yml
           cp db/scripts/init_prover_db.sql testnet/db/scripts
           mv testnet/config/environments/testnet/example.env testnet
           sed -i -e "s/image: zkevm-node/image: hermeznetwork\/zkevm-node:$GIT_TAG_NAME/g" testnet/docker-compose.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
     - 'v[0-9]+.[0-9]+.[0-9]' # this action will only run on tags that follow semver
-
+    - 'test[0-9]+.[0-9]+.[0-9]' # this action will only run on tags that follow semver
 jobs:
   releaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: release
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]' # this action will only run on tags that follow semver
-    - 'test[0-9]+.[0-9]+.[0-9]' # this action will only run on tags that follow semver
+    - 'v[0-9]+.[0-9]+.[0-9]+' # this action will only run on tags that follow semver
 jobs:
   releaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,11 @@ builds:
     - arm64
   env:
     - CGO_ENABLED=0
+  ldflags:
+    - -X github.com/0xPolygonHermez/zkevm-node.Version={{.Version}}
+    - -X github.com/0xPolygonHermez/zkevm-node.GitRev={{.Commit}} 
+    - -X github.com/0xPolygonHermez/zkevm-node.BuildDate={{.Date}}
+    - -X github.com/0xPolygonHermez/zkevm-node.GitBranch={{.Branch}}
 release:
   # If set to auto, will mark the release as not ready for production
   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1


### PR DESCRIPTION
…. Also add a new tag test* to be able to test this solution

Closes #2607
Closes #2719

### What does this PR do?
- Set the right version of releases binaries
- Allow releases with patch version >9
- Generate testnet.zip

### Reviewers

Main reviewers:

@arnaubennassar 
