### PR TITLE
if a batch have no l2block it returns an zero l1inforoot

### DIFF
--- a/state/batch.go
+++ b/state/batch.go
@@ -563,6 +563,9 @@ func (s *State) GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Dat
 	if err != nil {
 		return nil, ZeroHash, err
 	}
+	if len(batchRaw.Blocks) == 0 {
+		return map[uint32]L1DataV2{}, ZeroHash, nil
+	}
 
 	l1InfoTreeData := map[uint32]L1DataV2{}
 	maxIndex := findMax(batchRaw.Blocks)


### PR DESCRIPTION
Closes #<issue number>.

The call to `state.GetL1InfoTreeDataFromBatchL2Data` produce a panic because the function `findMax` access to `block[0]` that doesn't exists

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @ARR552 
- @ToniRamirezM 

