### PR TITLE
Fix tx size when calculating egp and checking remaining batch resources

### DIFF
--- a/pool/effectivegasprice.go
+++ b/pool/effectivegasprice.go
@@ -77,7 +77,7 @@ func (e *EffectiveGasPrice) CalculateBreakEvenGasPrice(rawTx []byte, txGasPrice 
 	}
 
 	txZeroBytes := uint64(bytes.Count(rawTx, []byte{0}))
-	txNonZeroBytes := uint64(len(rawTx)) - txZeroBytes
+	txNonZeroBytes := uint64(len(rawTx)) - txZeroBytes + state.EfficiencyPercentageByteLength
 
 	// Calculate BreakEvenGasPrice
 	totalTxPrice := (txGasUsed * l2MinGasPrice) +

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -1207,7 +1207,7 @@ func (f *finalizer) setNextGERDeadline() {
 func (f *finalizer) checkRemainingResources(result *state.ProcessBatchResponse, tx *TxTracker) error {
 	usedResources := state.BatchResources{
 		ZKCounters: result.UsedZkCounters,
-		Bytes:      uint64(len(tx.RawTx)),
+		Bytes:      tx.BatchResources.Bytes,
 	}
 
 	err := f.wipBatch.remainingResources.Sub(usedResources)

--- a/state/batchV2.go
+++ b/state/batchV2.go
@@ -96,7 +96,6 @@ func (s *State) ProcessBatchV2(ctx context.Context, request ProcessRequest, upda
 }
 
 // ExecuteBatchV2 is used by the synchronizer to reprocess batches to compare generated state root vs stored one
-// It is also used by the sequencer in order to calculate used zkCounter of a WIPBatch
 func (s *State) ExecuteBatchV2(ctx context.Context, batch Batch, l1InfoRoot common.Hash, timestampLimit time.Time, updateMerkleTree bool, dbTx pgx.Tx) (*executor.ProcessBatchResponseV2, error) {
 	if dbTx == nil {
 		return nil, ErrDBTxNil


### PR DESCRIPTION
### What does this PR do?

Fixes the tx size when calculating effective gas price and when checking remaining batch resources, as it was not taking into account the byte used to store the effective gas price percentage

### Reviewers

@ToniRamirezM 
@dpunish3r 