### PR TITLE
synchronizer: unittest and remove pool_reorg  (#3111)

### DIFF
--- a/synchronizer/default_l1processors.go
+++ b/synchronizer/default_l1processors.go
@@ -15,7 +15,7 @@ func defaultsL1EventProcessors(sync *ClientSynchronizer) *processor_manager.L1Ev
 	p.Register(incaberry.NewProcessL1SequenceForcedBatches(sync.state, sync))
 	p.Register(incaberry.NewProcessorForkId(sync.state, sync))
 	p.Register(etrog.NewProcessorL1InfoTreeUpdate(sync.state))
-	p.Register(etrog.NewProcessorL1SequenceBatches(sync.state, sync.etherMan, sync.pool, sync, common.DefaultTimeProvider{}, sync.halter))
+	p.Register(etrog.NewProcessorL1SequenceBatches(sync.state, sync, common.DefaultTimeProvider{}, sync.halter))
 	p.Register(incaberry.NewProcessorL1VerifyBatch(sync.state))
 	p.Register(etrog.NewProcessorL1UpdateEtrogSequence(sync.state, sync, common.DefaultTimeProvider{}))
 	return p.Build()


### PR DESCRIPTION
cherry-pick 3111

* removed reorgPool call
* add test for l1 sequenced batches
* removed panic after halt call as PR comments ask for

Closes #<issue number>.

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
