### PR TITLE
synchronizer: update fromTrusted fix cache update

### DIFF
--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
@@ -193,14 +193,11 @@ func (s *ProcessorTrustedBatchSync) GetNextStatus(status TrustedState, processBa
 			log.Warnf("%s error checking sanity of processBatchResp. Error: ", debugPrefix, err)
 		}
 	}
-	if processBatchResp != nil && !processBatchResp.ClearCache {
-		newStatus := updateStatus(status, processBatchResp, closedBatch)
-		log.Debugf("%s Batch synchronized, updated cache for next run", debugPrefix)
-		return &newStatus, nil
-	} else {
-		log.Debugf("%s Batch synchronized -> clear cache", debugPrefix)
-		return nil, nil
-	}
+
+	newStatus := updateStatus(status, processBatchResp, closedBatch)
+	log.Debugf("%s Batch synchronized, updated cache for next run", debugPrefix)
+	return &newStatus, nil
+
 }
 
 // ExecuteProcessBatch execute the batch and process it
@@ -239,6 +236,8 @@ func updateStatus(status TrustedState, response *ProcessResponse, closedBatch bo
 	if response == nil || response.ClearCache {
 		return res
 	}
+	res.LastTrustedBatches[0] = status.LastTrustedBatches[0]
+	res.LastTrustedBatches[1] = status.LastTrustedBatches[1]
 	if response.UpdateBatch != nil {
 		res.LastTrustedBatches[0] = response.UpdateBatch
 	}

--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
@@ -197,7 +197,6 @@ func (s *ProcessorTrustedBatchSync) GetNextStatus(status TrustedState, processBa
 	newStatus := updateStatus(status, processBatchResp, closedBatch)
 	log.Debugf("%s Batch synchronized, updated cache for next run", debugPrefix)
 	return &newStatus, nil
-
 }
 
 // ExecuteProcessBatch execute the batch and process it
@@ -236,8 +235,10 @@ func updateStatus(status TrustedState, response *ProcessResponse, closedBatch bo
 	if response == nil || response.ClearCache {
 		return res
 	}
-	res.LastTrustedBatches[0] = status.LastTrustedBatches[0]
-	res.LastTrustedBatches[1] = status.LastTrustedBatches[1]
+
+	res.LastTrustedBatches[0] = status.GetCurrentBatch()
+	res.LastTrustedBatches[1] = status.GetPreviousBatch()
+
 	if response.UpdateBatch != nil {
 		res.LastTrustedBatches[0] = response.UpdateBatch
 	}

--- a/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
+++ b/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
@@ -287,7 +287,7 @@ func TestGetNextStatusDiscardCache(t *testing.T) {
 	ProcessResponse.DiscardCache()
 	newStatus, err := testData.sut.GetNextStatus(l2_shared.TrustedState{}, &ProcessResponse, false, "test")
 	require.NoError(t, err)
-	require.Equal(t, (*l2_shared.TrustedState)(nil), newStatus)
+	require.True(t, newStatus.IsEmpty())
 }
 
 func TestGetNextStatusUpdateCurrentBatch(t *testing.T) {

--- a/synchronizer/l2_sync/l2_shared/trusted_state.go
+++ b/synchronizer/l2_sync/l2_shared/trusted_state.go
@@ -31,6 +31,20 @@ func (ts *TrustedState) IsEmpty() bool {
 	return false
 }
 
+func (ts *TrustedState) GetCurrentBatch() *state.Batch {
+	if ts == nil || len(ts.LastTrustedBatches) == 0 {
+		return nil
+	}
+	return ts.LastTrustedBatches[0]
+}
+
+func (ts *TrustedState) GetPreviousBatch() *state.Batch {
+	if ts == nil || len(ts.LastTrustedBatches) < 2 {
+		return nil
+	}
+	return ts.LastTrustedBatches[1]
+}
+
 // TrustedStateManager is the trusted state manager, basically contains the batch cache and create the TrustedState
 type TrustedStateManager struct {
 	Cache *common.Cache[uint64, *state.Batch]

--- a/synchronizer/l2_sync/l2_shared/trusted_state.go
+++ b/synchronizer/l2_sync/l2_shared/trusted_state.go
@@ -31,6 +31,7 @@ func (ts *TrustedState) IsEmpty() bool {
 	return false
 }
 
+// GetCurrentBatch returns the current batch or nil
 func (ts *TrustedState) GetCurrentBatch() *state.Batch {
 	if ts == nil || len(ts.LastTrustedBatches) == 0 {
 		return nil
@@ -38,6 +39,7 @@ func (ts *TrustedState) GetCurrentBatch() *state.Batch {
 	return ts.LastTrustedBatches[0]
 }
 
+// GetPreviousBatch returns the previous batch or nil
 func (ts *TrustedState) GetPreviousBatch() *state.Batch {
 	if ts == nil || len(ts.LastTrustedBatches) < 2 {
 		return nil

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
@@ -89,7 +89,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) NothingProcess(ctx context.Context, d
 			return nil, ErrCriticalClosedBatchDontContainExpectedData
 		}
 	}
-
+	res := l2_shared.NewProcessResponse()
 	if data.BatchMustBeClosed {
 		log.Debugf("%s Closing batch", data.DebugPrefix)
 		err := b.CloseBatch(ctx, data.TrustedBatch, dbTx, data.DebugPrefix)
@@ -97,10 +97,10 @@ func (b *SyncTrustedBatchExecutorForEtrog) NothingProcess(ctx context.Context, d
 			log.Error("%s error closing batch. Error: ", data.DebugPrefix, err)
 			return nil, err
 		}
+		data.StateBatch.WIP = false
+		res.UpdateCurrentBatch(data.StateBatch)
 	}
-	data.StateBatch.WIP = !data.BatchMustBeClosed
-	res := l2_shared.NewProcessResponse()
-	res.UpdateCurrentBatch(data.StateBatch)
+
 	return &res, nil
 }
 

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync_test.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync_test.go
@@ -130,13 +130,14 @@ func newData() l2_shared.ProcessData {
 
 func TestNothingProcessDontCloseBatch(t *testing.T) {
 	testData := newTestData(t)
+
 	// Arrange
 	data := l2_shared.ProcessData{
 		BatchNumber:       123,
 		Mode:              l2_shared.NothingProcessMode,
 		BatchMustBeClosed: false,
 		DebugPrefix:       "test",
-		StateBatch:        &state.Batch{},
+		StateBatch:        &state.Batch{WIP: true},
 		TrustedBatch:      &types.Batch{},
 	}
 


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?
- It was showing some warning when trusted batch is closed and there are no update
- Also fix update cache that was not working as expected

### Reviewers

Main reviewers:

- @ARR552 
- @tclemos 
- 
Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
