### PR TITLE
Fix batch GER

### DIFF
--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -22,7 +22,6 @@ type Batch struct {
 	initialStateRoot   common.Hash // initial stateRoot of the batch
 	imStateRoot        common.Hash // intermediate stateRoot that is updated each time a single tx is processed
 	finalStateRoot     common.Hash // final stateroot of the batch when a L2 block is processed
-	localExitRoot      common.Hash
 	countOfTxs         int
 	countOfL2Blocks    int
 	remainingResources state.BatchResources
@@ -64,7 +63,6 @@ func (f *finalizer) setWIPBatch(ctx context.Context, wipStateBatch *state.Batch)
 		imStateRoot:        wipStateBatch.StateRoot,
 		initialStateRoot:   prevStateBatch.StateRoot,
 		finalStateRoot:     wipStateBatch.StateRoot,
-		localExitRoot:      wipStateBatch.LocalExitRoot,
 		timestamp:          wipStateBatch.Timestamp,
 		countOfTxs:         wipStateBatchCountOfTxs,
 		remainingResources: remainingResources,
@@ -100,7 +98,7 @@ func (f *finalizer) initWIPBatch(ctx context.Context) {
 			f.Halt(ctx, fmt.Errorf("finalizer reached stop sequencer on batch number: %d", f.cfg.HaltOnBatchNumber))
 		}
 
-		f.wipBatch, err = f.openNewWIPBatch(ctx, lastStateBatch.BatchNumber+1, lastStateBatch.StateRoot, lastStateBatch.LocalExitRoot)
+		f.wipBatch, err = f.openNewWIPBatch(ctx, lastStateBatch.BatchNumber+1, lastStateBatch.StateRoot)
 		if err != nil {
 			log.Fatalf("failed to open new wip batch, error: %v", err)
 		}
@@ -111,8 +109,8 @@ func (f *finalizer) initWIPBatch(ctx context.Context) {
 		}
 	}
 
-	log.Infof("initial batch: %d, initialStateRoot: %s, stateRoot: %s, coinbase: %s, LER: %s",
-		f.wipBatch.batchNumber, f.wipBatch.initialStateRoot, f.wipBatch.finalStateRoot, f.wipBatch.coinbase, f.wipBatch.localExitRoot)
+	log.Infof("initial batch: %d, initialStateRoot: %s, stateRoot: %s, coinbase: %s",
+		f.wipBatch.batchNumber, f.wipBatch.initialStateRoot, f.wipBatch.finalStateRoot, f.wipBatch.coinbase)
 }
 
 // finalizeBatch retries until successful closes the current batch and opens a new one, potentially processing forced batches between the batch is closed and the resulting new empty batch
@@ -187,7 +185,7 @@ func (f *finalizer) closeAndOpenNewWIPBatch(ctx context.Context) error {
 		f.initWIPL2Block(ctx)
 	}
 
-	batch, err := f.openNewWIPBatch(ctx, lastBatchNumber+1, stateRoot, f.wipBatch.localExitRoot)
+	batch, err := f.openNewWIPBatch(ctx, lastBatchNumber+1, stateRoot)
 	if err != nil {
 		return fmt.Errorf("failed to open new wip batch, error: %v", err)
 	}
@@ -206,15 +204,15 @@ func (f *finalizer) closeAndOpenNewWIPBatch(ctx context.Context) error {
 }
 
 // openNewWIPBatch opens a new batch in the state and returns it as WipBatch
