### PR TITLE
Cherry-pick #3169 synchronizer: update fromTrusted fix cache update (#3169)

### DIFF
--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
@@ -193,14 +193,10 @@ func (s *ProcessorTrustedBatchSync) GetNextStatus(status TrustedState, processBa
 			log.Warnf("%s error checking sanity of processBatchResp. Error: ", debugPrefix, err)
 		}
 	}
-	if processBatchResp != nil && !processBatchResp.ClearCache {
-		newStatus := updateStatus(status, processBatchResp, closedBatch)
-		log.Debugf("%s Batch synchronized, updated cache for next run", debugPrefix)
-		return &newStatus, nil
-	} else {
-		log.Debugf("%s Batch synchronized -> clear cache", debugPrefix)
-		return nil, nil
-	}
+
+	newStatus := updateStatus(status, processBatchResp, closedBatch)
+	log.Debugf("%s Batch synchronized, updated cache for next run", debugPrefix)
+	return &newStatus, nil
 }
 
 // ExecuteProcessBatch execute the batch and process it
@@ -239,6 +235,10 @@ func updateStatus(status TrustedState, response *ProcessResponse, closedBatch bo
 	if response == nil || response.ClearCache {
 		return res
 	}
+
+	res.LastTrustedBatches[0] = status.GetCurrentBatch()
+	res.LastTrustedBatches[1] = status.GetPreviousBatch()
+
 	if response.UpdateBatch != nil {
 		res.LastTrustedBatches[0] = response.UpdateBatch
 	}

--- a/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
+++ b/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
@@ -256,3 +256,68 @@ func TestGetNextStatusUpdate(t *testing.T) {
 	require.Nil(t, res.LastTrustedBatches[0])
 	require.Equal(t, processBatchResp.ProcessBatchResponse.NewStateRoot, res.LastTrustedBatches[1].StateRoot)
 }
+
+func TestGetNextStatusUpdateNothing(t *testing.T) {
+	testData := newTestDataForProcessorTrustedBatchSync(t)
+
+	batch0 := state.Batch{
+		BatchNumber: 123,
+	}
+	batch1 := state.Batch{
+		BatchNumber: 122,
+	}
+	previousStatus := l2_shared.TrustedState{
+		LastTrustedBatches: []*state.Batch{&batch0, &batch1},
+	}
+	ProcessResponse := l2_shared.NewProcessResponse()
+	newStatus, err := testData.sut.GetNextStatus(previousStatus, &ProcessResponse, false, "test")
+	require.NoError(t, err)
+	require.Equal(t, &previousStatus, newStatus)
+	// If batch is close move current batch to previous one
+	newStatus, err = testData.sut.GetNextStatus(previousStatus, &ProcessResponse, true, "test")
+	require.NoError(t, err)
+	require.Equal(t, &l2_shared.TrustedState{
+		LastTrustedBatches: []*state.Batch{nil, &batch0},
+	}, newStatus)
+}
+
+func TestGetNextStatusDiscardCache(t *testing.T) {
+	testData := newTestDataForProcessorTrustedBatchSync(t)
+	ProcessResponse := l2_shared.NewProcessResponse()
+	ProcessResponse.DiscardCache()
+	newStatus, err := testData.sut.GetNextStatus(l2_shared.TrustedState{}, &ProcessResponse, false, "test")
+	require.NoError(t, err)
+	require.True(t, newStatus.IsEmpty())
+}
+
+func TestGetNextStatusUpdateCurrentBatch(t *testing.T) {
+	testData := newTestDataForProcessorTrustedBatchSync(t)
+	ProcessResponse := l2_shared.NewProcessResponse()
+	batch := state.Batch{
+		BatchNumber: 123,
+	}
+	ProcessResponse.UpdateCurrentBatch(&batch)
+	newStatus, err := testData.sut.GetNextStatus(l2_shared.TrustedState{}, &ProcessResponse, false, "test")
+	require.NoError(t, err)
+	require.Equal(t, &l2_shared.TrustedState{
+		LastTrustedBatches: []*state.Batch{&batch, nil},
+	}, newStatus)
+}
+
+func TestGetNextStatusUpdateExecutionResult(t *testing.T) {
+	testData := newTestDataForProcessorTrustedBatchSync(t)
+	ProcessResponse := l2_shared.NewProcessResponse()
+	batch := state.Batch{
+		BatchNumber: 123,
+	}
+	previousStatus := l2_shared.TrustedState{
+		LastTrustedBatches: []*state.Batch{nil, nil},
+	}
+
+	ProcessResponse.UpdateCurrentBatchWithExecutionResult(&batch, &state.ProcessBatchResponse{
+		NewStateRoot: common.HexToHash("0x123"),
+	})
+	newStatus, err := testData.sut.GetNextStatus(previousStatus, &ProcessResponse, false, "test")
+	require.NoError(t, err)
+	require.Equal(t, common.HexToHash("0x123"), newStatus.LastTrustedBatches[0].StateRoot)
+}

--- a/synchronizer/l2_sync/l2_shared/trusted_state.go
+++ b/synchronizer/l2_sync/l2_shared/trusted_state.go
@@ -31,6 +31,22 @@ func (ts *TrustedState) IsEmpty() bool {
 	return false
 }
 
+// GetCurrentBatch returns the current batch or nil
+func (ts *TrustedState) GetCurrentBatch() *state.Batch {
+	if ts == nil || len(ts.LastTrustedBatches) == 0 {
+		return nil
+	}
+	return ts.LastTrustedBatches[0]
+}
+
+// GetPreviousBatch returns the previous batch or nil
+func (ts *TrustedState) GetPreviousBatch() *state.Batch {
+	if ts == nil || len(ts.LastTrustedBatches) < 2 {
+		return nil
+	}
+	return ts.LastTrustedBatches[1]
+}
+
 // TrustedStateManager is the trusted state manager, basically contains the batch cache and create the TrustedState
 type TrustedStateManager struct {
 	Cache *common.Cache[uint64, *state.Batch]

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
@@ -89,7 +89,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) NothingProcess(ctx context.Context, d
 			return nil, ErrCriticalClosedBatchDontContainExpectedData
 		}
 	}
