### PR TITLE
feat: optimized txpool purge

### DIFF
--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -37,6 +37,7 @@ type storage interface {
 	MarkWIPTxsAsPending(ctx context.Context) error
 	GetAllAddressesBlocked(ctx context.Context) ([]common.Address, error)
 	MinL2GasPriceSince(ctx context.Context, timestamp time.Time) (uint64, error)
+	GetEarliestProcessedTx(ctx context.Context) (common.Hash, error)
 }
 
 type stateInterface interface {

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -30,6 +30,7 @@ type txPool interface {
 	GetGasPrices(ctx context.Context) (pool.GasPrices, error)
 	GetDefaultMinGasPriceAllowed() uint64
 	GetL1AndL2GasPrice() (uint64, uint64)
+	GetEarliestProcessedTx(ctx context.Context) (common.Hash, error)
 }
 
 // etherman contains the methods required to interact with ethereum.
@@ -48,6 +49,7 @@ type etherman interface {
 type stateInterface interface {
 	GetTimeForLatestBatchVirtualization(ctx context.Context, dbTx pgx.Tx) (time.Time, error)
 	GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uint64, dbTx pgx.Tx) ([]common.Hash, error)
+	GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error)
 	GetBatchByNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.Batch, error)
 	GetTransactionsByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (txs []types.Transaction, effectivePercentages []uint8, err error)
 	BeginStateTransaction(ctx context.Context) (pgx.Tx, error)

--- a/sequencer/mock_pool.go
+++ b/sequencer/mock_pool.go
@@ -77,6 +77,32 @@ func (_m *PoolMock) GetDefaultMinGasPriceAllowed() uint64 {
 	return r0
 }
 
+// GetEarliestProcessedTx provides a mock function with given fields: ctx
+func (_m *PoolMock) GetEarliestProcessedTx(ctx context.Context) (common.Hash, error) {
+	ret := _m.Called(ctx)
+
+	var r0 common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (common.Hash, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) common.Hash); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetGasPrices provides a mock function with given fields: ctx
 func (_m *PoolMock) GetGasPrices(ctx context.Context) (pool.GasPrices, error) {
 	ret := _m.Called(ctx)

--- a/sequencer/mock_state.go
+++ b/sequencer/mock_state.go
@@ -888,6 +888,32 @@ func (_m *StateMock) GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uin
 	return r0, r1
 }
 
