### PR TITLE
for L1 sequence batch event if the batch only use leaf 0 set GER as 0x0...0000

### DIFF
--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -75,8 +75,6 @@ type stateInterface interface {
 	UpdateWIPBatch(ctx context.Context, receipt state.ProcessingReceipt, dbTx pgx.Tx) error
 	GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, common.Hash, error)
 	GetExitRootByGlobalExitRoot(ctx context.Context, ger common.Hash, dbTx pgx.Tx) (*state.GlobalExitRoot, error)
-	// TODO: GER-0:check if need that
-	GetL1InfoRootLeafByIndex(ctx context.Context, l1InfoTreeIndex uint32, dbTx pgx.Tx) (state.L1InfoTreeExitRootStorageEntry, error)
 }
 
 type ethTxManager interface {


### PR DESCRIPTION
Closes #3087

### What does this PR do?

Synchronizer use GER 0x00..000 if a batch use only index 0 of L1InfoTree

### Reviewers

Main reviewers:

- @ARR552 
- @ToniRamirezM 
- @agnusmor 
