### PR TITLE
Okx/context logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -48,6 +48,11 @@ func getDefaultLog() *Logger {
 	return log.Load()
 }
 
+// GetDefaultLog returns the default logger
+func GetDefaultLog() *Logger {
+	return getDefaultLog()
+}
+
 // Init the logger with defined level. outputs defines the outputs where the
 // logs will be sent. By default outputs contains "stdout", which prints the
 // logs at the output of the process. To add a log file as output, the path

--- a/log/utils.go
+++ b/log/utils.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"context"
+)
+
+type contextKey string
+
+const (
+	ctxKeyLogger contextKey = "logger"
+)
+
+func CtxWithLogger(parentCtx context.Context, logger *Logger) context.Context {
+	return context.WithValue(parentCtx, ctxKeyLogger, logger)
+}
+
+func LoggerFromCtx(ctx context.Context) *Logger {
+	res := ctx.Value(ctxKeyLogger)
+	if res == nil {
+		return getDefaultLog()
+	}
+	if logger, ok := res.(*Logger); ok {
+		return logger
+	}
+	return getDefaultLog()
+}

--- a/log/utils.go
+++ b/log/utils.go
@@ -10,10 +10,12 @@ const (
 	ctxKeyLogger contextKey = "logger"
 )
 
+// CtxWithLogger injects a logger into the context
 func CtxWithLogger(parentCtx context.Context, logger *Logger) context.Context {
 	return context.WithValue(parentCtx, ctxKeyLogger, logger)
 }
 
+// LoggerFromCtx returns the logger injected to context. If there is no logger, return the default logger
 func LoggerFromCtx(ctx context.Context) *Logger {
 	res := ctx.Value(ctxKeyLogger)
 	if res == nil {


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

Use a more "contextual" logger to make it easy to trace the logs that belong to the same context (e.g. one API request, or one monitorTx cycle). The main idea is to generate a random "traceID" and pass it down through the ctx object.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
