### PR TITLE
Fix data streamer out-of-order with the fork upgrading

### DIFF
--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -2852,6 +2852,8 @@ func (p *PostgresStorage) GetDSBatches(ctx context.Context, firstBatchNumber, la
 		getBatchByNumberSQL += " AND b.state_root is not null"
 	}
 
+	getBatchByNumberSQL += " ORDER BY b.batch_num"
+
 	e := p.getExecQuerier(dbTx)
 	rows, err := e.Query(ctx, getBatchByNumberSQL, firstBatchNumber, lastBatchNumber)
 	if err != nil {

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -2852,7 +2852,7 @@ func (p *PostgresStorage) GetDSBatches(ctx context.Context, firstBatchNumber, la
 		getBatchByNumberSQL += " AND b.state_root is not null"
 	}
 
-	getBatchByNumberSQL += " ORDER BY b.batch_num"
+	getBatchByNumberSQL += " ORDER BY b.batch_num ASC"
 
 	e := p.getExecQuerier(dbTx)
 	rows, err := e.Query(ctx, getBatchByNumberSQL, firstBatchNumber, lastBatchNumber)


### PR DESCRIPTION
### What does this PR do?

GenerateDataStreamerFile(data streamer file) will be out of order batches at the batch of fork5 to fork 6 

