### PR TITLE
Return zero GER when L1IntroTreeIndex is 0

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -245,6 +245,11 @@ func (f *finalizer) checkL1InfoTreeUpdate(ctx context.Context) {
 			continue
 		}
 
+		// L1InfoTreeIndex = 0 is a special case (empty tree) therefore we will set GER as zero
+		if l1InfoRoot.L1InfoTreeIndex == 0 {
+			l1InfoRoot.GlobalExitRoot.GlobalExitRoot = state.ZeroHash
+		}
+
 		if firstL1InfoRootUpdate || l1InfoRoot.L1InfoTreeIndex > f.lastL1InfoTree.L1InfoTreeIndex {
 			firstL1InfoRootUpdate = false
 

--- a/state/pgstatestorage/l1infotree.go
+++ b/state/pgstatestorage/l1infotree.go
@@ -64,12 +64,6 @@ func (p *PostgresStorage) GetLatestL1InfoRoot(ctx context.Context, maxBlockNumbe
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return entry, err
 	}
-
-	// L1InfoTreeIndex = 0 is a special case (empty tree) therefore we will set GER as zero
-	if entry.L1InfoTreeIndex == 0 {
-		entry.GlobalExitRoot.GlobalExitRoot = state.ZeroHash
-	}
-
 	return entry, nil
 }
 func (p *PostgresStorage) GetLatestIndex(ctx context.Context, dbTx pgx.Tx) (uint32, error) {

--- a/state/pgstatestorage/l1infotree.go
+++ b/state/pgstatestorage/l1infotree.go
@@ -64,6 +64,7 @@ func (p *PostgresStorage) GetLatestL1InfoRoot(ctx context.Context, maxBlockNumbe
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return entry, err
 	}
+
 	return entry, nil
 }
 func (p *PostgresStorage) GetLatestIndex(ctx context.Context, dbTx pgx.Tx) (uint32, error) {

--- a/state/pgstatestorage/l1infotree.go
+++ b/state/pgstatestorage/l1infotree.go
@@ -65,6 +65,11 @@ func (p *PostgresStorage) GetLatestL1InfoRoot(ctx context.Context, maxBlockNumbe
 		return entry, err
 	}
 
+	// L1InfoTreeIndex = 0 is a special case (empty tree) therefore we will set GER as zero
+	if entry.L1InfoTreeIndex == 0 {
+		entry.GlobalExitRoot.GlobalExitRoot = state.ZeroHash
+	}
+
 	return entry, nil
 }
 func (p *PostgresStorage) GetLatestIndex(ctx context.Context, dbTx pgx.Tx) (uint32, error) {


### PR DESCRIPTION
### What does this PR do?

- Fixes return a zero GER when sequencer gets the last L1InfoRoot and the index is 0

### Reviewers

Main reviewers:

@joanestebanr 
@ToniRamirezM 
@ARR552 