### PR TITLE
Fix merkle proof in aggregator. Fix finalize batch on sequencer

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -1022,31 +1022,18 @@ func (a *Aggregator) buildInputProver(ctx context.Context, batchToVerify *state.
 				aLeaves := make([][32]byte, len(leaves))
 				for i, leaf := range leaves {
 					aLeaves[i] = l1infotree.HashLeafData(leaf.GlobalExitRoot.GlobalExitRoot, leaf.PreviousBlockHash, uint64(leaf.Timestamp.Unix()))
-					log.Debugf("aLeaves[%d]: %s", i, common.Bytes2Hex(aLeaves[i][:]))
 				}
-
-				log.Debugf("IndexL1InfoTree: %d", l2blockRaw.IndexL1InfoTree)
 
 				// Calculate smt proof
-				smtProof, l1InfoRoot, err := tree.ComputeMerkleProof(l2blockRaw.IndexL1InfoTree, aLeaves)
+				smtProof, _, err := tree.ComputeMerkleProof(l2blockRaw.IndexL1InfoTree, aLeaves)
 				if err != nil {
 					return nil, err
-				}
-
-				log.Debugf("L1InfoRoot: %s", l1InfoRoot.String())
-
-				for i, proof := range smtProof {
-					log.Debugf("smtProof[%d]: %s", i, common.Bytes2Hex(proof[:]))
 				}
 
 				protoProof := make([][]byte, len(smtProof))
 				for i, proof := range smtProof {
 					tmpProof := proof
 					protoProof[i] = tmpProof[:]
-				}
-
-				for i, proof := range protoProof {
-					log.Debugf("proof[%d]: %s", i, common.Bytes2Hex(proof))
 				}
 
 				l1InfoTreeData[l2blockRaw.IndexL1InfoTree] = &prover.L1Data{

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -1022,17 +1022,31 @@ func (a *Aggregator) buildInputProver(ctx context.Context, batchToVerify *state.
 				aLeaves := make([][32]byte, len(leaves))
 				for i, leaf := range leaves {
 					aLeaves[i] = l1infotree.HashLeafData(leaf.GlobalExitRoot.GlobalExitRoot, leaf.PreviousBlockHash, uint64(leaf.Timestamp.Unix()))
+					log.Debugf("aLeaves[%d]: %s", i, common.Bytes2Hex(aLeaves[i][:]))
 				}
 
+				log.Debugf("IndexL1InfoTree: %d", l2blockRaw.IndexL1InfoTree)
+
 				// Calculate smt proof
-				smtProof, _, err := tree.ComputeMerkleProof(l2blockRaw.IndexL1InfoTree, aLeaves)
+				smtProof, l1InfoRoot, err := tree.ComputeMerkleProof(l2blockRaw.IndexL1InfoTree, aLeaves)
 				if err != nil {
 					return nil, err
 				}
 
+				log.Debugf("L1InfoRoot: %s", l1InfoRoot.String())
+
+				for i, proof := range smtProof {
+					log.Debugf("smtProof[%d]: %s", i, common.Bytes2Hex(proof[:]))
+				}
+
 				protoProof := make([][]byte, len(smtProof))
 				for i, proof := range smtProof {
-					protoProof[i] = proof[:]
+					tmpProof := proof
+					protoProof[i] = tmpProof[:]
+				}
+
+				for i, proof := range protoProof {
+					log.Debugf("proof[%d]: %s", i, common.Bytes2Hex(proof))
 				}
 
 				l1InfoTreeData[l2blockRaw.IndexL1InfoTree] = &prover.L1Data{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   zkevm-prover:
     container_name: zkevm-prover
     restart: unless-stopped
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
     depends_on:
       zkevm-state-db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   zkevm-prover:
     container_name: zkevm-prover
     restart: unless-stopped
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
     depends_on:
       zkevm-state-db:
         condition: service_healthy

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -120,15 +120,17 @@ func (f *finalizer) finalizeBatch(ctx context.Context) {
 		metrics.ProcessingTime(time.Since(start))
 	}()
 
-	// Finalize the wip L2 block if it has transactions, if not we keep it open to store it in the new wip batch
+	// Close the wip L2 block if it has transactions, if not we keep it open to store it in the new wip batch
 	if !f.wipL2Block.isEmpty() {
-		f.finalizeL2Block(ctx)
+		f.closeWIPL2Block(ctx)
 	}
 
 	err := f.closeAndOpenNewWIPBatch(ctx)
 	if err != nil {
 		f.Halt(ctx, fmt.Errorf("failed to create new WIP batch, error: %v", err))
 	}
+
+	f.openNewWIPL2Block(ctx, nil)
 }
 
 // closeAndOpenNewWIPBatch closes the current batch and opens a new one, potentially processing forced batches between the batch is closed and the resulting new empty batch

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -287,7 +287,7 @@ func (f *finalizer) finalizeBatches(ctx context.Context) {
 		start := now()
 		// We have reached the L2 block time, we need to close the current L2 block and open a new one
 		if !f.wipL2Block.timestamp.Add(f.cfg.L2BlockMaxDeltaTimestamp.Duration).After(time.Now()) {
-			f.finalizeL2Block(ctx)
+			f.finalizeWIPL2Block(ctx)
 		}
 
 		tx, err := f.workerIntf.GetBestFittingTx(f.wipBatch.remainingResources)

--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -452,7 +452,7 @@ func (f *finalizer) openNewWIPL2Block(ctx context.Context, prevTimestamp *time.T
 
 	// Check if L1InfoTreeIndex has changed, in this case we need to use this index in the changeL2block instead of zero
 	// If it's the first wip L2 block after starting sequencer (wipL2Block == nil) then we assume that the L1InfoTreeIndex has changed (there is no problem assuming this)
-	if f.wipL2Block == nil || newL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex != f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex {
+	if f.wipL2Block != nil && newL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex != f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex {
 		newL2Block.l1InfoTreeExitRootChanged = true
 	}
 

--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -454,7 +454,7 @@ func (f *finalizer) openNewWIPL2Block(ctx context.Context, prevTimestamp *time.T
 
 	// Check if L1InfoTreeIndex has changed, in this case we need to use this index in the changeL2block instead of zero
 	// If it's the first wip L2 block after starting sequencer (wipL2Block == nil) then we assume that the L1InfoTreeIndex has changed (there is no problem assuming this)
-	if f.wipL2Block != nil && newL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex != f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex {
+	if f.wipL2Block == nil || newL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex != f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex {
 		newL2Block.l1InfoTreeExitRootChanged = true
 	}
 

--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -411,9 +411,9 @@ func (f *finalizer) storeL2Block(ctx context.Context, l2Block *L2Block) error {
 	return nil
 }
 
-// finalizeL2Block closes the current L2 block and opens a new one
-func (f *finalizer) finalizeL2Block(ctx context.Context) {
-	log.Debugf("finalizing L2 block")
+// finalizeWIPL2Block closes the wip L2 block and opens a new one
+func (f *finalizer) finalizeWIPL2Block(ctx context.Context) {
+	log.Debugf("finalizing WIP L2 block")
 
 	f.closeWIPL2Block(ctx)
 
@@ -421,6 +421,8 @@ func (f *finalizer) finalizeL2Block(ctx context.Context) {
 }
 
 func (f *finalizer) closeWIPL2Block(ctx context.Context) {
+	log.Debugf("closing WIP L2 block")
+
 	// If the L2 block is empty (no txs) We need to process it to update the state root and remaining batch resources before closing it
 	if f.wipL2Block.isEmpty() {
 		log.Debug("processing WIP L2 block because it is empty")

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -512,7 +512,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -601,7 +601,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -512,7 +512,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -601,7 +601,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover


### PR DESCRIPTION
### What does this PR do?

- Fixes generation of the merkle proof in the aggregator
- Fixes a problem when finalizing a batch due to resource exhausted in sequencer, since sometimes it was creating and closing an empty batch after close de exhausted batch
- Prover image updated to v4.0.0-RC28

### Reviewers

Main reviewers:

@ToniRamirezM 
@ARR552 