### PR TITLE
fix nil pointer when fails etherman call

### DIFF
--- a/synchronizer/l1_rollup_info_producer.go
+++ b/synchronizer/l1_rollup_info_producer.go
@@ -203,7 +203,7 @@ func newL1DataRetriever(cfg configProducer, ethermans []EthermanInterface, outgo
 		workers:                              newWorkerDecoratorLimitRetriesByTime(newWorkers(ethermans, workersConfig), cfg.minTimeBetweenRetriesForRollupInfo),
 		filterToSendOrdererResultsToConsumer: newFilterToSendOrdererResultsToConsumer(invalidBlockNumber),
 		outgoingChannel:                      outgoingChannel,
-		statistics:                           newRollupInfoProducerStatistics(invalidBlockNumber),
+		statistics:                           newRollupInfoProducerStatistics(invalidBlockNumber, DefaultTimeProvider{}),
 		status:                               producerNoRunning,
 		cfg:                                  cfg,
 		channelCmds:                          make(chan producerCmd, lenCommandsChannels),
@@ -413,7 +413,7 @@ func (l *l1RollupInfoProducer) step(waitDuration *time.Duration) bool {
 	}
 
 	if l.cfg.timeForShowUpStatisticsLog != 0 && time.Since(l.statistics.lastShowUpTime) > l.cfg.timeForShowUpStatisticsLog {
-		log.Infof("producer: Statistics:%s", l.statistics.getETA())
+		log.Infof("producer: Statistics:%s", l.statistics.getStatisticsDebugString())
 		l.statistics.lastShowUpTime = time.Now()
 	}
 	*waitDuration = l.getNextTimeout()

--- a/synchronizer/l1_rollup_info_producer_statistics.go
+++ b/synchronizer/l1_rollup_info_producer_statistics.go
@@ -9,29 +9,33 @@ import (
 
 // This object keep track of the statistics of the process, to be able to estimate the ETA
 type l1RollupInfoProducerStatistics struct {
-	initialBlockNumber  uint64
-	lastBlockNumber     uint64
-	numRollupInfoOk     uint64
-	numRollupInfoErrors uint64
-	numRetrievedBlocks  uint64
-	startTime           time.Time
-	lastShowUpTime      time.Time
+	initialBlockNumber              uint64
+	lastBlockNumber                 uint64
+	numRollupInfoOk                 uint64
+	numRollupInfoErrors             uint64
+	numRetrievedBlocks              uint64
+	startTime                       time.Time
+	lastShowUpTime                  time.Time
+	accumulatedTimeProcessingRollup time.Duration
+	timeProvider                    TimeProvider
 }
 
-func newRollupInfoProducerStatistics(startingBlockNumber uint64) l1RollupInfoProducerStatistics {
+func newRollupInfoProducerStatistics(startingBlockNumber uint64, timeProvider TimeProvider) l1RollupInfoProducerStatistics {
 	return l1RollupInfoProducerStatistics{
-		initialBlockNumber: startingBlockNumber,
-		startTime:          time.Now(),
+		initialBlockNumber:              startingBlockNumber,
+		startTime:                       timeProvider.Now(),
+		timeProvider:                    timeProvider,
+		accumulatedTimeProcessingRollup: time.Duration(0),
 	}
 }
 
 func (l *l1RollupInfoProducerStatistics) reset(startingBlockNumber uint64) {
 	l.initialBlockNumber = startingBlockNumber
-	l.startTime = time.Now()
+	l.startTime = l.timeProvider.Now()
 	l.numRollupInfoOk = 0
 	l.numRollupInfoErrors = 0
 	l.numRetrievedBlocks = 0
-	l.lastShowUpTime = time.Now()
+	l.lastShowUpTime = l.timeProvider.Now()
 }
 
 func (l *l1RollupInfoProducerStatistics) updateLastBlockNumber(lastBlockNumber uint64) {
@@ -44,20 +48,43 @@ func (l *l1RollupInfoProducerStatistics) onResponseRollupInfo(result responseRol
 	if isOk {
 		l.numRollupInfoOk++
 		l.numRetrievedBlocks += uint64(result.result.blockRange.len())
+		l.accumulatedTimeProcessingRollup += result.generic.duration
 	} else {
 		l.numRollupInfoErrors++
 	}
 }
 
-func (l *l1RollupInfoProducerStatistics) getETA() string {
+func (l *l1RollupInfoProducerStatistics) getStatisticsDebugString() string {
 	numTotalOfBlocks := l.lastBlockNumber - l.initialBlockNumber
 	if l.numRetrievedBlocks == 0 {
 		return "N/A"
 	}
+	now := l.timeProvider.Now()
+	elapsedTime := now.Sub(l.startTime)
+	eta := l.getEstimatedTimeOfArrival()
+	percent := l.getPercent()
+	blocksPerSeconds := l.getBlocksPerSecond(elapsedTime)
+	return fmt.Sprintf(" EstimatedTimeOfArrival: %s percent:%2.2f  blocks_per_seconds:%2.2f pending_block:%v/%v num_errors:%v",
+		eta, percent, blocksPerSeconds, l.numRetrievedBlocks, numTotalOfBlocks, l.numRollupInfoErrors)
+}
+
+func (l *l1RollupInfoProducerStatistics) getEstimatedTimeOfArrival() time.Duration {
+	numTotalOfBlocks := l.lastBlockNumber - l.initialBlockNumber
+	if l.numRetrievedBlocks == 0 {
+		return time.Duration(0)
+	}
 	elapsedTime := time.Since(l.startTime)
 	eta := time.Duration(float64(elapsedTime) / float64(l.numRetrievedBlocks) * float64(numTotalOfBlocks-l.numRetrievedBlocks))
+	return eta
+}
+
+func (l *l1RollupInfoProducerStatistics) getPercent() float64 {
+	numTotalOfBlocks := l.lastBlockNumber - l.initialBlockNumber
 	percent := float64(l.numRetrievedBlocks) / float64(numTotalOfBlocks) * conversionFactorPercentage
+	return percent
+}
+
+func (l *l1RollupInfoProducerStatistics) getBlocksPerSecond(elapsedTime time.Duration) float64 {
 	blocksPerSeconds := float64(l.numRetrievedBlocks) / float64(elapsedTime.Seconds())
-	return fmt.Sprintf("ETA: %s percent:%2.2f  blocks_per_seconds:%2.2f pending_block:%v/%v num_errors:%v",
-		eta, percent, blocksPerSeconds, l.numRetrievedBlocks, numTotalOfBlocks, l.numRollupInfoErrors)
+	return blocksPerSeconds
 }

--- a/synchronizer/l1_rollup_info_producer_statistics_test.go
+++ b/synchronizer/l1_rollup_info_producer_statistics_test.go
@@ -1,0 +1,31 @@
+package synchronizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProducerStatisticsPercent(t *testing.T) {
+	sut := newRollupInfoProducerStatistics(100, &mockTimerProvider{})
+	sut.updateLastBlockNumber(200)
+	require.Equal(t, float64(0.0), sut.getPercent())
+
+	sut.onResponseRollupInfo(responseRollupInfoByBlockRange{
+		generic: genericResponse{
+			err:      nil,
+			duration: 0,
+		},
+		result: &rollupInfoByBlockRangeResult{
+			blockRange: blockRange{
+				fromBlock: 101,
+				toBlock:   200,
+			},
+		},
+	})
+
+	require.Equal(t, float64(100.0), sut.getPercent())
+
+	sut.reset(100)
+	require.Equal(t, float64(0.0), sut.getPercent())
+}

--- a/synchronizer/l1_rollup_info_producer_test.go
+++ b/synchronizer/l1_rollup_info_producer_test.go
@@ -110,6 +110,7 @@ func setupNoResetCall(t *testing.T) (*l1RollupInfoProducer, []*ethermanMock, cha
 	cfg := configProducer{
 		syncChunkSize:      100,
 		ttlOfLastBlockOnL1: time.Second,
+		timeOutMainLoop:    time.Second,
 	}
 
 	sut := newL1DataRetriever(cfg, ethermans, resultChannel)

--- a/synchronizer/l1_worker_etherman.go
+++ b/synchronizer/l1_worker_etherman.go
@@ -269,7 +269,7 @@ func (w *workerEtherman) asyncRequestRollupInfoByBlockRange(ctx contextWithCance
 		//ch <- newResponseRollupInfo(nil, time.Second, typeRequestRollupInfo, &rollupInfoByBlockRangeResult{blockRange, nil, nil, nil})
 
 		now := time.Now()
-		err, data := w.executeRequestRollupInfoByBlockRange(ctx, ch, request)
+		data, err := w.executeRequestRollupInfoByBlockRange(ctx, ch, request)
 		duration := time.Since(now)
 		result := newResponseRollupInfo(err, duration, typeRequestRollupInfo, data)
 		w.setStatus(ethermanIdle)
@@ -282,21 +282,21 @@ func (w *workerEtherman) asyncRequestRollupInfoByBlockRange(ctx contextWithCance
 	return nil
 }
 
-func (w *workerEtherman) executeRequestRollupInfoByBlockRange(ctx contextWithCancel, ch chan responseRollupInfoByBlockRange, request requestRollupInfoByBlockRange) (error, *rollupInfoByBlockRangeResult) {
+func (w *workerEtherman) executeRequestRollupInfoByBlockRange(ctx contextWithCancel, ch chan responseRollupInfoByBlockRange, request requestRollupInfoByBlockRange) (*rollupInfoByBlockRangeResult, error) {
 	resultRollupInfo := rollupInfoByBlockRangeResult{request.blockRange, nil, nil, nil, nil}
 	if err := w.fillLastBlock(&resultRollupInfo, ctx, request, false); err != nil {
-		return err, nil
+		return &resultRollupInfo, err
 	}
 	if err := w.fillRollup(&resultRollupInfo, ctx, request); err != nil {
-		return err, nil
+		return &resultRollupInfo, err
 	}
 	if err := w.fillLastBlock(&resultRollupInfo, ctx, request, true); err != nil {
-		return err, nil
+		return &resultRollupInfo, err
 	}
 	if err := w.fillPreviousBlock(&resultRollupInfo, ctx, request); err != nil {
-		return err, nil
+		return &resultRollupInfo, err
 	}
-	return nil, &resultRollupInfo
+	return &resultRollupInfo, nil
 }
 
 func (w *workerEtherman) fillPreviousBlock(result *rollupInfoByBlockRangeResult, ctx contextWithCancel, request requestRollupInfoByBlockRange) error {

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -215,7 +215,7 @@ func (s *ClientSynchronizer) Sync() error {
 					log.Errorf("error rolling back state. RollbackErr: %v", rollbackErr)
 					return rollbackErr
 				}
-				return fmt.Errorf("Calculated newRoot should be %s instead of %s", s.genesis.Root.String(), root.String())
+				return fmt.Errorf("calculated newRoot should be %s instead of %s", s.genesis.Root.String(), root.String())
 			}
 			log.Debug("Genesis root matches!")
 		} else {


### PR DESCRIPTION
### What does this PR do?
There are a `invalid memory address or nil pointer dereference` when fails etherman call

### Reviewers

Main reviewers:

@ARR552 