### PR TITLE
cherry-pick Fix/3200 l1inforoot error on reorg (#3201)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -486,7 +486,7 @@ func newState(ctx context.Context, c *config.Config, l2ChainID uint64, forkIDInt
 		MaxLogsBlockRange:            c.RPC.MaxLogsBlockRange,
 		MaxNativeBlockHashBlockRange: c.RPC.MaxNativeBlockHashBlockRange,
 	}
-	stateDb := pgstatestorage.NewPostgresStorage(stateCfg, sqlDB)
+
 	st := state.NewState(stateCfg, stateDb, executorClient, stateTree, eventLog, nil)
 	// This is to force to build cache, and check that DB is ok before starting the application
 	l1inforoot, err := st.GetCurrentL1InfoRoot(ctx, nil)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,7 +25,6 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/gasprice"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/client"
-	"github.com/0xPolygonHermez/zkevm-node/l1infotree"
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/merkletree"
 	"github.com/0xPolygonHermez/zkevm-node/metrics"
@@ -487,20 +486,15 @@ func newState(ctx context.Context, c *config.Config, l2ChainID uint64, forkIDInt
 		MaxLogsBlockRange:            c.RPC.MaxLogsBlockRange,
 		MaxNativeBlockHashBlockRange: c.RPC.MaxNativeBlockHashBlockRange,
 	}
-	allLeaves, err := stateDb.GetAllL1InfoRootEntries(ctx, nil)
+	stateDb := pgstatestorage.NewPostgresStorage(stateCfg, sqlDB)
+	st := state.NewState(stateCfg, stateDb, executorClient, stateTree, eventLog, nil)
+	// This is to force to build cache, and check that DB is ok before starting the application
+	l1inforoot, err := st.GetCurrentL1InfoRoot(ctx, nil)
 	if err != nil {
-		log.Fatal("error getting all leaves. Error: ", err)
+		log.Fatal("error getting current L1InfoRoot. Error: ", err)
 	}
-	var leaves [][32]byte
-	for _, leaf := range allLeaves {
-		leaves = append(leaves, leaf.Hash())
-	}
-	mt, err := l1infotree.NewL1InfoTree(uint8(32), leaves) //nolint:gomnd
-	if err != nil {
-		log.Fatal("error creating L1InfoTree. Error: ", err)
-	}
+	log.Infof("Starting L1InfoRoot: %v", l1inforoot.String())
 
-	st := state.NewState(stateCfg, stateDb, executorClient, stateTree, eventLog, mt)
 	return st
 }
 

