### PR TITLE
Fix EGP tx size (remove signature bytes)

### DIFF
--- a/pool/effectivegasprice.go
+++ b/pool/effectivegasprice.go
@@ -70,7 +70,7 @@ func (e *EffectiveGasPrice) CalculateBreakEvenGasPrice(rawTx []byte, txGasPrice 
 	}
 
 	txZeroBytes := uint64(bytes.Count(rawTx, []byte{0}))
-	txNonZeroBytes := uint64(len(rawTx)) - txZeroBytes
+	txNonZeroBytes := uint64(len(rawTx)) - txZeroBytes + state.EfficiencyPercentageByteLength
 
 	// Calculate BreakEvenGasPrice
 	totalTxPrice := (txGasUsed * l2MinGasPrice) +

--- a/pool/effectivegasprice.go
+++ b/pool/effectivegasprice.go
@@ -54,13 +54,6 @@ func (e *EffectiveGasPrice) GetTxAndL2GasPrice(txGasPrice *big.Int, l1GasPrice u
 
 // CalculateBreakEvenGasPrice calculates the break even gas price for a transaction
 func (e *EffectiveGasPrice) CalculateBreakEvenGasPrice(rawTx []byte, txGasPrice *big.Int, txGasUsed uint64, l1GasPrice uint64) (*big.Int, error) {
-	const (
-		// constants used in calculation of BreakEvenGasPrice
-		signatureBytesLength           = 65
-		effectivePercentageBytesLength = 1
-		constBytesTx                   = signatureBytesLength + effectivePercentageBytesLength
-	)
-
 	if l1GasPrice == 0 {
 		return nil, ErrZeroL1GasPrice
 	}
@@ -81,7 +74,7 @@ func (e *EffectiveGasPrice) CalculateBreakEvenGasPrice(rawTx []byte, txGasPrice 
 
 	// Calculate BreakEvenGasPrice
 	totalTxPrice := (txGasUsed * l2MinGasPrice) +
-		((constBytesTx+txNonZeroBytes)*e.cfg.ByteGasCost+txZeroBytes*e.cfg.ZeroByteGasCost)*l1GasPrice
+		((txNonZeroBytes*e.cfg.ByteGasCost)+(txZeroBytes*e.cfg.ZeroByteGasCost))*l1GasPrice
 	breakEvenGasPrice := new(big.Int).SetUint64(uint64(float64(totalTxPrice/txGasUsed) * e.cfg.NetProfit))
 
 	return breakEvenGasPrice, nil

--- a/pool/effectivegasprice_test.go
+++ b/pool/effectivegasprice_test.go
@@ -136,7 +136,7 @@ func TestCalculateBreakEvenGasPrice(t *testing.T) {
 			txGasPrice:    new(big.Int).SetUint64(1000),
 			txGasUsed:     200,
 			l1GasPrice:    100,
-			expectedValue: new(big.Int).SetUint64(553),
+			expectedValue: new(big.Int).SetUint64(33),
 		},
 		{
 			name:          "Test l1GasPrice=0",
@@ -161,7 +161,7 @@ func TestCalculateBreakEvenGasPrice(t *testing.T) {
 			txGasPrice:    new(big.Int).SetUint64(1000),
 			txGasUsed:     200,
 			l1GasPrice:    100,
-			expectedValue: new(big.Int).SetUint64(633),
+			expectedValue: new(big.Int).SetUint64(113),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=10",
@@ -169,7 +169,7 @@ func TestCalculateBreakEvenGasPrice(t *testing.T) {
 			txGasPrice:    new(big.Int).SetUint64(1000),
 			txGasUsed:     200,
 			l1GasPrice:    100,
-			expectedValue: new(big.Int).SetUint64(573),
+			expectedValue: new(big.Int).SetUint64(53),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=5",
@@ -177,7 +177,7 @@ func TestCalculateBreakEvenGasPrice(t *testing.T) {
 			txGasPrice:    new(big.Int).SetUint64(1000),
 			txGasUsed:     200,
 			l1GasPrice:    100,
-			expectedValue: new(big.Int).SetUint64(603),
+			expectedValue: new(big.Int).SetUint64(83),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=5 minGasPrice",
@@ -185,7 +185,7 @@ func TestCalculateBreakEvenGasPrice(t *testing.T) {
 			txGasPrice:    new(big.Int).SetUint64(1000),
 			txGasUsed:     200,
 			l1GasPrice:    10,
-			expectedValue: new(big.Int).SetUint64(67),
+			expectedValue: new(big.Int).SetUint64(15),
 		},
 	}
 
@@ -224,7 +224,7 @@ func TestCalculateEffectiveGasPrice(t *testing.T) {
 			txGasUsed:     200,
 			l1GasPrice:    100,
 			l2GasPrice:    1000,
-			expectedValue: new(big.Int).SetUint64(633),
+			expectedValue: new(big.Int).SetUint64(113),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=10",
@@ -233,7 +233,7 @@ func TestCalculateEffectiveGasPrice(t *testing.T) {
 			txGasUsed:     200,
 			l1GasPrice:    100,
 			l2GasPrice:    500,
-			expectedValue: new(big.Int).SetUint64(573 * 2),
+			expectedValue: new(big.Int).SetUint64(53 * 2),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=5",
@@ -242,7 +242,7 @@ func TestCalculateEffectiveGasPrice(t *testing.T) {
 			txGasUsed:     200,
 			l1GasPrice:    100,
 			l2GasPrice:    250,
-			expectedValue: new(big.Int).SetUint64(603 * 4),
+			expectedValue: new(big.Int).SetUint64(83 * 4),
 		},
 		{
 			name:          "Test tx len=10, zeroByte=5 minGasPrice",
@@ -251,7 +251,7 @@ func TestCalculateEffectiveGasPrice(t *testing.T) {
 			txGasUsed:     200,
 			l1GasPrice:    10,
 			l2GasPrice:    1100,
-			expectedValue: new(big.Int).SetUint64(67),
+			expectedValue: new(big.Int).SetUint64(15),
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes the size of the tx used to calculated the EGP. We were adding 65 bytes to the length of the tx to consider the bytes needed for the signature, but these bytes are already included in the rawTX data that is used to calculate the EGP, therefore we need to remove this 65 bytes addition

### Reviewers

Main reviewers:

@ToniRamirezM 
@dpunish3r 