### PR TITLE
Fix sequencer/executor metrics. Rename poolPackage/statePackage to poolIntf/stateIntf.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -176,7 +176,7 @@ func start(cliCtx *cli.Context) error {
 			if poolInstance == nil {
 				poolInstance = createPool(c.Pool, c.State.Batch.Constraints, l2ChainID, st, eventLog)
 			}
-			seq := createSequencer(*c, poolInstance, st, eventLog)
+			seq := createSequencer(*c, poolInstance, st, etherman, eventLog)
 			go seq.Start(cliCtx.Context)
 		case SEQUENCE_SENDER:
 			ev.Component = event.Component_Sequence_Sender
@@ -389,12 +389,7 @@ func runJSONRPCServer(c config.Config, etherman *etherman.Client, chainID uint64
 	}
 }
 
-func createSequencer(cfg config.Config, pool *pool.Pool, st *state.State, eventLog *event.EventLog) *sequencer.Sequencer {
-	etherman, err := newEtherman(cfg)
-	if err != nil {
-		log.Fatal(err)
-	}
-
+func createSequencer(cfg config.Config, pool *pool.Pool, st *state.State, etherman *etherman.Client, eventLog *event.EventLog) *sequencer.Sequencer {
 	seq, err := sequencer.New(cfg.Sequencer, cfg.State.Batch, cfg.Pool, pool, st, etherman, eventLog)
 	if err != nil {
 		log.Fatal(err)

--- a/db/migrations/state/0013.sql
+++ b/db/migrations/state/0013.sql
@@ -6,8 +6,7 @@ ALTER TABLE state.exit_root
 CREATE INDEX IF NOT EXISTS idx_exit_root_l1_info_tree_index ON state.exit_root (l1_info_tree_index);
 
 ALTER TABLE state.transaction
-    ADD COLUMN l2_hash VARCHAR UNIQUE,
-    ADD COLUMN used_sha256_hashes INTEGER;
+    ADD COLUMN l2_hash VARCHAR UNIQUE;
 
 CREATE INDEX IF NOT EXISTS idx_transaction_l2_hash ON state.transaction (l2_hash);
 
@@ -25,9 +24,8 @@ ALTER TABLE state.exit_root
 DROP INDEX IF EXISTS state.idx_exit_root_l1_info_tree_index;
 
 ALTER TABLE state.transaction
-    DROP COLUMN l2_hash,
-    DROP COLUMN used_sha256_hashes;
-
+    DROP COLUMN l2_hash;
+    
 DROP INDEX IF EXISTS state.idx_transaction_l2_hash;
 
 ALTER TABLE state.batch

--- a/db/migrations/state/0013_test.go
+++ b/db/migrations/state/0013_test.go
@@ -85,8 +85,8 @@ func (m migrationTest0013) InsertDataIntoTransactionsTable(db *sql.DB) error {
 	}
 
 	const insertTx = `
-		INSERT INTO state.transaction (hash, encoded, decoded, l2_block_num, effective_percentage, l2_hash, used_sha256_hashes)
-		VALUES ('0x0001', 'ABCDEF', '{}', 0, 255, '0x0002', 1000)`
+		INSERT INTO state.transaction (hash, encoded, decoded, l2_block_num, effective_percentage, l2_hash)
+		VALUES ('0x0001', 'ABCDEF', '{}', 0, 255, '0x0002')`
 
 	// insert tx
 	_, err = db.Exec(insertTx)
@@ -140,12 +140,6 @@ func (m migrationTest0013) RunAssertsAfterMigrationUp(t *testing.T, db *sql.DB) 
 	assert.NoError(t, row.Scan(&result))
 	assert.Equal(t, 1, result)
 
-	// Check column used_sha256_hashes exists in state.transactions table
-	const getUsedSHA256HashesColumn = `SELECT count(*) FROM information_schema.columns WHERE table_name='transaction' and column_name='used_sha256_hashes'`
-	row = db.QueryRow(getUsedSHA256HashesColumn)
-	assert.NoError(t, row.Scan(&result))
-	assert.Equal(t, 1, result)
-
 	// Check column wip exists in state.batch table
 	const getWIPColumn = `SELECT count(*) FROM information_schema.columns WHERE table_name='batch' and column_name='wip'`
 	row = db.QueryRow(getWIPColumn)
@@ -168,12 +162,6 @@ func (m migrationTest0013) RunAssertsAfterMigrationDown(t *testing.T, db *sql.DB
 	const getL2HashColumn = `SELECT count(*) FROM information_schema.columns WHERE table_name='transaction' and column_name='l2_hash'`
 	row := db.QueryRow(getL2HashColumn)
 	var result int
-	assert.NoError(t, row.Scan(&result))
-	assert.Equal(t, 0, result)
-
-	// Check column wip doesn't exists in state.batch table
-	const getUsedSHA256HashesColumn = `SELECT count(*) FROM information_schema.columns WHERE table_name='batch' and column_name='used_sha256_hashes'`
-	row = db.QueryRow(getUsedSHA256HashesColumn)
 	assert.NoError(t, row.Scan(&result))
 	assert.Equal(t, 0, result)
 

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -141,14 +141,14 @@ func (f *finalizer) closeAndOpenNewWIPBatch(ctx context.Context) (*Batch, error)
 	// Wait until all L2 blocks are processed by the executor
 	startWait := time.Now()
 	f.pendingL2BlocksToProcessWG.Wait()
-	elapsed := time.Now().Sub(startWait)
+	elapsed := time.Since(startWait)
 	stateMetrics.ExecutorProcessingTime(string(stateMetrics.SequencerCallerLabel), elapsed)
 	log.Debugf("waiting for pending L2 blocks to be processed took: %v", elapsed)
 
 	// Wait until all L2 blocks are store
 	startWait = time.Now()
 	f.pendingL2BlocksToStoreWG.Wait()
-	log.Debugf("waiting for pending L2 blocks to be stored took: %v", time.Now().Sub(startWait))
+	log.Debugf("waiting for pending L2 blocks to be stored took: %v", time.Since(startWait))
 
 	var err error
 

--- a/sequencer/datastreamer.go
+++ b/sequencer/datastreamer.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (f *finalizer) DSSendL2Block(batchNumber uint64, blockResponse *state.ProcessBlockResponse) error {
-	forkID := f.state.GetForkIDByBatchNumber(batchNumber)
+	forkID := f.stateIntf.GetForkIDByBatchNumber(batchNumber)
 
 	// Send data to streamer
 	if f.streamServer != nil {

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -122,9 +122,9 @@ func TestNewFinalizer(t *testing.T) {
 	// assert
 	assert.NotNil(t, f)
 	assert.Equal(t, f.cfg, cfg)
-	assert.Equal(t, f.worker, workerMock)
+	assert.Equal(t, f.workerIntf, workerMock)
 	assert.Equal(t, poolMock, poolMock)
-	assert.Equal(t, f.state, stateMock)
+	assert.Equal(t, f.stateIntf, stateMock)
 	assert.Equal(t, f.sequencerAddress, seqAddr)
 	assert.Equal(t, f.batchConstraints, bc)
 }
@@ -2218,9 +2218,9 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 		cfg:                        cfg,
 		isSynced:                   isSynced,
 		sequencerAddress:           seqAddr,
-		worker:                     workerMock,
-		pool:                       poolMock,
-		state:                      stateMock,
+		workerIntf:                 workerMock,
+		poolIntf:                   poolMock,
+		stateIntf:                  stateMock,
 		wipBatch:                   wipBatch,
 		batchConstraints:           bc,
 		nextForcedBatches:          make([]state.ForcedBatch, 0),


### PR DESCRIPTION
### What does this PR do?

- Fixes sequencer/executor metrics
- Rename poolPackage/statePackage to poolIntf/stateIntf

### Reviewers

Main reviewers:

@ToniRamirezM 