### PR TITLE
Update/get wip batch used resources from the state (batch table)

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -1311,7 +1311,7 @@ func getUsedBatchResources(constraints state.BatchConstraintsCfg, remainingResou
 			UsedArithmetics:      constraints.MaxArithmetics - remainingResources.ZKCounters.UsedArithmetics,
 			UsedBinaries:         constraints.MaxBinaries - remainingResources.ZKCounters.UsedBinaries,
 			UsedSteps:            constraints.MaxSteps - remainingResources.ZKCounters.UsedSteps,
-			UsedSha256Hashes_V2:  constraints.MaxSteps - remainingResources.ZKCounters.UsedSha256Hashes_V2,
+			UsedSha256Hashes_V2:  constraints.MaxSHA256Hashes - remainingResources.ZKCounters.UsedSha256Hashes_V2,
 		},
 		Bytes: constraints.MaxBatchBytesSize - remainingResources.Bytes,
 	}

--- a/state/batch.go
+++ b/state/batch.go
@@ -37,6 +37,7 @@ type Batch struct {
 	Transactions   []types.Transaction
 	GlobalExitRoot common.Hash
 	ForcedBatchNum *uint64
+	Resources      BatchResources
 }
 
 // ProcessingContext is the necessary data that a batch needs to provide to the runtime,

--- a/state/types.go
+++ b/state/types.go
@@ -230,6 +230,12 @@ func (r *BatchResources) Sub(other BatchResources) error {
 	return err
 }
 
+// SumUp sum ups the batch resources from other
+func (r *BatchResources) SumUp(other BatchResources) {
+	r.Bytes += other.Bytes
+	r.ZKCounters.SumUp(other.ZKCounters)
+}
+
 // InfoReadWrite has information about modified addresses during the execution
 type InfoReadWrite struct {
 	Address common.Address


### PR DESCRIPTION
### What does this PR do?

When starting the sequencer we need to get the used resources (zkCounters, bytes) for the wip batch, to do this we are executing (executor) the full batch to get the zkCounters. Instead of this, now the used resources are updated in the batch table each time we store a L2 block, with this we can get the used resources from the batch table (GetBatchByNumber) when starting the sequencer.

### Reviewers

Main reviewers:

@ToniRamirezM 
@dpunish3r 