### PR TITLE
fix permissionless prover to avoid executor error EXECUTOR_ERROR_BALANCE_MISMATCH

### DIFF
--- a/test/config/test.permissionless.prover.config.json
+++ b/test/config/test.permissionless.prover.config.json
@@ -27,7 +27,7 @@
     "runBlakeTest": false,
 
     "executeInParallel": true,
-    "useMainExecGenerated": true,
+    "useMainExecGenerated": false,
     "saveRequestToFile": false,
     "saveInputToFile": false,
     "saveDbReadsToFile": false,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -602,7 +602,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC29
+    image: hermeznetwork/zkevm-prover:v4.0.0-RC30
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover


### PR DESCRIPTION

### What does this PR do?

If param `useMainExecGenerated` is `true` the execution of pre-etrog batches fails: 
```
EXECUTOR ERROR Description:EXECUTOR_ERROR_BALANCE_MISMATCH Data:[] Json:{"old_state_root":"0Jn+H7h4asyVvWuDAd8C1F2trLFV/Wf4WMJisMwNxIk=","old_acc_input_hash":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","chain_id":666,"fork_id":4,"batch_l2_data":"7giEAvrwgIJSCJREO7jbWo491uINI1dlPu4zToKORYkFa8deLWMQAACAggKagIAr9tK/Hqy6cub9X6W8re2W+hkb9HtS2WqXonfE3kHvxlCpNguRROfYut8FKFiu8ocaxAZTqJzmtSRQ0wANoPXbHA==","global_exit_root":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","eth_timestamp":1692864627,"coinbase":"0x823ba9dd219159C6a515F9B29e21d53Ff8751979","update_merkle_tree":1,"context_id":"32868dfb-1405-4eb1-b65c-ee9920432778"}}
```

### Reviewers

Main reviewers:

- @agnusmor 
- @ARR552 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
