### PR TITLE
force version of json-schema-for-humans to 0.47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ venv: $(VENV_PYTHON)
 .PHONY: install-config-doc-gen
 $(GENERATE_SCHEMA_DOC): $(VENV_PYTHON)
 	$(PYTHON) -m pip install --upgrade pip
-	$(PYTHON) -m pip install json-schema-for-humans
+	$(PYTHON) -m pip install json-schema-for-humans==0.47
 
 .PHONY: config-doc-gen
 config-doc-gen: config-doc-node config-doc-custom_network ## Generate config file's json-schema for node and custom_network and documentation


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

The current required version of python module `json-schema-for-humans` is 0.47, but if you are using an previous python3 version it'll install a not compatible version

### Reviewers

Main reviewers:

- @ARR552 
- @ToniRamirezM 
- @agnusmor 
