### PR TITLE
feat: optimize purge txn pool query

### DIFF
--- a/pool/interfaces.go
+++ b/pool/interfaces.go
@@ -38,6 +38,7 @@ type storage interface {
 	MarkWIPTxsAsPending(ctx context.Context) error
 	GetAllAddressesBlocked(ctx context.Context) ([]common.Address, error)
 	MinL2GasPriceSince(ctx context.Context, timestamp time.Time) (uint64, error)
+	GetEarliestProcessedTx(ctx context.Context) (common.Hash, error)
 }
 
 type stateInterface interface {

--- a/pool/pgpoolstorage/pgpoolstorage.go
+++ b/pool/pgpoolstorage/pgpoolstorage.go
@@ -790,3 +790,23 @@ func (p *PostgresPoolStorage) GetAllAddressesBlocked(ctx context.Context) ([]com
 
 	return addrs, nil
 }
+
+// GetEarliestProcessedTx gets the earliest processed tx from the pool. Mainly used for cleanup
+func (p *PostgresPoolStorage) GetEarliestProcessedTx(ctx context.Context) (common.Hash, error) {
+	const getEarliestProcessedTxnFromTxnPool = `SELECT hash
+	FROM pool.transaction
+	WHERE
+		status = 'selected'
+	ORDER BY received_at ASC
+	LIMIT 1`
+
+	var txnHash string
+	err := p.db.QueryRow(ctx, getEarliestProcessedTxnFromTxnPool).Scan(&txnHash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return common.Hash{}, nil
+	} else if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.HexToHash(txnHash), nil
+}

--- a/sequencer/interfaces.go
+++ b/sequencer/interfaces.go
@@ -29,6 +29,7 @@ type txPool interface {
 	GetGasPrices(ctx context.Context) (pool.GasPrices, error)
 	GetDefaultMinGasPriceAllowed() uint64
 	GetL1AndL2GasPrice() (uint64, uint64)
+	GetEarliestProcessedTx(ctx context.Context) (common.Hash, error)
 }
 
 // etherman contains the methods required to interact with ethereum.
@@ -46,6 +47,7 @@ type etherman interface {
 type stateInterface interface {
 	GetTimeForLatestBatchVirtualization(ctx context.Context, dbTx pgx.Tx) (time.Time, error)
 	GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uint64, dbTx pgx.Tx) ([]common.Hash, error)
+	GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error)
 	GetBatchByNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.Batch, error)
 	GetTransactionsByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (txs []types.Transaction, effectivePercentages []uint8, err error)
 	BeginStateTransaction(ctx context.Context) (pgx.Tx, error)

--- a/sequencer/mock_pool.go
+++ b/sequencer/mock_pool.go
@@ -93,6 +93,36 @@ func (_m *PoolMock) GetDefaultMinGasPriceAllowed() uint64 {
 	return r0
 }
 
+// GetEarliestProcessedTx provides a mock function with given fields: ctx
+func (_m *PoolMock) GetEarliestProcessedTx(ctx context.Context) (common.Hash, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEarliestProcessedTx")
+	}
+
+	var r0 common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (common.Hash, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) common.Hash); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetGasPrices provides a mock function with given fields: ctx
 func (_m *PoolMock) GetGasPrices(ctx context.Context) (pool.GasPrices, error) {
 	ret := _m.Called(ctx)

--- a/sequencer/mock_state.go
+++ b/sequencer/mock_state.go
@@ -1302,6 +1302,36 @@ func (_m *StateMock) GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uin
 	return r0, r1
 }
 
