### PR TITLE
Remove accInputHash calculation on finalizer. Fix batch GER

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -431,7 +431,6 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker, first
 	executorBatchRequest := state.ProcessRequest{
 		BatchNumber:               f.wipBatch.batchNumber,
 		OldStateRoot:              f.wipBatch.imStateRoot,
-		OldAccInputHash:           f.wipBatch.imAccInputHash,
 		Coinbase:                  f.wipBatch.coinbase,
 		L1InfoRoot_V2:             mockL1InfoRoot,
 		TimestampLimit_V2:         uint64(f.wipL2Block.timestamp.Unix()),
@@ -571,7 +570,6 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker, first
 	// Update wip batch
 	f.wipBatch.imStateRoot = processBatchResponse.NewStateRoot
 	f.wipBatch.localExitRoot = processBatchResponse.NewLocalExitRoot
-	f.wipBatch.imAccInputHash = processBatchResponse.NewAccInputHash
 
 	log.Infof("processed tx: %s. Batch.batchNumber: %d, batchNumber: %d, newStateRoot: %s, newLocalExitRoot: %s, oldStateRoot: %s",
 		hashStr, f.wipBatch.batchNumber, executorBatchRequest.BatchNumber, processBatchResponse.NewStateRoot.String(), processBatchResponse.NewLocalExitRoot.String(), oldStateRoot.String())

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -884,7 +884,6 @@ func TestFinalizer_openWIPBatch(t *testing.T) {
 		initialStateRoot:   oldHash,
 		imStateRoot:        oldHash,
 		timestamp:          now(),
-		globalExitRoot:     oldHash,
 		remainingResources: getMaxRemainingResources(f.batchConstraints),
 	}
 	testCases := []struct {
@@ -943,7 +942,7 @@ func TestFinalizer_openWIPBatch(t *testing.T) {
 			}
 
 			// act
-			wipBatch, err := f.openNewWIPBatch(ctx, batchNum, oldHash, oldHash, oldHash, oldHash)
+			wipBatch, err := f.openNewWIPBatch(ctx, batchNum, oldHash, oldHash, oldHash)
 
 			// assert
 			if tc.expectedErr != nil {
@@ -1887,7 +1886,7 @@ func TestFinalizer_reprocessFullBatch(t *testing.T) {
 			}
 
 			// act
-			result, err := f.reprocessFullBatch(context.Background(), tc.batchNum, f.wipBatch.initialStateRoot, f.wipBatch.initialAccInputHash, newHash)
+			result, err := f.reprocessFullBatch(context.Background(), tc.batchNum, f.wipBatch.initialStateRoot, newHash)
 
 			// assert
 			if tc.expectedError != nil {
@@ -2280,7 +2279,6 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 			imStateRoot:        newHash,
 			localExitRoot:      newHash,
 			timestamp:          now(),
-			globalExitRoot:     oldHash,
 			remainingResources: getMaxRemainingResources(bc),
 			closingReason:      state.EmptyClosingReason,
 		}

--- a/sequencer/forcedbatch.go
+++ b/sequencer/forcedbatch.go
@@ -13,7 +13,7 @@ import (
 )
 
 // processForcedBatches processes all the forced batches that are pending to be processed
-func (f *finalizer) processForcedBatches(ctx context.Context, lastBatchNumber uint64, stateRoot, accInputHash common.Hash) (newLastBatchNumber uint64, newStateRoot, newAccInputHash common.Hash) {
+func (f *finalizer) processForcedBatches(ctx context.Context, lastBatchNumber uint64, stateRoot common.Hash) (newLastBatchNumber uint64, newStateRoot common.Hash) {
 	f.nextForcedBatchesMux.Lock()
 	defer f.nextForcedBatchesMux.Unlock()
 	f.nextForcedBatchDeadline = 0
@@ -21,7 +21,7 @@ func (f *finalizer) processForcedBatches(ctx context.Context, lastBatchNumber ui
 	lastForcedBatchNumber, err := f.state.GetLastTrustedForcedBatchNumber(ctx, nil)
 	if err != nil {
 		log.Errorf("[processForcedBatches] failed to get last trusted forced batch number. Error: %w", err)
-		return lastBatchNumber, stateRoot, accInputHash
+		return lastBatchNumber, stateRoot
 	}
 	nextForcedBatchNumber := lastForcedBatchNumber + 1
 
@@ -35,48 +35,48 @@ func (f *finalizer) processForcedBatches(ctx context.Context, lastBatchNumber ui
 			missingForcedBatch, err := f.state.GetForcedBatch(ctx, nextForcedBatchNumber, nil)
 			if err != nil {
 				log.Errorf("[processForcedBatches] failed to get missing forced batch %d. Error: %w", nextForcedBatchNumber, err)
-				return lastBatchNumber, stateRoot, accInputHash
+				return lastBatchNumber, stateRoot
 			}
 			forcedBatchToProcess = *missingForcedBatch
 		}
 
-		log.Infof("processing forced batch %d, LastBatchNumber: %d, StateRoot: %s, AccInputHash: %s", forcedBatchToProcess.ForcedBatchNumber, lastBatchNumber, stateRoot.String(), accInputHash.String())
-		lastBatchNumber, stateRoot, accInputHash, err = f.processForcedBatch(ctx, forcedBatchToProcess, lastBatchNumber, stateRoot, accInputHash)
+		log.Infof("processing forced batch %d, LastBatchNumber: %d, StateRoot: %s", forcedBatchToProcess.ForcedBatchNumber, lastBatchNumber, stateRoot.String())
+		lastBatchNumber, stateRoot, err = f.processForcedBatch(ctx, forcedBatchToProcess, lastBatchNumber, stateRoot)
 
 		if err != nil {
 			log.Errorf("[processForcedBatches] error when processing forced batch %d. Error: %w", forcedBatchToProcess.ForcedBatchNumber, err)
-			return lastBatchNumber, stateRoot, accInputHash
+			return lastBatchNumber, stateRoot
 		}
 
-		log.Infof("processed forced batch %d, BatchNumber: %d, NewStateRoot: %s, NewAccInputHash: %s", forcedBatchToProcess.ForcedBatchNumber, lastBatchNumber, stateRoot.String(), accInputHash.String())
+		log.Infof("processed forced batch %d, BatchNumber: %d, NewStateRoot: %s", forcedBatchToProcess.ForcedBatchNumber, lastBatchNumber, stateRoot.String())
 
 		nextForcedBatchNumber += 1
 	}
 	f.nextForcedBatches = make([]state.ForcedBatch, 0)
 
-	return lastBatchNumber, stateRoot, accInputHash
+	return lastBatchNumber, stateRoot
 }
 
-func (f *finalizer) processForcedBatch(ctx context.Context, forcedBatch state.ForcedBatch, lastBatchNumber uint64, stateRoot, accInputHash common.Hash) (newLastBatchNumber uint64, newStateRoot, newAccInputHash common.Hash, retErr error) {
+func (f *finalizer) processForcedBatch(ctx context.Context, forcedBatch state.ForcedBatch, lastBatchNumber uint64, stateRoot common.Hash) (newLastBatchNumber uint64, newStateRoot common.Hash, retErr error) {
 	dbTx, err := f.state.BeginStateTransaction(ctx)
 	if err != nil {
 		log.Errorf("failed to begin state transaction for process forced batch %d. Error: %w", forcedBatch.ForcedBatchNumber, err)
-		return lastBatchNumber, stateRoot, accInputHash, err
+		return lastBatchNumber, stateRoot, err
 	}
 
 	// Helper function in case we get an error when processing the forced batch
-	rollbackOnError := func(retError error) (newLastBatchNumber uint64, newStateRoot, newAccInputHash common.Hash, retErr error) {
+	rollbackOnError := func(retError error) (newLastBatchNumber uint64, newStateRoot common.Hash, retErr error) {
 		err := dbTx.Rollback(ctx)
 		if err != nil {
-			return lastBatchNumber, stateRoot, accInputHash, fmt.Errorf("[processForcedBatch] rollback error due to error %w. Error: %w", retError, err)
+			return lastBatchNumber, stateRoot, fmt.Errorf("[processForcedBatch] rollback error due to error %w. Error: %w", retError, err)
 		}
-		return lastBatchNumber, stateRoot, accInputHash, retError
+		return lastBatchNumber, stateRoot, retError
 	}
 
 	// Get L1 block for the forced batch
 	fbL1Block, err := f.state.GetBlockByNumber(ctx, forcedBatch.ForcedBatchNumber, dbTx)
 	if err != nil {
-		return lastBatchNumber, stateRoot, accInputHash, fmt.Errorf("[processForcedBatch] error getting L1 block number %d for forced batch %d. Error: %w", forcedBatch.ForcedBatchNumber, forcedBatch.ForcedBatchNumber, err)
+		return lastBatchNumber, stateRoot, fmt.Errorf("[processForcedBatch] error getting L1 block number %d for forced batch %d. Error: %w", forcedBatch.ForcedBatchNumber, forcedBatch.ForcedBatchNumber, err)
 	}
 
 	newBatchNumber := lastBatchNumber + 1
@@ -99,7 +99,6 @@ func (f *finalizer) processForcedBatch(ctx context.Context, forcedBatch state.Fo
 		L1InfoRoot_V2:           forcedBatch.GlobalExitRoot,
 		ForcedBlockHashL1:       fbL1Block.ParentHash,
 		OldStateRoot:            stateRoot,
-		OldAccInputHash:         accInputHash,
 		Transactions:            forcedBatch.RawTxsData,
 		Coinbase:                f.sequencerAddress,
 		TimestampLimit_V2:       uint64(forcedBatch.ForcedAt.Unix()),
@@ -108,10 +107,6 @@ func (f *finalizer) processForcedBatch(ctx context.Context, forcedBatch state.Fo
 		Caller:                  stateMetrics.SequencerCallerLabel,
 	}
 
-	// falta pasar timestamp_limit = fb.ForcedAt
-	// L1InfoRoot = fb.GER
-	// forced_blockhash_l1 = table.forced_batch.block_num.parent_hash
-	// l1_info_tree_data  vacio
 	batchResponse, err := f.state.ProcessBatchV2(ctx, executorBatchRequest, true)
 	if err != nil {
 		return rollbackOnError(fmt.Errorf("[processForcedBatch] failed to process/execute forced batch %d. Error: %w", forcedBatch.ForcedBatchNumber, err))
@@ -151,7 +146,7 @@ func (f *finalizer) processForcedBatch(ctx context.Context, forcedBatch state.Fo
 	}*/
 	//}
 
-	return newBatchNumber, batchResponse.NewStateRoot, batchResponse.NewAccInputHash, nil
+	return newBatchNumber, batchResponse.NewStateRoot, nil
 }
 
 // addForcedTxToWorker adds the txs of the forced batch to the worker

--- a/state/batch.go
+++ b/state/batch.go
@@ -75,10 +75,11 @@ const (
 
 // ProcessingReceipt indicates the outcome (StateRoot, AccInputHash) of processing a batch
 type ProcessingReceipt struct {
-	BatchNumber   uint64
-	StateRoot     common.Hash
-	LocalExitRoot common.Hash
-	AccInputHash  common.Hash
+	BatchNumber    uint64
+	StateRoot      common.Hash
+	LocalExitRoot  common.Hash
+	GlobalExitRoot common.Hash
+	AccInputHash   common.Hash
 	// Txs           []types.Transaction
 	BatchL2Data    []byte
 	ClosingReason  ClosingReason


### PR DESCRIPTION
### What does this PR do?

- Removes the calculation of the accInputHash for the batch in the finalizer, since this must be done by the synchornizer. The finalizer needs to use an empry accInputHash in the request, since to calculate the valid accInputHash we need the "final" Timestamp_Limit and L1InfoRoot values and the finalizer doesn't have them (it uses now() and a mock value for the L1InfoRoot.
- Fix GER stored in the batch. In ETROG we will store the L1InfoTree GER used in the last L2 block of the batch. Anyway the GER we will update for the WIP batch each time we close a L2 block
 
### Reviewers

Main reviewers:

@ToniRamirezM 
@joanestebanr 
@ARR552 