### PR TITLE
etherman: read tx with blockHash and txIndex instead of txHash

### DIFF
--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -654,9 +654,12 @@ func (etherMan *Client) forcedBatchEvent(ctx context.Context, vLog types.Log, bl
 	forcedBatch.GlobalExitRoot = fb.LastGlobalExitRoot
 
 	// Read the tx for this batch.
-	tx, err := etherMan.getTxFromLog(ctx, &vLog)
+	tx, err := etherMan.EthClient.TransactionInBlock(ctx, vLog.BlockHash, vLog.TxIndex)
 	if err != nil {
 		return err
+	}
+	if tx.Hash() != vLog.TxHash {
+		return fmt.Errorf("error: tx hash mismatch. want: %s have: %s", vLog.TxHash, tx.Hash().String())
 	}
 
 	msg, err := core.TransactionToMessage(tx, types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
@@ -720,9 +723,12 @@ func (etherMan *Client) sequencedBatchesEvent(ctx context.Context, vLog types.Lo
 		return err
 	}
 	// Read the tx for this event.
-	tx, err := etherMan.getTxFromLog(ctx, &vLog)
+	tx, err := etherMan.EthClient.TransactionInBlock(ctx, vLog.BlockHash, vLog.TxIndex)
 	if err != nil {
 		return err
+	}
+	if tx.Hash() != vLog.TxHash {
+		return fmt.Errorf("error: tx hash mismatch. want: %s have: %s", vLog.TxHash, tx.Hash().String())
 	}
 	msg, err := core.TransactionToMessage(tx, types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
 	if err != nil {
@@ -843,9 +849,12 @@ func (etherMan *Client) forceSequencedBatchesEvent(ctx context.Context, vLog typ
 	}
 
 	// Read the tx for this batch.
-	tx, err := etherMan.getTxFromLog(ctx, &vLog)
+	tx, err := etherMan.EthClient.TransactionInBlock(ctx, vLog.BlockHash, vLog.TxIndex)
 	if err != nil {
 		return err
+	}
+	if tx.Hash() != vLog.TxHash {
+		return fmt.Errorf("error: tx hash mismatch. want: %s have: %s", vLog.TxHash, tx.Hash().String())
 	}
 	msg, err := core.TransactionToMessage(tx, types.NewLondonSigner(tx.ChainId()), big.NewInt(0))
 	if err != nil {
@@ -1157,29 +1166,6 @@ func (etherMan *Client) LoadAuthFromKeyStore(path, password string) (*bind.Trans
 	log.Infof("loaded authorization for address: %v", auth.From.String())
 	etherMan.auth[auth.From] = auth
 	return &auth, nil
-}
-
-// getTxFromLog gets the transaction from a log struct, because go-ethereum will prune the old txindex,
-// so we prefer to read the tx with block hash and tx index
-func (etherMan *Client) getTxFromLog(ctx context.Context, vLog *types.Log) (*types.Transaction, error) {
-	if ethClient, ok := etherMan.EthClient.(*ethclient.Client); ok {
-		tx, err := ethClient.TransactionInBlock(ctx, vLog.BlockHash, vLog.TxIndex)
-		if err != nil {
-			return nil, err
-		}
-		if tx.Hash() != vLog.TxHash {
-			return nil, fmt.Errorf("error: tx hash mismatch. want: %s have: %s", vLog.TxHash, tx.Hash().String())
-		}
-		return tx, nil
-	}
-
-	tx, isPending, err := etherMan.EthClient.TransactionByHash(ctx, vLog.TxHash)
-	if err != nil {
-		return nil, err
-	} else if isPending {
-		return nil, fmt.Errorf("error: tx is still pending. TxHash: %s", tx.Hash().String())
-	}
-	return tx, nil
 }
 
 // newKeyFromKeystore creates an instance of a keystore key from a keystore file


### PR DESCRIPTION
### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

As go-ethereum will prune the old txindex(default is 1year), so I failed to run zkevm-sync for the old events, the error as below:


```
zkevm-sync  | 2023-10-27T01:02:58.573Z  INFO    synchronizer/synchronizer.go:315        Getting rollup info from block 16898816 to block 16898916       {"pid": 1, "version": "v0.3.1"}
zkevm-sync  | 2023-10-27T01:02:58.584Z  WARN    etherman/etherman.go:331        error processing event. Retrying... Error: not found. vLog: {Address:0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2 Topics:[0x303446e6a8cb73c83dff421c0b1d5e5ce0719dab1bff13660fc254e58cc17fce 0x0000000000000000000000000000000000000000000000000000000000000001] Data:[] BlockNumber:16898855 TxHash:0x85c9daf131ba93998576b37dae569dd7e24044cdd8c5b6b89f6799f3c8ebeb4e TxIndex:72 BlockHash:0x71b3a59a08a5887513c43f7e5cd317f3b1cafa2f7316ed8b63d3e72c5694c8a1 Index:147 Removed:false}      {"pid": 1, "version": "v0.3.1"}
zkevm-sync  | github.com/0xPolygonHermez/zkevm-node/etherman.(*Client).readEvents
zkevm-sync  |   /src/etherman/etherman.go:331
zkevm-sync  | github.com/0xPolygonHermez/zkevm-node/etherman.(*Client).GetRollupInfoByBlockRange
zkevm-sync  |   /src/etherman/etherman.go:302
zkevm-sync  | github.com/0xPolygonHermez/zkevm-node/synchronizer.(*ClientSynchronizer).syncBlocks
zkevm-sync  |   /src/synchronizer/synchronizer.go:322
zkevm-sync  | github.com/0xPolygonHermez/zkevm-node/synchronizer.(*ClientSynchronizer).Sync
zkevm-sync  |   /src/synchronizer/synchronizer.go:265
zkevm-sync  | main.runSynchronizer
zkevm-sync  |   /src/cmd/run.go:305
zkevm-sync  | 2023-10-27T01:02:58.585Z  WARN    synchronizer/synchronizer.go:268        error syncing blocks: not found {"pid": 1, "version": "v0.3.1"}
zkevm-sync  | github.com/0xPolygonHermez/zkevm-node/synchronizer.(*ClientSynchronizer).Sync
zkevm-sync  |   /src/synchronizer/synchronizer.go:268
zkevm-sync  | main.runSynchronizer
zkevm-sync  |   /src/cmd/run.go:305
zkevm-sync  | 2023-10-27T01:02:58.586Z  INFO    synchronizer/synchronizer.go:278        L1 state fully synchronized     {"pid": 1, "version": "v0.3.1"}
zkevm-sync  | 2023-10-27T01:02:58.598Z  INFO    synchronizer/synchronizer.go:248        latestSequencedBatchNumber: 1115089, latestSyncedBatch: 0, lastVerifiedBatchNumber: 1114967     {"pid": 1, "version": "v0.3.1"}
```

So in this PR, I prefer to read the tx from blockHash and TxIndex instead of the txhash for the log syncing && processing phrase.


### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
