### PR TITLE
fix: remove the duplicate word.

### DIFF
--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -113,7 +113,7 @@ func SequencedBatchesSigHash() common.Hash { return sequenceBatchesSignatureHash
 // TrustedVerifyBatchesSigHash returns the hash for the `TrustedVerifyBatches` event.
 func TrustedVerifyBatchesSigHash() common.Hash { return verifyBatchesTrustedAggregatorSignatureHash }
 
-// EventOrder is the the type used to identify the events order
+// EventOrder is the type used to identify the events order
 type EventOrder string
 
 const (


### PR DESCRIPTION
There is an unnecessary duplicate word in the code comments. It is removed in this change set.

Closes #<issue number>.

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
