### PR TITLE
if a trusted batch is empty and WIP just create the entry in state.batch

### DIFF
--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -201,26 +201,32 @@ func NewClient(cfg Config, l1Config L1Config) (*Client, error) {
 	// Create smc clients
 	zkevm, err := polygonzkevm.NewPolygonzkevm(l1Config.ZkEVMAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating Polygonzkevm client (%s). Error: %w", l1Config.ZkEVMAddr.String(), err)
 		return nil, err
 	}
 	oldZkevm, err := oldpolygonzkevm.NewOldpolygonzkevm(l1Config.RollupManagerAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating NewOldpolygonzkevm client (%s). Error: %w", l1Config.RollupManagerAddr.String(), err)
 		return nil, err
 	}
 	rollupManager, err := polygonrollupmanager.NewPolygonrollupmanager(l1Config.RollupManagerAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating NewPolygonrollupmanager client (%s). Error: %w", l1Config.RollupManagerAddr.String(), err)
 		return nil, err
 	}
 	globalExitRoot, err := polygonzkevmglobalexitroot.NewPolygonzkevmglobalexitroot(l1Config.GlobalExitRootManagerAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating NewPolygonzkevmglobalexitroot client (%s). Error: %w", l1Config.GlobalExitRootManagerAddr.String(), err)
 		return nil, err
 	}
 	oldGlobalExitRoot, err := oldpolygonzkevmglobalexitroot.NewOldpolygonzkevmglobalexitroot(l1Config.GlobalExitRootManagerAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating NewOldpolygonzkevmglobalexitroot client (%s). Error: %w", l1Config.GlobalExitRootManagerAddr.String(), err)
 		return nil, err
 	}
 	pol, err := pol.NewPol(l1Config.PolAddr, ethClient)
 	if err != nil {
+		log.Errorf("error creating NewPol client (%s). Error: %w", l1Config.PolAddr.String(), err)
 		return nil, err
 	}
 	var scAddresses []common.Address
@@ -240,6 +246,7 @@ func NewClient(cfg Config, l1Config L1Config) (*Client, error) {
 	// Get RollupID
 	rollupID, err := rollupManager.RollupAddressToID(&bind.CallOpts{Pending: false}, l1Config.ZkEVMAddr)
 	if err != nil {
+		log.Errorf("error rollupManager.cRollupAddressToID(%s). Error: %w", l1Config.RollupManagerAddr, err)
 		return nil, err
 	}
 	log.Debug("rollupID: ", rollupID)

--- a/synchronizer/common/converters.go
+++ b/synchronizer/common/converters.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
+	"github.com/0xPolygonHermez/zkevm-node/state"
+)
+
+// RpcBatchToStateBatch converts a rpc batch to a state batch
+func RpcBatchToStateBatch(rpcBatch *types.Batch) *state.Batch {
+	if rpcBatch == nil {
+		return nil
+	}
+	batch := &state.Batch{
+		BatchNumber:    uint64(rpcBatch.Number),
+		Coinbase:       rpcBatch.Coinbase,
+		StateRoot:      rpcBatch.StateRoot,
+		BatchL2Data:    rpcBatch.BatchL2Data,
+		GlobalExitRoot: rpcBatch.GlobalExitRoot,
+		LocalExitRoot:  rpcBatch.MainnetExitRoot,
+		Timestamp:      time.Unix(int64(rpcBatch.Timestamp), 0),
+		WIP:            !rpcBatch.Closed,
+	}
+	if rpcBatch.ForcedBatchNumber != nil {
+		batch.ForcedBatchNum = (*uint64)(rpcBatch.ForcedBatchNumber)
+	}
+	return batch
+}

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
@@ -104,9 +104,32 @@ func (b *SyncTrustedBatchExecutorForEtrog) NothingProcess(ctx context.Context, d
 	return &res, nil
 }
 
+// CreateEmptyBatch create a new empty batch (no batchL2Data and WIP)
+func (b *SyncTrustedBatchExecutorForEtrog) CreateEmptyBatch(ctx context.Context, data *l2_shared.ProcessData, dbTx pgx.Tx) (*l2_shared.ProcessResponse, error) {
+	log.Debugf("%s The Batch is a WIP empty, so just creating a DB entry", data.DebugPrefix)
+	err := b.openBatch(ctx, data.TrustedBatch, dbTx, data.DebugPrefix)
+	if err != nil {
+		log.Errorf("%s error openning batch. Error: %v", data.DebugPrefix, err)
+		return nil, err
+	}
+	log.Debugf("%s updateWIPBatch", data.DebugPrefix)
+	err = b.updateWIPBatch(ctx, data, data.TrustedBatch.StateRoot, dbTx)
+	if err != nil {
+		log.Errorf("%s error updateWIPBatch. Error: ", data.DebugPrefix, err)
+		return nil, err
+	}
+	res := l2_shared.NewProcessResponse()
+	stateBatch := syncCommon.RpcBatchToStateBatch(data.TrustedBatch)
+	res.UpdateCurrentBatch(stateBatch)
+	return &res, nil
+}
+
 // FullProcess process a batch that is not on database, so is the first time we process it
 func (b *SyncTrustedBatchExecutorForEtrog) FullProcess(ctx context.Context, data *l2_shared.ProcessData, dbTx pgx.Tx) (*l2_shared.ProcessResponse, error) {
 	log.Debugf("%s FullProcess", data.DebugPrefix)
+	if len(data.TrustedBatch.BatchL2Data) == 0 && data.BatchMustBeClosed {
+		return b.CreateEmptyBatch(ctx, data, dbTx)
+	}
 	err := b.checkIfWeAreSyncedFromL1ToProcessGlobalExitRoot(ctx, data, dbTx)
 	if err != nil {
 		log.Errorf("%s error checkIfWeAreSyncedFromL1ToProcessGlobalExitRoot. Error: %v", data.DebugPrefix, err)
@@ -117,6 +140,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) FullProcess(ctx context.Context, data
 		log.Errorf("%s error openning batch. Error: %v", data.DebugPrefix, err)
 		return nil, err
 	}
+
 	leafs, l1InfoRoot, _, err := b.state.GetL1InfoTreeDataFromBatchL2Data(ctx, data.TrustedBatch.BatchL2Data, dbTx)
 	if err != nil {
 		log.Errorf("%s error getting GetL1InfoTreeDataFromBatchL2Data: %v. Error:%w", data.DebugPrefix, l1InfoRoot, err)
@@ -144,7 +168,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) FullProcess(ctx context.Context, data
 		}
 	} else {
 		log.Debugf("%s updateWIPBatch", data.DebugPrefix)
-		err = b.updateWIPBatch(ctx, data, processBatchResp, dbTx)
+		err = b.updateWIPBatch(ctx, data, processBatchResp.NewStateRoot, dbTx)
 		if err != nil {
 			log.Errorf("%s error updateWIPBatch. Error: ", data.DebugPrefix, err)
 			return nil, err
@@ -214,7 +238,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) IncrementalProcess(ctx context.Contex
 		}
 	} else {
 		log.Debugf("%s updateWIPBatch", data.DebugPrefix)
-		err = b.updateWIPBatch(ctx, data, processBatchResp, dbTx)
+		err = b.updateWIPBatch(ctx, data, processBatchResp.NewStateRoot, dbTx)
 		if err != nil {
 			log.Errorf("%s error updateWIPBatch. Error: ", data.DebugPrefix, err)
 			return nil, err
@@ -237,10 +261,10 @@ func (b *SyncTrustedBatchExecutorForEtrog) checkIfWeAreSyncedFromL1ToProcessGlob
 	return b.l1SyncChecker.CheckL1SyncStatusEnoughToProcessBatch(ctx, data.BatchNumber, data.TrustedBatch.GlobalExitRoot, dbTx)
 }
 
-func (b *SyncTrustedBatchExecutorForEtrog) updateWIPBatch(ctx context.Context, data *l2_shared.ProcessData, processBatchResp *state.ProcessBatchResponse, dbTx pgx.Tx) error {
+func (b *SyncTrustedBatchExecutorForEtrog) updateWIPBatch(ctx context.Context, data *l2_shared.ProcessData, NewStateRoot common.Hash, dbTx pgx.Tx) error {
 	receipt := state.ProcessingReceipt{
 		BatchNumber:    data.BatchNumber,
-		StateRoot:      processBatchResp.NewStateRoot,
+		StateRoot:      NewStateRoot,
 		LocalExitRoot:  data.TrustedBatch.LocalExitRoot,
 		BatchL2Data:    data.TrustedBatch.BatchL2Data,
 		AccInputHash:   data.TrustedBatch.AccInputHash,


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

When `sequencer` opens a batch set LocalExitRoot to zero because don't execute anything. 
So in permissionless synchronizer this PR do the same. If a Trusted Batch have len(batchl2data)== 0 and WIP is not executed just written on DB (state.batch)

### Reviewers

Main reviewers:

- @ARR552 
- @ToniRamirezM 
- @agnusmor 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
