### PR TITLE
Add StoreL2Block (ETROG) function to the state

### DIFF
--- a/state/transaction.go
+++ b/state/transaction.go
@@ -298,8 +298,8 @@ func (s *State) StoreL2Block(ctx context.Context, batchNumber uint64, l2Block *P
 			continue
 		}
 
-		transaction := &txResponse.Tx
-		transactions = append(transactions, transaction)
+		txResp := *txResponse
+		transactions = append(transactions, &txResp.Tx)
 
 		storeTxsEGPData = append(storeTxsEGPData, StoreTxEGPData{EGPLog: nil, EffectivePercentage: uint8(txResponse.EffectivePercentage)})
 		if txsEGPLog != nil {

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -298,7 +298,8 @@ func (s *State) StoreL2Block(ctx context.Context, batchNumber uint64, l2Block *P
 			continue
 		}
 
-		transactions = append(transactions, &txResponse.Tx)
+		transaction := &txResponse.Tx
+		transactions = append(transactions, transaction)
 
 		storeTxsEGPData = append(storeTxsEGPData, StoreTxEGPData{EGPLog: nil, EffectivePercentage: uint8(txResponse.EffectivePercentage)})
 		if txsEGPLog != nil {


### PR DESCRIPTION
### What does this PR do?

Adds the StoreL2Block funcion to the state. This function is used to store L2 blocks generated with the fork ETROG (but it also should work for previous forks, if needed)

### Reviewers

Main reviewers:

@joanestebanr
@ToniRamirezM 
@ARR552 