### PR TITLE
Remove L1SynchronizationMode parameter from environments config files

### DIFF
--- a/config/environments/cardona/node.config.toml
+++ b/config/environments/cardona/node.config.toml
@@ -68,7 +68,6 @@ EnableL2SuggestedGasPricePolling = false
 SyncInterval = "2s"
 SyncChunkSize = 100
 TrustedSequencerURL = "" # If it is empty or not specified, then the value is read from the smc
-L1SynchronizationMode = "sequential"
 
 [MTClient]
 URI = "zkevm-prover:50061"

--- a/config/environments/mainnet/node.config.toml
+++ b/config/environments/mainnet/node.config.toml
@@ -66,7 +66,6 @@ EnableL2SuggestedGasPricePolling = false
 SyncInterval = "2s"
 SyncChunkSize = 100
 TrustedSequencerURL = "" # If it is empty or not specified, then the value is read from the smc
-L1SynchronizationMode = "sequential"
 
 [MTClient]
 URI = "zkevm-prover:50061"

--- a/config/environments/testnet/node.config.toml
+++ b/config/environments/testnet/node.config.toml
@@ -68,7 +68,6 @@ EnableL2SuggestedGasPricePolling = false
 SyncInterval = "2s"
 SyncChunkSize = 100
 TrustedSequencerURL = "" # If it is empty or not specified, then the value is read from the smc
-L1SynchronizationMode = "sequential"
 
 [MTClient]
 URI = "zkevm-prover:50061"


### PR DESCRIPTION
### What does this PR do?

- Remove L1SynchronizationMode parameter from environments config files (it will use default "sequential" value).

### Reviewers

Main reviewers:

@joanestebanr 
@tclemos 
@ToniRamirezM 