-func (f *finalizer) openNewWIPBatch(ctx context.Context, batchNumber uint64, stateRoot, LER common.Hash) (*Batch, error) {
+func (f *finalizer) openNewWIPBatch(ctx context.Context, batchNumber uint64, stateRoot common.Hash) (*Batch, error) {
 	// open next batch
 	newStateBatch := state.Batch{
 		BatchNumber:    batchNumber,
 		Coinbase:       f.sequencerAddress,
 		Timestamp:      now(),
-		GlobalExitRoot: state.ZeroHash,
 		StateRoot:      stateRoot,
-		LocalExitRoot:  LER,
+		GlobalExitRoot: state.ZeroHash,
+		LocalExitRoot:  state.ZeroHash,
 	}
 
 	dbTx, err := f.stateIntf.BeginStateTransaction(ctx)
@@ -251,7 +249,6 @@ func (f *finalizer) openNewWIPBatch(ctx context.Context, batchNumber uint64, sta
 		imStateRoot:        newStateBatch.StateRoot,
 		finalStateRoot:     newStateBatch.StateRoot,
 		timestamp:          newStateBatch.Timestamp,
-		localExitRoot:      newStateBatch.LocalExitRoot,
 		remainingResources: getMaxRemainingResources(f.batchConstraints),
 		closingReason:      state.EmptyClosingReason,
 	}, err

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -495,11 +495,10 @@ func (f *finalizer) processTransaction(ctx context.Context, tx *TxTracker, first
 
 	// Update wip batch
 	f.wipBatch.imStateRoot = batchResponse.NewStateRoot
-	f.wipBatch.localExitRoot = batchResponse.NewLocalExitRoot
 
-	log.Infof("processed tx %s. Batch.batchNumber: %d, batchNumber: %d, newStateRoot: %s, newLocalExitRoot: %s, oldStateRoot: %s, %s",
+	log.Infof("processed tx %s. Batch.batchNumber: %d, batchNumber: %d, newStateRoot: %s, oldStateRoot: %s, %s",
 		tx.HashStr, f.wipBatch.batchNumber, batchRequest.BatchNumber, batchResponse.NewStateRoot.String(),
-		batchResponse.NewLocalExitRoot.String(), batchRequest.OldStateRoot.String(), f.logZKCounters(batchResponse.UsedZkCounters))
+		batchRequest.OldStateRoot.String(), f.logZKCounters(batchResponse.UsedZkCounters))
 
 	return nil, nil
 }
@@ -646,11 +645,10 @@ func (f *finalizer) processEmptyL2Block(ctx context.Context) error {
 
 	// Update wip batch
 	f.wipBatch.imStateRoot = batchResponse.NewStateRoot
-	f.wipBatch.localExitRoot = batchResponse.NewLocalExitRoot
 
-	log.Infof("processed empty L2 block %d, batch.batchNumber: %d, batchNumber: %d, newStateRoot: %s, newLocalExitRoot: %s, oldStateRoot: %s, %s",
+	log.Infof("processed empty L2 block %d, batch.batchNumber: %d, batchNumber: %d, newStateRoot: %s, oldStateRoot: %s, %s",
 		batchResponse.BlockResponses[0].BlockNumber, f.wipBatch.batchNumber, batchRequest.BatchNumber, batchResponse.NewStateRoot.String(),
-		batchResponse.NewLocalExitRoot.String(), batchRequest.OldStateRoot.String(), f.logZKCounters(batchResponse.UsedZkCounters))
+		batchRequest.OldStateRoot.String(), f.logZKCounters(batchResponse.UsedZkCounters))
 
 	return nil
 }

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -2196,7 +2196,6 @@ func setupFinalizer(withWipBatch bool) *finalizer {
 			coinbase:           seqAddr,
 			initialStateRoot:   oldHash,
 			imStateRoot:        newHash,
-			localExitRoot:      newHash,
 			timestamp:          now(),
 			remainingResources: getMaxRemainingResources(bc),
 			closingReason:      state.EmptyClosingReason,


### PR DESCRIPTION
### What does this PR do?

- Fixes the final GER assigned to the trusted batch. It must be the GER form the last L2 block on the batch that has performed a L1InfoRootIndex change. If the batch doesn't contains any L2 block that has done a L1InfoRootIndex change (index 0 for all the L2 blocks) then the GER of the batch will be zero
- Fixes use of LER, since we were using it in places that didn't make sense

### Reviewers

Main reviewers:

@joanestebanr 
@ARR552 
@ToniRamirezM 