+// GetTxsOlderThanNL1BlocksUntilTxHash provides a mock function with given fields: ctx, nL1Blocks, earliestTxHash, dbTx
+func (_m *StateMock) GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error) {
+	ret := _m.Called(ctx, nL1Blocks, earliestTxHash, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTxsOlderThanNL1BlocksUntilTxHash")
+	}
+
+	var r0 []common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) ([]common.Hash, error)); ok {
+		return rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) []common.Hash); ok {
+		r0 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, common.Hash, pgx.Tx) error); ok {
+		r1 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetVirtualBatch provides a mock function with given fields: ctx, batchNumber, dbTx
 func (_m *StateMock) GetVirtualBatch(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.VirtualBatch, error) {
 	ret := _m.Called(ctx, batchNumber, dbTx)

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -139,7 +139,13 @@ func (s *Sequencer) deleteOldPoolTxs(ctx context.Context) {
 	for {
 		time.Sleep(s.cfg.DeletePoolTxsCheckInterval.Duration)
 		log.Infof("trying to get txs to delete from the pool...")
-		txHashes, err := s.stateIntf.GetTxsOlderThanNL1Blocks(ctx, s.cfg.DeletePoolTxsL1BlockConfirmations, nil)
+		earliestTxHash, err := s.pool.GetEarliestProcessedTx(ctx)
+		if err != nil {
+			log.Errorf("failed to get earliest tx hash to delete, err: %v", err)
+			continue
+		}
+
+		txHashes, err := s.stateIntf.GetTxsOlderThanNL1BlocksUntilTxHash(ctx, s.cfg.DeletePoolTxsL1BlockConfirmations, earliestTxHash, nil)
 		if err != nil {
 			log.Errorf("failed to get txs hashes to delete, error: %v", err)
 			continue

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -21,6 +21,7 @@ type storage interface {
 	ResetTrustedState(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error
 	AddBlock(ctx context.Context, block *Block, dbTx pgx.Tx) error
 	GetTxsOlderThanNL1Blocks(ctx context.Context, nL1Blocks uint64, dbTx pgx.Tx) ([]common.Hash, error)
+	GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error)
 	GetLastBlock(ctx context.Context, dbTx pgx.Tx) (*Block, error)
 	GetPreviousBlock(ctx context.Context, offset uint64, dbTx pgx.Tx) (*Block, error)
 	AddGlobalExitRoot(ctx context.Context, exitRoot *GlobalExitRoot, dbTx pgx.Tx) error

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -6364,6 +6364,67 @@ func (_c *StorageMock_GetTxsOlderThanNL1Blocks_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// GetTxsOlderThanNL1BlocksUntilTxHash provides a mock function with given fields: ctx, nL1Blocks, earliestTxHash, dbTx
+func (_m *StorageMock) GetTxsOlderThanNL1BlocksUntilTxHash(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx) ([]common.Hash, error) {
+	ret := _m.Called(ctx, nL1Blocks, earliestTxHash, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTxsOlderThanNL1BlocksUntilTxHash")
+	}
+
+	var r0 []common.Hash
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) ([]common.Hash, error)); ok {
+		return rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, common.Hash, pgx.Tx) []common.Hash); ok {
+		r0 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.Hash)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, common.Hash, pgx.Tx) error); ok {
+		r1 = rf(ctx, nL1Blocks, earliestTxHash, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTxsOlderThanNL1BlocksUntilTxHash'
+type StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call struct {
+	*mock.Call
+}
+
+// GetTxsOlderThanNL1BlocksUntilTxHash is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nL1Blocks uint64
+//   - earliestTxHash common.Hash
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) GetTxsOlderThanNL1BlocksUntilTxHash(ctx interface{}, nL1Blocks interface{}, earliestTxHash interface{}, dbTx interface{}) *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call {
+	return &StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call{Call: _e.mock.On("GetTxsOlderThanNL1BlocksUntilTxHash", ctx, nL1Blocks, earliestTxHash, dbTx)}
+}
+
+func (_c *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call) Run(run func(ctx context.Context, nL1Blocks uint64, earliestTxHash common.Hash, dbTx pgx.Tx)) *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(common.Hash), args[3].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call) Return(_a0 []common.Hash, _a1 error) *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call) RunAndReturn(run func(context.Context, uint64, common.Hash, pgx.Tx) ([]common.Hash, error)) *StorageMock_GetTxsOlderThanNL1BlocksUntilTxHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetVerifiedBatch provides a mock function with given fields: ctx, batchNumber, dbTx
 func (_m *StorageMock) GetVerifiedBatch(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.VerifiedBatch, error) {
 	ret := _m.Called(ctx, batchNumber, dbTx)


### PR DESCRIPTION
Closes Issue #3031.
This is also a duplicate of the PR #3058 that I made for mainnet `v0.4.7`.

### What does this PR do?

At a high level, this PR optimizes the logic of pulling the number of transactions to clean from the transaction pool. 

Within the `purgeOldPoolTxs()` function, there is a potential performance bottleneck where it retrieves all transactions (including ones that have already been deleted from the txn pool), as seen in this [query](https://github.com/0xPolygonHermez/zkevm-node/blob/10fdcf9935851e5685ff4c9c8d4b33ca2a3147ae/state/pgstatestorage/transaction.go#L22):

```
SELECT hash FROM state.transaction JOIN state.l2block ON state.transaction.l2_block_num = state.l2block.block_num AND state.l2block.batch_num <= $1
```

The potential performance bottleneck is caused by the query not taking into account a lower bound (i.e. it just retrieves all transactions from the latest batch num: `AND state.l2block.batch_num <= $1)`.

This PR optimizes the approach by:
1. finding the oldest completed txn in the txn pool
2. retrieve all txn from that oldest txn until the latest virtual batch number
3. delete all those txn from txn pool

### Testing

Refer to PR #3058 

### Reviewers

Main reviewers:

- @tclemos 
- @ToniRamirezM 