--- a/state/batchV2.go
+++ b/state/batchV2.go
@@ -250,7 +250,11 @@ func (s *State) processBatchV2(ctx context.Context, processingCtx *ProcessingCon
 	if processingCtx.L1InfoRoot != (common.Hash{}) {
 		processBatchRequest.L1InfoRoot = processingCtx.L1InfoRoot.Bytes()
 	} else {
-		currentl1InfoRoot := s.GetCurrentL1InfoRoot()
+		currentl1InfoRoot, err := s.GetCurrentL1InfoRoot(ctx, dbTx)
+		if err != nil {
+			log.Errorf("error getting current L1InfoRoot: %v", err)
+			return nil, err
+		}
 		processBatchRequest.L1InfoRoot = currentl1InfoRoot.Bytes()
 	}
 

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -16,7 +16,7 @@ type storage interface {
 	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
 	Begin(ctx context.Context) (pgx.Tx, error)
 	StoreGenesisBatch(ctx context.Context, batch Batch, dbTx pgx.Tx) error
-	Reset(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error
+	ResetToL1BlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error
 	ResetForkID(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error
 	ResetTrustedState(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error
 	AddBlock(ctx context.Context, block *Block, dbTx pgx.Tx) error

--- a/state/l1infotree_test.go
+++ b/state/l1infotree_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/l1infotree"
 	"github.com/0xPolygonHermez/zkevm-node/state"
+	"github.com/0xPolygonHermez/zkevm-node/state/mocks"
 	"github.com/0xPolygonHermez/zkevm-node/state/pgstatestorage"
 	"github.com/0xPolygonHermez/zkevm-node/test/dbutils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,4 +65,85 @@ func TestFirstLeafOfL1InfoTreeIsIndex0(t *testing.T) {
 	insertedLeaf, err := testState.AddL1InfoTreeLeaf(ctx, &leaf, dbTx)
 	require.NoError(t, err)
 	require.Equal(t, insertedLeaf.L1InfoTreeIndex, uint32(0))
+}
+
+func TestGetCurrentL1InfoRootBuildCacheIfNil(t *testing.T) {
+	mockStorage := mocks.NewStorageMock(t)
+	stateCfg := state.Config{
+		MaxCumulativeGasUsed: 800000,
+		ChainID:              1000,
+		MaxLogsCount:         10000,
+		MaxLogsBlockRange:    10000,
+		ForkIDIntervals: []state.ForkIDInterval{{
+			FromBatchNumber: 0,
+			ToBatchNumber:   math.MaxUint64,
+			ForkId:          uint64(state.FORKID_ETROG),
+			Version:         "",
+		}},
+	}
+	ctx := context.Background()
+	testState := state.NewState(stateCfg, mockStorage, nil, nil, nil, nil)
+
+	mockStorage.EXPECT().GetAllL1InfoRootEntries(ctx, nil).Return([]state.L1InfoTreeExitRootStorageEntry{}, nil)
+
+	l1InfoRoot, err := testState.GetCurrentL1InfoRoot(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, l1InfoRoot, common.HexToHash("0x27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757"))
+}
+
+func TestGetCurrentL1InfoRootNoBuildCacheIfNotNil(t *testing.T) {
+	mockStorage := mocks.NewStorageMock(t)
+	stateCfg := state.Config{
+		MaxCumulativeGasUsed: 800000,
+		ChainID:              1000,
+		MaxLogsCount:         10000,
+		MaxLogsBlockRange:    10000,
+		ForkIDIntervals: []state.ForkIDInterval{{
+			FromBatchNumber: 0,
+			ToBatchNumber:   math.MaxUint64,
+			ForkId:          uint64(state.FORKID_ETROG),
+			Version:         "",
+		}},
+	}
+	ctx := context.Background()
+	l1InfoTree, err := l1infotree.NewL1InfoTree(uint8(32), nil)
+	require.NoError(t, err)
+	testState := state.NewState(stateCfg, mockStorage, nil, nil, nil, l1InfoTree)
+
+	// GetCurrentL1InfoRoot use the cache value in state.l1InfoTree
+	l1InfoRoot, err := testState.GetCurrentL1InfoRoot(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, l1InfoRoot, common.HexToHash("0x27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757"))
+}
+
+func TestAddL1InfoTreeLeafIfNil(t *testing.T) {
+	mockStorage := mocks.NewStorageMock(t)
+	stateCfg := state.Config{
+		MaxCumulativeGasUsed: 800000,
+		ChainID:              1000,
+		MaxLogsCount:         10000,
+		MaxLogsBlockRange:    10000,
+		ForkIDIntervals: []state.ForkIDInterval{{
+			FromBatchNumber: 0,
+			ToBatchNumber:   math.MaxUint64,
+			ForkId:          uint64(state.FORKID_ETROG),
+			Version:         "",
+		}},
+	}
+	ctx := context.Background()
+	testState := state.NewState(stateCfg, mockStorage, nil, nil, nil, nil)
+
+	mockStorage.EXPECT().GetLatestIndex(ctx, mock.Anything).Return(uint32(0), state.ErrNotFound)
+	mockStorage.EXPECT().AddL1InfoRootToExitRoot(ctx, mock.Anything, mock.Anything).Return(nil)
+	// This call is for rebuild cache
+	mockStorage.EXPECT().GetAllL1InfoRootEntries(ctx, nil).Return([]state.L1InfoTreeExitRootStorageEntry{}, nil)
+	leaf := state.L1InfoTreeLeaf{
+		GlobalExitRoot: state.GlobalExitRoot{
+			GlobalExitRoot: common.Hash{},
+		},
+	}
+	addLeaf, err := testState.AddL1InfoTreeLeaf(ctx, &leaf, nil)
+	require.NoError(t, err)
+	require.Equal(t, addLeaf.L1InfoTreeRoot, common.HexToHash("0xea536769cad1a63ffb1ea52ae772983905c3f0e2f8914e6c0e2af956637e480c"))
+	require.Equal(t, addLeaf.L1InfoTreeIndex, uint32(0))
 }

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -7479,54 +7479,6 @@ func (_c *StorageMock_QueryRow_Call) RunAndReturn(run func(context.Context, stri
 	return _c
 }
 
-// Reset provides a mock function with given fields: ctx, blockNumber, dbTx
-func (_m *StorageMock) Reset(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error {
-	ret := _m.Called(ctx, blockNumber, dbTx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Reset")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) error); ok {
-		r0 = rf(ctx, blockNumber, dbTx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// StorageMock_Reset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reset'
-type StorageMock_Reset_Call struct {
-	*mock.Call
-}
-
-// Reset is a helper method to define mock.On call
-//   - ctx context.Context
-//   - blockNumber uint64
-//   - dbTx pgx.Tx
-func (_e *StorageMock_Expecter) Reset(ctx interface{}, blockNumber interface{}, dbTx interface{}) *StorageMock_Reset_Call {
-	return &StorageMock_Reset_Call{Call: _e.mock.On("Reset", ctx, blockNumber, dbTx)}
-}
-
-func (_c *StorageMock_Reset_Call) Run(run func(ctx context.Context, blockNumber uint64, dbTx pgx.Tx)) *StorageMock_Reset_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
-	})
-	return _c
-}
-
-func (_c *StorageMock_Reset_Call) Return(_a0 error) *StorageMock_Reset_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *StorageMock_Reset_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) error) *StorageMock_Reset_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ResetForkID provides a mock function with given fields: ctx, batchNumber, dbTx
 func (_m *StorageMock) ResetForkID(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error {
 	ret := _m.Called(ctx, batchNumber, dbTx)
@@ -7571,6 +7523,54 @@ func (_c *StorageMock_ResetForkID_Call) Return(_a0 error) *StorageMock_ResetFork
 }
 
 func (_c *StorageMock_ResetForkID_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) error) *StorageMock_ResetForkID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResetToL1BlockNumber provides a mock function with given fields: ctx, blockNumber, dbTx
+func (_m *StorageMock) ResetToL1BlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error {
+	ret := _m.Called(ctx, blockNumber, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResetToL1BlockNumber")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r0 = rf(ctx, blockNumber, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StorageMock_ResetToL1BlockNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetToL1BlockNumber'
+type StorageMock_ResetToL1BlockNumber_Call struct {
+	*mock.Call
+}
+
+// ResetToL1BlockNumber is a helper method to define mock.On call
+//   - ctx context.Context
+//   - blockNumber uint64
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) ResetToL1BlockNumber(ctx interface{}, blockNumber interface{}, dbTx interface{}) *StorageMock_ResetToL1BlockNumber_Call {
+	return &StorageMock_ResetToL1BlockNumber_Call{Call: _e.mock.On("ResetToL1BlockNumber", ctx, blockNumber, dbTx)}
+}
+
+func (_c *StorageMock_ResetToL1BlockNumber_Call) Run(run func(ctx context.Context, blockNumber uint64, dbTx pgx.Tx)) *StorageMock_ResetToL1BlockNumber_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_ResetToL1BlockNumber_Call) Return(_a0 error) *StorageMock_ResetToL1BlockNumber_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *StorageMock_ResetToL1BlockNumber_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) error) *StorageMock_ResetToL1BlockNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -34,8 +34,8 @@ func (p *PostgresStorage) getExecQuerier(dbTx pgx.Tx) ExecQuerier {
 	return p
 }
 
-// Reset resets the state to a block for the given DB tx
-func (p *PostgresStorage) Reset(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error {
+// ResetToL1BlockNumber resets the state to a block for the given DB tx
+func (p *PostgresStorage) ResetToL1BlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error {
 	e := p.getExecQuerier(dbTx)
 	const resetSQL = "DELETE FROM state.block WHERE block_num > $1"
 	if _, err := e.Exec(ctx, resetSQL, blockNumber); err != nil {

--- a/state/reset.go
+++ b/state/reset.go
@@ -1,0 +1,24 @@
+package state
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+// Reset resets the state to the given L1 block number
+func (s *State) Reset(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error {
+	// Reset from DB to L1 block number, this will remove in cascade:
+	//  - VirtualBatches
+	//  - VerifiedBatches
+	//  - Entries in exit_root table
+	err := s.ResetToL1BlockNumber(ctx, blockNumber, dbTx)
+	if err == nil {
+		// Discard L1InfoTree cache
+		// We can't rebuild cache, because we are inside a transaction, so we dont known
+		// is going to be a commit or a rollback. So is going to be rebuild on the next
+		// request that needs it.
+		s.l1InfoTree = nil
+	}
+	return err
+}

--- a/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
+++ b/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
@@ -821,53 +821,6 @@ func (_c *StateFullInterface_GetBatchByNumber_Call) RunAndReturn(run func(contex
 	return _c
 }
 
-// GetCurrentL1InfoRoot provides a mock function with given fields:
-func (_m *StateFullInterface) GetCurrentL1InfoRoot() common.Hash {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetCurrentL1InfoRoot")
-	}
-
-	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func() common.Hash); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(common.Hash)
-		}
-	}
-
-	return r0
-}
-
-// StateFullInterface_GetCurrentL1InfoRoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCurrentL1InfoRoot'
-type StateFullInterface_GetCurrentL1InfoRoot_Call struct {
-	*mock.Call
-}
-
-// GetCurrentL1InfoRoot is a helper method to define mock.On call
-func (_e *StateFullInterface_Expecter) GetCurrentL1InfoRoot() *StateFullInterface_GetCurrentL1InfoRoot_Call {
-	return &StateFullInterface_GetCurrentL1InfoRoot_Call{Call: _e.mock.On("GetCurrentL1InfoRoot")}
-}
-
-func (_c *StateFullInterface_GetCurrentL1InfoRoot_Call) Run(run func()) *StateFullInterface_GetCurrentL1InfoRoot_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *StateFullInterface_GetCurrentL1InfoRoot_Call) Return(_a0 common.Hash) *StateFullInterface_GetCurrentL1InfoRoot_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *StateFullInterface_GetCurrentL1InfoRoot_Call) RunAndReturn(run func() common.Hash) *StateFullInterface_GetCurrentL1InfoRoot_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetExitRootByGlobalExitRoot provides a mock function with given fields: ctx, ger, dbTx
 func (_m *StateFullInterface) GetExitRootByGlobalExitRoot(ctx context.Context, ger common.Hash, dbTx pgx.Tx) (*state.GlobalExitRoot, error) {
 	ret := _m.Called(ctx, ger, dbTx)

--- a/synchronizer/common/syncinterfaces/state.go
+++ b/synchronizer/common/syncinterfaces/state.go
@@ -63,7 +63,6 @@ type StateFullInterface interface {
 	GetForkIDByBlockNumber(blockNumber uint64) uint64
 	GetStoredFlushID(ctx context.Context) (uint64, string, error)
 	AddL1InfoTreeLeaf(ctx context.Context, L1InfoTreeLeaf *state.L1InfoTreeLeaf, dbTx pgx.Tx) (*state.L1InfoTreeExitRootStorageEntry, error)
-	GetCurrentL1InfoRoot() common.Hash
 	StoreL2Block(ctx context.Context, batchNumber uint64, l2Block *state.ProcessBlockResponse, txsEGPLog []*state.EffectiveGasPriceLog, dbTx pgx.Tx) error
 	GetL1InfoRootLeafByL1InfoRoot(ctx context.Context, l1InfoRoot common.Hash, dbTx pgx.Tx) (state.L1InfoTreeExitRootStorageEntry, error)
 	UpdateWIPBatch(ctx context.Context, receipt state.ProcessingReceipt, dbTx pgx.Tx) error


### PR DESCRIPTION
* L1InfooTree cache is calculated when needed and is discard when a reorg happens

Closes #3200
original PR over v0.5.5 : #3201 
Commit: `112bdd069179fbee3225c4fae6074ae33b8e249e`


### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
