### PR TITLE
Return last L1InfoRoot used in batchL2Data in function GetL1InfoTreeDataFromBatchL2Data

### DIFF
--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -417,7 +417,7 @@ func (f *finalizer) reprocessFullBatch(ctx context.Context, batchNum uint64, ini
 
 	executorBatchRequest := state.ProcessRequest{
 		BatchNumber:             batch.BatchNumber,
-		L1InfoRoot_V2:           mockL1InfoRoot, //TODO: Carlos
+		L1InfoRoot_V2:           mockL1InfoRoot,
 		OldStateRoot:            initialStateRoot,
 		OldAccInputHash:         initialAccInputHash,
 		Transactions:            batch.BatchL2Data,
@@ -427,7 +427,7 @@ func (f *finalizer) reprocessFullBatch(ctx context.Context, batchNum uint64, ini
 		SkipVerifyL1InfoRoot_V2: true,
 		Caller:                  caller,
 	}
-	executorBatchRequest.L1InfoTreeData_V2, err = f.state.GetL1InfoTreeDataFromBatchL2Data(ctx, batch.BatchL2Data, nil)
+	executorBatchRequest.L1InfoTreeData_V2, _, err = f.state.GetL1InfoTreeDataFromBatchL2Data(ctx, batch.BatchL2Data, nil)
 	if err != nil {
 		log.Errorf("[reprocessFullBatch] failed to get L1InfoTreeData for batch %d. Error: %w", batch.BatchNumber, err)
 		reprocessError(nil)

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -92,7 +92,7 @@ type stateInterface interface {
 	GetStorageAt(ctx context.Context, address common.Address, position *big.Int, root common.Hash) (*big.Int, error)
 	StoreL2Block(ctx context.Context, batchNumber uint64, l2Block *state.ProcessBlockResponse, txsEGPLog []*state.EffectiveGasPriceLog, dbTx pgx.Tx) error
 	BuildChangeL2Block(deltaTimestamp uint32, l1InfoTreeIndex uint32) []byte
-	GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, error)
+	GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, common.Hash, error)
 	GetBlockByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*state.Block, error)
 }
 

--- a/sequencer/mock_state.go
+++ b/sequencer/mock_state.go
@@ -475,12 +475,13 @@ func (_m *StateMock) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
 }
 
 // GetL1InfoTreeDataFromBatchL2Data provides a mock function with given fields: ctx, batchL2Data, dbTx
-func (_m *StateMock) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, error) {
+func (_m *StateMock) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, common.Hash, error) {
 	ret := _m.Called(ctx, batchL2Data, dbTx)
 
 	var r0 map[uint32]state.L1DataV2
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, pgx.Tx) (map[uint32]state.L1DataV2, error)); ok {
+	var r1 common.Hash
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, pgx.Tx) (map[uint32]state.L1DataV2, common.Hash, error)); ok {
 		return rf(ctx, batchL2Data, dbTx)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, []byte, pgx.Tx) map[uint32]state.L1DataV2); ok {
@@ -491,13 +492,21 @@ func (_m *StateMock) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batch
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []byte, pgx.Tx) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []byte, pgx.Tx) common.Hash); ok {
 		r1 = rf(ctx, batchL2Data, dbTx)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(common.Hash)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, []byte, pgx.Tx) error); ok {
+		r2 = rf(ctx, batchL2Data, dbTx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetLastBatch provides a mock function with given fields: ctx, dbTx

--- a/state/batch.go
+++ b/state/batch.go
@@ -554,3 +554,36 @@ func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, force
 	}
 	return batchTimestamp, nil
 }
+
+// GetL1InfoTreeDataFromBatchL2Data returns a map with the L1InfoTreeData used in the L2 blocks included in the batchL2Data and the last L1InfoRoot used
+func (s *State) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]L1DataV2, common.Hash, error) {
+	batchRaw, err := DecodeBatchV2(batchL2Data)
+	if err != nil {
+		return nil, ZeroHash, err
+	}
+
+	l1InfoTreeData := map[uint32]L1DataV2{}
+	lastL1InfoRoot := ZeroHash
+
+	for _, l2blockRaw := range batchRaw.Blocks {
+		_, found := l1InfoTreeData[l2blockRaw.IndexL1InfoTree]
+		if !found {
+			l1InfoTreeExitRootStorageEntry, err := s.GetL1InfoRootLeafByIndex(ctx, l2blockRaw.IndexL1InfoTree, dbTx)
+			if err != nil {
+				return nil, ZeroHash, err
+			}
+
+			l1Data := L1DataV2{
+				GlobalExitRoot: l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.GlobalExitRoot.GlobalExitRoot,
+				BlockHashL1:    l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.PreviousBlockHash,
+				MinTimestamp:   uint64(l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.GlobalExitRoot.Timestamp.Unix()),
+			}
+
+			l1InfoTreeData[l2blockRaw.IndexL1InfoTree] = l1Data
+
+			lastL1InfoRoot = l1InfoTreeExitRootStorageEntry.L1InfoTreeRoot
+		}
+	}
+
+	return l1InfoTreeData, lastL1InfoRoot, nil
+}

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -144,6 +144,5 @@ type storage interface {
 	GetL1InfoRootLeafByL1InfoRoot(ctx context.Context, l1InfoRoot common.Hash, dbTx pgx.Tx) (L1InfoTreeExitRootStorageEntry, error)
 	GetL1InfoRootLeafByIndex(ctx context.Context, l1InfoTreeIndex uint32, dbTx pgx.Tx) (L1InfoTreeExitRootStorageEntry, error)
 	GetLeafsByL1InfoRoot(ctx context.Context, l1InfoRoot common.Hash, dbTx pgx.Tx) ([]L1InfoTreeExitRootStorageEntry, error)
-	GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]L1DataV2, error)
 	GetBlockByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*Block, error)
 }

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -956,30 +956,3 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	}
 	return batchTimestamp, virtualBatchTimestamp, err
 }
-
-// GetL1InfoTreeDataFromBatchL2Data returns a map with the L1InfoTreeData used in the L2 blocks included in the batchL2Data
-func (p *PostgresStorage) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, error) {
-	batchRaw, err := state.DecodeBatchV2(batchL2Data)
-	if err != nil {
-		return nil, err
-	}
-
-	l1InfoTreeData := map[uint32]state.L1DataV2{}
-
-	for _, l2blockRaw := range batchRaw.Blocks {
-		_, found := l1InfoTreeData[l2blockRaw.IndexL1InfoTree]
-		if !found {
-			l1InfoTreeExitRootStorageEntry, err := p.GetL1InfoRootLeafByIndex(ctx, l2blockRaw.IndexL1InfoTree, dbTx)
-			if err != nil {
-				return nil, err
-			}
-			l1InfoTreeData[l2blockRaw.IndexL1InfoTree] = state.L1DataV2{
-				GlobalExitRoot: l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.GlobalExitRoot.GlobalExitRoot,
-				BlockHashL1:    l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.PreviousBlockHash,
-				MinTimestamp:   uint64(l1InfoTreeExitRootStorageEntry.L1InfoTreeLeaf.GlobalExitRoot.Timestamp.Unix()),
-			}
-		}
-	}
-
-	return l1InfoTreeData, nil
-}


### PR DESCRIPTION
### What does this PR do?

Function GetL1InfoTreeDataFromBatchL2Data now returns also the last L1InfoRoot used in batchL2Data. Also, the function has been moved to the state (state/batch.go)

### Reviewers

Main reviewers:

@ToniRamirezM 
@joanestebanr 
@ARR552 