### PR TITLE
Fix e2e group 8 (debug trace) 

### DIFF
--- a/test/e2e/debug_calltracer_test.go
+++ b/test/e2e/debug_calltracer_test.go
@@ -414,7 +414,12 @@ func TestDebugTraceBlockCallTracer(t *testing.T) {
 				resultTransactions := []interface{}{}
 				err = json.Unmarshal(result, &resultTransactions)
 				require.NoError(t, err)
-
+				log.Debugf("transactions length: L1 : %v / L2 %v", len(referenceTransactions), len(resultTransactions))
+				if len(referenceTransactions) != len(resultTransactions) {
+					log.Debug("difer length L1: ", referenceTransactions)
+					log.Debug("difer length L2: ", resultTransactions)
+					require.Fail(t, "transactions results length doesn't match")
+				}
 				for transactionIndex := range referenceTransactions {
 					referenceTransactionMap := referenceTransactions[transactionIndex].(map[string]interface{})
 					resultTransactionMap := resultTransactions[transactionIndex].(map[string]interface{})

--- a/test/e2e/debug_calltracer_test.go
+++ b/test/e2e/debug_calltracer_test.go
@@ -94,7 +94,7 @@ func TestDebugTraceTransactionCallTracer(t *testing.T) {
 		{name: "eth transfer", createSignedTx: createEthTransferSignedTx},
 		{name: "sc deployment", createSignedTx: createScDeploySignedTx},
 		{name: "sc call", prepare: prepareScCall, createSignedTx: createScCallSignedTx},
-		{name: "erc20 transfer", prepare: prepareERC20TransferNoWaitToBeMined, createSignedTx: createERC20TransferSignedTx},
+		{name: "erc20 transfer", prepare: prepareERC20Transfer, createSignedTx: createERC20TransferSignedTx},
 		{name: "create", prepare: prepareCreate, createSignedTx: createCreateSignedTx},
 		{name: "create2", prepare: prepareCreate, createSignedTx: createCreate2SignedTx},
 		{name: "call", prepare: prepareCalls, createSignedTx: createCallSignedTx},

--- a/test/e2e/debug_calltracer_test.go
+++ b/test/e2e/debug_calltracer_test.go
@@ -355,78 +355,85 @@ func TestDebugTraceBlockCallTracer(t *testing.T) {
 			log.Debug("************************ ", tc.name, " ************************")
 
 			for _, network := range networks {
-				log.Debug("------------------------ ", network.Name, " ------------------------")
-				ethereumClient := operations.MustGetClient(network.URL)
-				auth := operations.MustGetAuth(network.PrivateKey, network.ChainID)
+				for true {
+					log.Debug("------------------------ ", network.Name, " ------------------------")
+					ethereumClient := operations.MustGetClient(network.URL)
+					auth := operations.MustGetAuth(network.PrivateKey, network.ChainID)
 
-				var customData map[string]interface{}
-				if tc.prepare != nil {
-					customData, err = tc.prepare(t, ctx, auth, ethereumClient)
+					var customData map[string]interface{}
+					if tc.prepare != nil {
+						customData, err = tc.prepare(t, ctx, auth, ethereumClient)
+						require.NoError(t, err)
+					}
+
+					signedTx, err := tc.createSignedTx(t, ctx, auth, ethereumClient, customData)
 					require.NoError(t, err)
-				}
 
-				signedTx, err := tc.createSignedTx(t, ctx, auth, ethereumClient, customData)
-				require.NoError(t, err)
-
-				err = ethereumClient.SendTransaction(ctx, signedTx)
-				require.NoError(t, err)
-
-				log.Debugf("tx sent: %v", signedTx.Hash().String())
-
-				err = operations.WaitTxToBeMined(ctx, ethereumClient, signedTx, operations.DefaultTimeoutTxToBeMined)
-				if err != nil && !strings.HasPrefix(err.Error(), "transaction has failed, reason:") {
+					err = ethereumClient.SendTransaction(ctx, signedTx)
 					require.NoError(t, err)
+
+					log.Debugf("tx sent: %v", signedTx.Hash().String())
+
+					err = operations.WaitTxToBeMined(ctx, ethereumClient, signedTx, operations.DefaultTimeoutTxToBeMined)
+					if err != nil && !strings.HasPrefix(err.Error(), "transaction has failed, reason:") {
+						require.NoError(t, err)
+					}
+
+					receipt, err := ethereumClient.TransactionReceipt(ctx, signedTx.Hash())
+					require.NoError(t, err)
+
+					debugOptions := map[string]interface{}{
+						"tracer": "callTracer",
+						"tracerConfig": map[string]interface{}{
+							"onlyTopCall": false,
+							"withLog":     true,
+						},
+					}
+
+					var response types.Response
+					if tc.blockNumberOrHash == "number" {
+						log.Infof("debug_traceBlockByNumber %v", receipt.BlockNumber)
+						response, err = client.JSONRPCCall(network.URL, "debug_traceBlockByNumber", hex.EncodeBig(receipt.BlockNumber), debugOptions)
+					} else {
+						log.Infof("debug_traceBlockByHash %v", receipt.BlockHash.String())
+						response, err = client.JSONRPCCall(network.URL, "debug_traceBlockByHash", receipt.BlockHash.String(), debugOptions)
+					}
+					require.NoError(t, err)
+					require.Nil(t, response.Error)
+					require.NotNil(t, response.Result)
+					log.Debugf("[%s/%s] response:%s", tc.name, network.Name, string(response.Result))
+					results[network.Name] = response.Result
+					referenceTransactions := []interface{}{}
+					err = json.Unmarshal(response.Result, &referenceTransactions)
+					require.NoError(t, err)
+					if len(referenceTransactions) > 1 {
+						log.Debug(response.Result)
+						log.Debugf("transactions length: %v", len(referenceTransactions))
+						panic("transactions length > 1")
+					}
 				}
-
-				receipt, err := ethereumClient.TransactionReceipt(ctx, signedTx.Hash())
-				require.NoError(t, err)
-
-				debugOptions := map[string]interface{}{
-					"tracer": "callTracer",
-					"tracerConfig": map[string]interface{}{
-						"onlyTopCall": false,
-						"withLog":     true,
-					},
-				}
-
-				var response types.Response
-				if tc.blockNumberOrHash == "number" {
-					response, err = client.JSONRPCCall(network.URL, "debug_traceBlockByNumber", hex.EncodeBig(receipt.BlockNumber), debugOptions)
-				} else {
-					response, err = client.JSONRPCCall(network.URL, "debug_traceBlockByHash", receipt.BlockHash.String(), debugOptions)
-				}
-				require.NoError(t, err)
-				require.Nil(t, response.Error)
-				require.NotNil(t, response.Result)
-
-				results[network.Name] = response.Result
 			}
 
 			referenceTransactions := []interface{}{}
 			err = json.Unmarshal(results[l1NetworkName], &referenceTransactions)
 			require.NoError(t, err)
 
-			for networkName, result := range results {
-				if networkName == l1NetworkName {
-					continue
-				}
-
-				resultTransactions := []interface{}{}
-				err = json.Unmarshal(result, &resultTransactions)
-				require.NoError(t, err)
-				log.Debugf("transactions length: L1 : %v / L2 %v", len(referenceTransactions), len(resultTransactions))
-				if len(referenceTransactions) != len(resultTransactions) {
-					log.Debug("difer length L1: ", referenceTransactions)
-					log.Debug("difer length L2: ", resultTransactions)
-					require.Fail(t, "transactions results length doesn't match")
-				}
-				for transactionIndex := range referenceTransactions {
-					referenceTransactionMap := referenceTransactions[transactionIndex].(map[string]interface{})
-					resultTransactionMap := resultTransactions[transactionIndex].(map[string]interface{})
-
-					compareCallFrame(t, referenceTransactionMap, resultTransactionMap, networkName)
-				}
+			resultTransactions := []interface{}{}
+			err = json.Unmarshal(results[l2NetworkName], &resultTransactions)
+			require.NoError(t, err)
+			log.Debugf("[%s] transactions length: L1 : %v / L2 %v", tc.name, len(referenceTransactions), len(resultTransactions))
+			if len(referenceTransactions) != len(resultTransactions) {
+				log.Debug("[%s] difer length L1: ", tc.name, results[l1NetworkName])
+				log.Debug("[%s] difer length L2: ", tc.name, results[l2NetworkName])
+				require.Fail(t, "transactions results length doesn't match")
 			}
+			for transactionIndex := range referenceTransactions {
+				referenceTransactionMap := referenceTransactions[transactionIndex].(map[string]interface{})
+				resultTransactionMap := resultTransactions[transactionIndex].(map[string]interface{})
+
+				compareCallFrame(t, referenceTransactionMap, resultTransactionMap, l2NetworkName)
+			}
+
 		})
 	}
 }

--- a/test/e2e/debug_calltracer_test.go
+++ b/test/e2e/debug_calltracer_test.go
@@ -45,9 +45,8 @@ func TestDebugTraceTransactionCallTracer(t *testing.T) {
 
 	ctx := context.Background()
 	opsCfg := operations.GetDefaultOperationsConfig()
-	var opsMan *operations.Manager
 	if !dockersArePreLaunchedForCallTracerTests {
-		opsMan, err = operations.NewManager(ctx, opsCfg)
+		opsMan, err := operations.NewManager(ctx, opsCfg)
 		require.NoError(t, err)
 		err = opsMan.Setup()
 		require.NoError(t, err)
@@ -55,8 +54,6 @@ func TestDebugTraceTransactionCallTracer(t *testing.T) {
 		require.NoError(t, err)
 	} else {
 		log.Info("Using pre-launched dockers: no reset Database")
-		opsMan, err = operations.NewManagerNoInitDB(ctx, opsCfg)
-		require.NoError(t, err)
 	}
 
 	const l1NetworkName, l2NetworkName = "Local L1", "Local L2"
@@ -299,9 +296,8 @@ func TestDebugTraceBlockCallTracer(t *testing.T) {
 
 	ctx := context.Background()
 	opsCfg := operations.GetDefaultOperationsConfig()
-	var opsMan *operations.Manager
 	if !dockersArePreLaunchedForCallTracerTests {
-		opsMan, err = operations.NewManager(ctx, opsCfg)
+		opsMan, err := operations.NewManager(ctx, opsCfg)
 		require.NoError(t, err)
 		err = opsMan.Setup()
 		require.NoError(t, err)
@@ -309,8 +305,6 @@ func TestDebugTraceBlockCallTracer(t *testing.T) {
 		require.NoError(t, err)
 	} else {
 		log.Info("Using pre-launched dockers: no reset Database")
-		//opsMan, err = operations.NewManagerNoInitDB(ctx, opsCfg)
-		//require.NoError(t, err)
 	}
 
 	const l1NetworkName, l2NetworkName = "Local L1", "Local L2"

--- a/test/e2e/debug_shared.go
+++ b/test/e2e/debug_shared.go
@@ -110,29 +110,17 @@ func createScCallSignedTx(t *testing.T, ctx context.Context, auth *bind.Transact
 }
 
 func prepareERC20Transfer(t *testing.T, ctx context.Context, auth *bind.TransactOpts, client *ethclient.Client) (map[string]interface{}, error) {
-	return prepareERC20TransferInternal(t, ctx, auth, client, true)
-}
-
-func prepareERC20TransferNoWaitToBeMined(t *testing.T, ctx context.Context, auth *bind.TransactOpts, client *ethclient.Client) (map[string]interface{}, error) {
-	return prepareERC20TransferInternal(t, ctx, auth, client, false)
-}
-
-func prepareERC20TransferInternal(t *testing.T, ctx context.Context, auth *bind.TransactOpts, client *ethclient.Client, waitToBeMined bool) (map[string]interface{}, error) {
 	_, tx, sc, err := ERC20.DeployERC20(auth, client, "MyToken", "MT")
 	require.NoError(t, err)
 	log.Debugf("prepareERC20Transfer DeployERC20 tx: %s", tx.Hash().String())
-	if waitToBeMined {
-		err = operations.WaitTxToBeMined(ctx, client, tx, operations.DefaultTimeoutTxToBeMined)
-		require.NoError(t, err)
-	}
+	err = operations.WaitTxToBeMined(ctx, client, tx, operations.DefaultTimeoutTxToBeMined)
+	require.NoError(t, err)
 
 	tx, err = sc.Mint(auth, big.NewInt(1000000000))
 	require.NoError(t, err)
 	log.Debugf("prepareERC20Transfer Mint tx: %s", tx.Hash().String())
-	if waitToBeMined {
-		err = operations.WaitTxToBeMined(ctx, client, tx, operations.DefaultTimeoutTxToBeMined)
-		require.NoError(t, err)
-	}
+	err = operations.WaitTxToBeMined(ctx, client, tx, operations.DefaultTimeoutTxToBeMined)
+	require.NoError(t, err)
 
 	return map[string]interface{}{
 		"sc": sc,


### PR DESCRIPTION
Closes #2760

### What does this PR do?
Sometimes a L1 block could contain more that one tx. In that case the test fails, now match the tx that we want to check in the response of `debug_traceBlockByNumber` or `debug_traceBlockByHash`
