### PR TITLE
Add zkevm_EstimateFee endpoint

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -361,7 +361,7 @@ func runJSONRPCServer(c config.Config, etherman *etherman.Client, chainID uint64
 	if _, ok := apis[jsonrpc.APIZKEVM]; ok {
 		services = append(services, jsonrpc.Service{
 			Name:    jsonrpc.APIZKEVM,
-			Service: jsonrpc.NewZKEVMEndpoints(c.RPC, st, etherman),
+			Service: jsonrpc.NewZKEVMEndpoints(c.RPC, pool, st, etherman),
 		})
 	}
 

--- a/jsonrpc/mocks/mock_pool.go
+++ b/jsonrpc/mocks/mock_pool.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
 
@@ -35,6 +36,32 @@ func (_m *PoolMock) AddTx(ctx context.Context, tx types.Transaction, ip string) 
 	return r0
 }
 
+// CalculateEffectiveGasPrice provides a mock function with given fields: rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice
+func (_m *PoolMock) CalculateEffectiveGasPrice(rawTx []byte, txGasPrice *big.Int, txGasUsed uint64, l1GasPrice uint64, l2GasPrice uint64) (*big.Int, error) {
+	ret := _m.Called(rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice)
+
+	var r0 *big.Int
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]byte, *big.Int, uint64, uint64, uint64) (*big.Int, error)); ok {
+		return rf(rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice)
+	}
+	if rf, ok := ret.Get(0).(func([]byte, *big.Int, uint64, uint64, uint64) *big.Int); ok {
+		r0 = rf(rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]byte, *big.Int, uint64, uint64, uint64) error); ok {
+		r1 = rf(rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountPendingTransactions provides a mock function with given fields: ctx
 func (_m *PoolMock) CountPendingTransactions(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)
@@ -57,6 +84,20 @@ func (_m *PoolMock) CountPendingTransactions(ctx context.Context) (uint64, error
 	}
 
 	return r0, r1
+}
+
+// EffectiveGasPriceEnabled provides a mock function with given fields:
+func (_m *PoolMock) EffectiveGasPriceEnabled() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // GetGasPrices provides a mock function with given fields: ctx

--- a/jsonrpc/server_test.go
+++ b/jsonrpc/server_test.go
@@ -82,7 +82,7 @@ func newMockedServer(t *testing.T, cfg Config) (*mockedServer, *mocksWrapper, *e
 	if _, ok := apis[APIZKEVM]; ok {
 		services = append(services, Service{
 			Name:    APIZKEVM,
-			Service: NewZKEVMEndpoints(cfg, st, etherman),
+			Service: NewZKEVMEndpoints(cfg, pool, st, etherman),
 		})
 	}
 

--- a/jsonrpc/types/interfaces.go
+++ b/jsonrpc/types/interfaces.go
@@ -22,6 +22,8 @@ type PoolInterface interface {
 	GetPendingTxs(ctx context.Context, limit uint64) ([]pool.Transaction, error)
 	CountPendingTransactions(ctx context.Context) (uint64, error)
 	GetTxByHash(ctx context.Context, hash common.Hash) (*pool.Transaction, error)
+	CalculateEffectiveGasPrice(rawTx []byte, txGasPrice *big.Int, txGasUsed uint64, l1GasPrice uint64, l2GasPrice uint64) (*big.Int, error)
+	EffectiveGasPriceEnabled() bool
 }
 
 // StateInterface gathers the methods required to interact with the state.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -666,6 +666,16 @@ const (
 	txDataZeroGas         uint64 = 4
 )
 
+// CalculateEffectiveGasPrice calculates the final effective gas price for a tx
+func (p *Pool) CalculateEffectiveGasPrice(rawTx []byte, txGasPrice *big.Int, txGasUsed uint64, l1GasPrice uint64, l2GasPrice uint64) (*big.Int, error) {
+	return p.effectiveGasPrice.CalculateEffectiveGasPrice(rawTx, txGasPrice, txGasUsed, l1GasPrice, l2GasPrice)
+}
+
+// EffectiveGasPriceEnabled returns if effective gas price calculation is enabled or not
+func (p *Pool) EffectiveGasPriceEnabled() bool {
+	return p.effectiveGasPrice.IsEnabled()
+}
+
 // IntrinsicGas computes the 'intrinsic gas' for a given transaction.
 func IntrinsicGas(tx types.Transaction) (uint64, error) {
 	// Set the starting gas for the raw transaction


### PR DESCRIPTION
### What does this PR do?

Add new zkevm_EstimateFee custom endpoint. This endpoint returns the estimate fee (in wei) for a tx. It takes into account the effective gas price calculation if it's enabled, if not it uses current L2 gas price to calculate the fee.

This new endpoint will be used by l2fees.info to get the estimated fee for the txs in the zkEVM

### Reviewers

Main reviewers:

@tclemos 
@ARR552 
@joanestebanr 
@ToniRamirezM 