### PR TITLE
Add sanity check: last L2 block timestamp in the sequence is also L1BlockTimestampMargin seconds behind "now"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   zkevm-prover:
     container_name: zkevm-prover
     restart: unless-stopped
-    image: hermeznetwork/zkevm-prover:v4.0.2
+    image: hermeznetwork/zkevm-prover:v4.0.4
     depends_on:
       zkevm-state-db:
         condition: service_healthy

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -1575,6 +1575,15 @@ func (etherMan *Client) GetLatestBatchNumber() (uint64, error) {
 	return latestBatchNum, nil
 }
 
+// GetLatestBlockHeader gets the latest block header from the ethereum
+func (etherMan *Client) GetLatestBlockHeader(ctx context.Context) (*types.Header, error) {
+	header, err := etherMan.EthClient.HeaderByNumber(ctx, big.NewInt(int64(rpc.LatestBlockNumber)))
+	if err != nil || header == nil {
+		return nil, err
+	}
+	return header, nil
+}
+
 // GetLatestBlockNumber gets the latest block number from the ethereum
 func (etherMan *Client) GetLatestBlockNumber(ctx context.Context) (uint64, error) {
 	return etherMan.getBlockNumber(ctx, rpc.LatestBlockNumber)

--- a/sequencesender/interfaces.go
+++ b/sequencesender/interfaces.go
@@ -20,7 +20,7 @@ type etherman interface {
 	BuildSequenceBatchesTxData(sender common.Address, sequences []ethmanTypes.Sequence, l2Coinbase common.Address) (to *common.Address, data []byte, err error)
 	EstimateGasSequenceBatches(sender common.Address, sequences []ethmanTypes.Sequence, l2Coinbase common.Address) (*types.Transaction, error)
 	// GetLastBatchTimestamp() (uint64, error)
-	GetLatestBlockTimestamp(ctx context.Context) (uint64, error)
+	GetLatestBlockHeader(ctx context.Context) (*types.Header, error)
 	GetLatestBatchNumber() (uint64, error)
 }
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -513,7 +513,7 @@ services:
 
   zkevm-prover:
     container_name: zkevm-prover
-    image: hermeznetwork/zkevm-prover:v4.0.2
+    image: hermeznetwork/zkevm-prover:v4.0.4
     ports:
       - 50061:50061 # MT
       - 50071:50071 # Executor
@@ -602,7 +602,7 @@ services:
 
   zkevm-permissionless-prover:
     container_name: zkevm-permissionless-prover
-    image: hermeznetwork/zkevm-prover:v4.0.2
+    image: hermeznetwork/zkevm-prover:v4.0.4
     ports:
       # - 50058:50058 # Prover
       - 50059:50052 # Mock prover


### PR DESCRIPTION
### What does this PR do?

- Adds sanity check on sequence-sender to check that the timestamp of the last L2 block in the sequence is also  L1BlockTimestampMargin seconds behind the current time (now)

### Reviewers

Main reviewers:

@ToniRamirezM 
@ARR552 
@joanestebanr 