### PR TITLE
fix wipL2Block imStateRoot

### DIFF
--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -202,6 +202,7 @@ func (f *finalizer) closeAndOpenNewWIPBatch(ctx context.Context, closeReason sta
 	}
 
 	if f.wipL2Block != nil {
+		f.wipBatch.imStateRoot = f.wipL2Block.imStateRoot
 		// Subtract the WIP L2 block used resources to batch
 		overflow, overflowResource := batch.imRemainingResources.Sub(f.wipL2Block.usedResources)
 		if overflow {

--- a/state/batch.go
+++ b/state/batch.go
@@ -72,7 +72,7 @@ const (
 	// MaxDeltaTimestampClosingReason is the closing reason used when max delta batch timestamp is reached
 	MaxDeltaTimestampClosingReason ClosingReason = "Max delta timestamp"
 	// NoTxFitsClosingReason is the closing reason used when any of the txs in the pool (worker) fits in the remaining resources of the batch
-	NoTxFitsClosingReason ClosingReason = "No transactions fits"
+	NoTxFitsClosingReason ClosingReason = "No transaction fits"
 )
 
 // ProcessingReceipt indicates the outcome (StateRoot, AccInputHash) of processing a batch


### PR DESCRIPTION
### What does this PR do?

- Fixes wipBatch imStateRoot when creating a new wipBatch. If a wipL2Block exists it must set to the imStateRoot of the wipL2Block

### Reviewers

Main reviewers:

@ToniRamirezM 