### PR TITLE
Fix migration batch wip field. Fix send sequence when no wip batch

### DIFF
--- a/db/migrations/state/0013.sql
+++ b/db/migrations/state/0013.sql
@@ -11,7 +11,7 @@ ALTER TABLE state.transaction
 CREATE INDEX IF NOT EXISTS idx_transaction_l2_hash ON state.transaction (l2_hash);
 
 ALTER TABLE state.batch
-    ADD COLUMN IF NOT EXISTS wip BOOLEAN NOT NULL;
+    ADD COLUMN IF NOT EXISTS wip BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE state.virtual_batch
     ADD COLUMN IF NOT EXISTS timestamp_batch_etrog TIMESTAMP WITH TIME ZONE NULL,

--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -504,7 +504,7 @@ func (f *finalizer) openNewWIPL2Block(ctx context.Context, prevTimestamp time.Ti
 		}
 	}
 
-	log.Infof("new WIP L2 block [%d] created, batch: %d, timestamp: %d, l1InfoTreeIndex: %d, l1InfTreeIndexChanged: %s, oldStateRoot: %s, stateRoot: %s, used counters: %s",
+	log.Infof("new WIP L2 block [%d] created, batch: %d, timestamp: %d, l1InfoTreeIndex: %d, l1InfTreeIndexChanged: %v, oldStateRoot: %s, stateRoot: %s, used counters: %s",
 		f.wipL2Block.trackingNum, f.wipBatch.batchNumber, f.wipL2Block.timestamp.Unix(), f.wipL2Block.l1InfoTreeExitRoot.L1InfoTreeIndex,
 		f.wipL2Block.l1InfoTreeExitRootChanged, f.wipBatch.imStateRoot, batchResponse.NewStateRoot, f.logZKCounters(f.wipL2Block.usedResources.ZKCounters))
 }

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -187,8 +187,11 @@ func (s *SequenceSender) getSequencesToSend(ctx context.Context) ([]types.Sequen
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last virtual batch num, err: %w", err)
 	}
+	log.Debugf("last virtual batch number: %d", lastVirtualBatchNum)
 
 	currentBatchNumToSequence := lastVirtualBatchNum + 1
+	log.Debugf("current batch number to sequence: %d", currentBatchNumToSequence)
+
 	sequences := []types.Sequence{}
 	// var estimatedGas uint64
 
@@ -202,19 +205,26 @@ func (s *SequenceSender) getSequencesToSend(ctx context.Context) ([]types.Sequen
 			return nil, fmt.Errorf("aborting sequencing process as we reached the batch %d where a new forkid is applied (upgrade)", s.cfg.ForkUpgradeBatchNumber+1)
 		}
 
-		// Check if batch is closed
-		isClosed, err := s.state.IsBatchClosed(ctx, currentBatchNumToSequence, nil)
-		if err != nil {
-			return nil, err
-		}
-		if !isClosed {
-			// Reached current (WIP) batch
-			break
-		}
 		// Add new sequence
 		batch, err := s.state.GetBatchByNumber(ctx, currentBatchNumToSequence, nil)
 		if err != nil {
+			if err == state.ErrNotFound {
+				break
+			}
+			log.Debugf("failed to get batch by number %d, err: %w", currentBatchNumToSequence, err)
 			return nil, err
+		}
+
+		// Check if batch is closed
+		isClosed, err := s.state.IsBatchClosed(ctx, currentBatchNumToSequence, nil)
+		if err != nil {
+			log.Debugf("failed to check if batch %d is closed, err: %w", currentBatchNumToSequence, err)
+			return nil, err
+		}
+
+		if !isClosed {
+			// Reached current (WIP) batch
+			break
 		}
 
 		seq := types.Sequence{

--- a/state/batch.go
+++ b/state/batch.go
@@ -70,7 +70,7 @@ const (
 	// ForcedBatchDeadlineClosingReason is the closing reason used when forced batch deadline is reached
 	ForcedBatchDeadlineClosingReason ClosingReason = "Forced batch deadline"
 	// MaxDeltaTimestampClosingReason is the closing reason used when max delta batch timestamp is reached
-	MaxDeltaTimestampClosingReason ClosingReason = "Max delta timestamp delta"
+	MaxDeltaTimestampClosingReason ClosingReason = "Max delta timestamp"
 	// NoTxFitsClosingReason is the closing reason used when any of the txs in the pool (worker) fits in the remaining resources of the batch
 	NoTxFitsClosingReason ClosingReason = "No transactions fits"
 )


### PR DESCRIPTION
### What does this PR do?

- Fixes migration that creates the WIP field in the state.batch table. It must set as default value (FALSE) for existing records in the table
- Fixes sequence-sender when no WIP batch exists in the state.batch table. Iin this case is not sending the sequence for the pending to virtualize batches in the state.batch table

### Reviewers

Main reviewers:

@ToniRamirezM 
@ARR552 
@joanestebanr 