### PR TITLE
Fix default value when creating transaction.used_sha256_hashes field in the pool

### DIFF
--- a/db/migrations/pool/0012.sql
+++ b/db/migrations/pool/0012.sql
@@ -1,7 +1,7 @@
 -- +migrate Up
 ALTER TABLE pool.transaction
     ADD COLUMN l2_hash VARCHAR UNIQUE,
-    ADD COLUMN used_sha256_hashes INTEGER;
+    ADD COLUMN used_sha256_hashes INTEGER DEFAULT 0;
 CREATE INDEX IF NOT EXISTS idx_transaction_l2_hash ON pool.transaction (l2_hash);
 
 -- +migrate Down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   zkevm-prover:
     container_name: zkevm-prover
     restart: unless-stopped
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC31
+    image: hermeznetwork/zkevm-prover:v4.0.0
     depends_on:
       zkevm-state-db:
         condition: service_healthy

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -513,7 +513,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC31
+    image: hermeznetwork/zkevm-prover:v4.0.0
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -602,7 +602,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.0-RC31
+    image: hermeznetwork/zkevm-prover:v4.0.0
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover


### PR DESCRIPTION
### What does this PR do?

- Fixes default value when creating transaction.used_sha256_hashes field in the pool
- Update prover image to v4.0.0

### Reviewers

Main reviewers:

@ARR552 
@joanestebanr 