### PR TITLE
Fix new wipL2block on finalizeBatch function

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   zkevm-prover:
     container_name: zkevm-prover
     restart: unless-stopped
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
     depends_on:
       zkevm-state-db:
         condition: service_healthy

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -135,7 +135,7 @@ func (f *finalizer) finalizeBatch(ctx context.Context) {
 
 	// If we have closed the wipL2Block then we open a new one
 	if f.wipL2Block == nil {
-		f.openNewWIPL2Block(ctx, prevTimestamp, prevL1InfoTreeIndex)
+		f.openNewWIPL2Block(ctx, prevTimestamp, &prevL1InfoTreeIndex)
 	}
 }
 

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -120,6 +120,9 @@ func (f *finalizer) finalizeBatch(ctx context.Context) {
 		metrics.ProcessingTime(time.Since(start))
 	}()
 
+	prevTimestamp := f.wipL2Block.timestamp
+	prevL1InfoTreeIndex := f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex
+
 	// Close the wip L2 block if it has transactions, if not we keep it open to store it in the new wip batch
 	if !f.wipL2Block.isEmpty() {
 		f.closeWIPL2Block(ctx)
@@ -132,7 +135,7 @@ func (f *finalizer) finalizeBatch(ctx context.Context) {
 
 	// If we have closed the wipL2Block then we open a new one
 	if f.wipL2Block == nil {
-		f.openNewWIPL2Block(ctx, nil)
+		f.openNewWIPL2Block(ctx, prevTimestamp, prevL1InfoTreeIndex)
 	}
 }
 

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -130,7 +130,10 @@ func (f *finalizer) finalizeBatch(ctx context.Context) {
 		f.Halt(ctx, fmt.Errorf("failed to create new WIP batch, error: %v", err))
 	}
 
-	f.openNewWIPL2Block(ctx, nil)
+	// We keep the wip L2 block since is empty, it's not necessary to open a new WIP L2 block
+	if !f.wipL2Block.isEmpty() {
+		f.openNewWIPL2Block(ctx, nil)
+	}
 }
 
 // closeAndOpenNewWIPBatch closes the current batch and opens a new one, potentially processing forced batches between the batch is closed and the resulting new empty batch

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -98,6 +98,7 @@ type stateInterface interface {
 	GetForcedBatchParentHash(ctx context.Context, forcedBatchNumber uint64, dbTx pgx.Tx) (common.Hash, error)
 	GetL1InfoRootLeafByIndex(ctx context.Context, l1InfoTreeIndex uint32, dbTx pgx.Tx) (state.L1InfoTreeExitRootStorageEntry, error)
 	GetVirtualBatch(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.VirtualBatch, error)
+	GetLatestBatchGlobalExitRoot(ctx context.Context, dbTx pgx.Tx) (common.Hash, error)
 }
 
 type workerInterface interface {

--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -418,6 +418,8 @@ func (f *finalizer) finalizeWIPL2Block(ctx context.Context) {
 	f.closeWIPL2Block(ctx)
 
 	f.openNewWIPL2Block(ctx, nil)
+
+	f.wipL2Block = nil
 }
 
 func (f *finalizer) closeWIPL2Block(ctx context.Context) {

--- a/sequencer/mock_state.go
+++ b/sequencer/mock_state.go
@@ -954,6 +954,36 @@ func (_m *StateMock) GetLastVirtualBatchNum(ctx context.Context, dbTx pgx.Tx) (u
 	return r0, r1
 }
 
+// GetLatestBatchGlobalExitRoot provides a mock function with given fields: ctx, dbTx
+func (_m *StateMock) GetLatestBatchGlobalExitRoot(ctx context.Context, dbTx pgx.Tx) (common.Hash, error) {
+	ret := _m.Called(ctx, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLatestBatchGlobalExitRoot")
+	}
+
+	var r0 common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) (common.Hash, error)); ok {
+		return rf(ctx, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) common.Hash); ok {
+		r0 = rf(ctx, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pgx.Tx) error); ok {
+		r1 = rf(ctx, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLatestGer provides a mock function with given fields: ctx, maxBlockNumber
 func (_m *StateMock) GetLatestGer(ctx context.Context, maxBlockNumber uint64) (state.GlobalExitRoot, time.Time, error) {
 	ret := _m.Called(ctx, maxBlockNumber)

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -512,7 +512,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -601,7 +601,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -512,7 +512,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -601,7 +601,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -512,7 +512,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -601,7 +601,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC28
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC27
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover


### PR DESCRIPTION
### What does this PR do?

- Fixes new wipL2block on finalizeBatch function. The new WIP L2 block must be created only if the wipL2Block is not empty, it it's empty we keep the current wipL2Block to process it in the next wipBatch
- Updates prover image to previous v4.0.0-RC27 version, since versions RC28 and RC29 were failing
 
### Reviewers

Main reviewers:

@ToniRamirezM 