+// GetTxsOlderThanNL1BlocksUntilTxHash provides a mock function with given fields: ctx, nL1Blocks, earliestTxHash, dbTx
+func (_m *StateMock) GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error) {
+	ret := _m.Called(ctx, nL1Blocks, earliestTxHash, dbTx)
+
+	var r0 []common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) ([]common.Hash, error)); ok {
+		return rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) []common.Hash); ok {
+		r0 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, common.Hash, pgx.Tx) error); ok {
+		r1 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsBatchClosed provides a mock function with given fields: ctx, batchNum, dbTx
 func (_m *StateMock) IsBatchClosed(ctx context.Context, batchNum uint64, dbTx pgx.Tx) (bool, error) {
 	ret := _m.Called(ctx, batchNum, dbTx)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -207,7 +207,13 @@ func (s *Sequencer) purgeOldPoolTxs(ctx context.Context) {
 	for {
 		waitTick(ctx, ticker)
 		log.Infof("trying to get txs to delete from the pool...")
-		txHashes, err := s.state.GetTxsOlderThanNL1Blocks(ctx, s.cfg.BlocksAmountForTxsToBeDeleted, nil)
+		earliestTxHash, err := s.pool.GetEarliestProcessedTx(ctx)
+		if err != nil {
+			log.Errorf("failed to get earliest tx hash to delete, err: %v", err)
+			continue
+		}
+
+		txHashes, err := s.state.GetTxsOlderThanNL1BlocksUntilTxHash(ctx, s.cfg.BlocksAmountForTxsToBeDeleted, earliestTxHash, nil)
 		if err != nil {
 			log.Errorf("failed to get txs hashes to delete, err: %v", err)
 			continue

--- a/state/pgstatestorage.go
+++ b/state/pgstatestorage.go
@@ -98,6 +98,67 @@ func (p *PostgresStorage) AddBlock(ctx context.Context, block *Block, dbTx pgx.T
 	return err
 }
 
+// GetTxsOlderThanNL1BlocksUntilTxHash get txs hashes to delete from tx pool from the oldest processed transaction to the latest
+// txn that has been virtualized.
+// Works like GetTxsOlderThanNL1Blocks but pulls hashes until earliestTxHash
+func (p *PostgresStorage) GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error) {
+	var earliestBatchNum, latestBatchNum, blockNum uint64
+	const getLatestBatchNumByBlockNumFromVirtualBatch = "SELECT batch_num FROM state.virtual_batch WHERE block_num <= $1 ORDER BY batch_num DESC LIMIT 1"
+	const getTxsHashesBeforeBatchNum = "SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num >= $1 AND state.l2block.batch_num <= $2"
+
+	// Get lower bound batch_num which is the batch num from the oldest tx in txpool
+	const getEarliestBatchNumByTxHashFromVirtualBatch = `SELECT batch_num
+	FROM state.transaction
+	JOIN state.l2block ON
+		state.transaction.l2_block_num = state.l2block.block_num AND state.transaction.hash = $1`
+
+	e := p.getExecQuerier(dbTx)
+
+	err := e.QueryRow(ctx, getLastBlockNumSQL).Scan(&blockNum)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	blockNum = blockNum - nL1Blocks
+	if blockNum <= 0 {
+		return nil, errors.New("blockNumDiff is too big, there are no txs to delete")
+	}
+
+	err = e.QueryRow(ctx, getEarliestBatchNumByTxHashFromVirtualBatch, earliestTxHash.String()).Scan(&earliestBatchNum)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	err = e.QueryRow(ctx, getLatestBatchNumByBlockNumFromVirtualBatch, blockNum).Scan(&latestBatchNum)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	rows, err := e.Query(ctx, getTxsHashesBeforeBatchNum, earliestBatchNum, latestBatchNum)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+	hashes := make([]common.Hash, 0, len(rows.RawValues()))
+	for rows.Next() {
+		var hash string
+		err := rows.Scan(&hash)
+		if err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, common.HexToHash(hash))
+	}
+
+	return hashes, nil
+}
+
 // GetTxsOlderThanNL1Blocks get txs hashes to delete from tx pool
 func (p *PostgresStorage) GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uint64, dbTx pgx.Tx) ([]common.Hash, error) {
 	var batchNum, blockNum uint64


### PR DESCRIPTION
Closes Issue #3031.

### What does this PR do?

At a high level, this PR optimizes the logic of pulling the number of transactions to clean from the transaction pool. 

Within the `purgeOldPoolTxs()` function, there is a potential performance bottleneck where it retrieves all transactions (including ones that have already been deleted from the txn pool), as seen in this [query](https://github.com/0xPolygonHermez/zkevm-node/blob/10fdcf9935851e5685ff4c9c8d4b33ca2a3147ae/state/pgstatestorage/transaction.go#L22):

```
SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num <= $1
```

The potential performance bottleneck is caused by the query not taking into account a lower bound (i.e. it just retrieves all transactions from the latest batch num: `AND state.l2block.batch_num <= $1)`.

This PR optimizes the approach by:
1. finding the oldest completed txn in the txn pool
2. retrieve all txn from that oldest txn until the latest virtual batch number
3. delete all those txn from txn pool

### Testing

Steps to test these changes:

Update the node config to delete old txn from pool at a lower frequency by changing the [`FrequencyToCheckTxsForDelete`](https://github.com/0xPolygonHermez/zkevm-node/blob/release/v0.4.7/test/config/test.node.config.toml#L103) to `30s`:
```
[Sequencer]
...
FrequencyToCheckTxsForDelete = "30s"
```

Then run the docker containers:
```
$ make build-docker
$ cd test
$ make run
```

Then fill the txn pool with transactions:
```
$ cast send --legacy --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-url http://localhost:8123 --value 0.01ether 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
```

Or using [`polycli`](https://github.com/maticnetwork/polygon-cli) to generate a load of transactions:
```
$ loadtest --legacy --verbosity 700 --mode t --rate-limit 10 --concurrency 10 --requests 5 --rpc-url http://localhost:8123 --private-key ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --gas-price 100000000000
```

Then observe the sequencer logs to validate that it only retrieves the necessary amount of transactions to delete:
```
$ docker logs --follow -t zkevm-sequencer
...
trying to delete 50 selected txs	{"pid": 1, "version": "v0.4.6-2-gd1ed8b82"}
2024-01-12T01:28:54.256773956Z 2024-01-12T01:28:54.256Z	INFO	sequencer/sequencer.go:227	deleted 50 selected txs from the pool	{"pid": 1, "version": "v0.4.6-2-gd1ed8b82"}
2024-01-12T01:28:54.256795626Z 2024-01-12T01:28:54.256Z	INFO	sequencer/sequencer.go:229	trying to delete failed txs from the pool	{"pid": 1, "version": "v0.4.6-2-gd1ed8b82"}
2024-01-12T01:28:54.257000625Z 2024-01-12T01:28:54.256Z	INFO	sequencer/sequencer.go:236	failed txs deleted from the pool	{"pid": 1, "version": "v0.4.6-2-gd1ed8b82"}
...
```

### Reviewers

Main reviewers:

- @tclemos 
- @ToniRamirezM 