-
+	res := l2_shared.NewProcessResponse()
 	if data.BatchMustBeClosed {
 		log.Debugf("%s Closing batch", data.DebugPrefix)
 		err := b.CloseBatch(ctx, data.TrustedBatch, dbTx, data.DebugPrefix)
@@ -97,10 +97,10 @@ func (b *SyncTrustedBatchExecutorForEtrog) NothingProcess(ctx context.Context, d
 			log.Error("%s error closing batch. Error: ", data.DebugPrefix, err)
 			return nil, err
 		}
+		data.StateBatch.WIP = false
+		res.UpdateCurrentBatch(data.StateBatch)
 	}
-	data.StateBatch.WIP = !data.BatchMustBeClosed
-	res := l2_shared.NewProcessResponse()
-	res.UpdateCurrentBatch(data.StateBatch)
+
 	return &res, nil
 }
 

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync_test.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync_test.go
@@ -130,13 +130,14 @@ func newData() l2_shared.ProcessData {
 
 func TestNothingProcessDontCloseBatch(t *testing.T) {
 	testData := newTestData(t)
+
 	// Arrange
 	data := l2_shared.ProcessData{
 		BatchNumber:       123,
 		Mode:              l2_shared.NothingProcessMode,
 		BatchMustBeClosed: false,
 		DebugPrefix:       "test",
-		StateBatch:        &state.Batch{},
+		StateBatch:        &state.Batch{WIP: true},
 		TrustedBatch:      &types.Batch{},
 	}
 


### PR DESCRIPTION



### What does this PR do?
Cherry-pick from #3169 (v0.5.4)
* fix cache update and sync from Trusted of closed batch


### Reviewers

Main reviewers:

- @ARR552 
- @tclemos 

