### PR TITLE
Feature/2914 etrog use l1inforoot from event

### DIFF
--- a/state/batchV2.go
+++ b/state/batchV2.go
@@ -203,11 +203,10 @@ func (s *State) processBatchV2(ctx context.Context, batchNumber uint64, batchL2D
 	}
 	// Create Batch
 	processBatchRequest := &executor.ProcessBatchRequestV2{
-		OldBatchNum:  lastBatch.BatchNumber - 1,
-		Coinbase:     lastBatch.Coinbase.String(),
-		BatchL2Data:  batchL2Data,
-		OldStateRoot: previousBatch.StateRoot.Bytes(),
-		// L1InfoRoot:       l1InfoRoot.Bytes() => This can be nil and so is set later
+		OldBatchNum:      lastBatch.BatchNumber - 1,
+		Coinbase:         lastBatch.Coinbase.String(),
+		BatchL2Data:      batchL2Data,
+		OldStateRoot:     previousBatch.StateRoot.Bytes(),
 		OldAccInputHash:  previousBatch.AccInputHash.Bytes(),
 		TimestampLimit:   timestampLimitUnix,
 		UpdateMerkleTree: cTrue,


### PR DESCRIPTION
Closes #2914

### What does this PR do?
set L1InfoRoot reported in the process_batch event from L1
set ForkId in the call to ProcessBatchV2


Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @ARR552 
- 
Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
