### PR TITLE
cherry-pick Fix/3203 panic if batch process fail and must be closed (#3206)

### DIFF
--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
@@ -218,7 +218,7 @@ func (s *ProcessorTrustedBatchSync) ExecuteProcessBatch(ctx context.Context, pro
 		log.Debugf("%s is partially synchronized but we don't have intermediate stateRoot so it needs to be fully reprocessed", processMode.DebugPrefix)
 		processBatchResp, err = s.Steps.ReProcess(ctx, processMode, dbTx)
 	}
-	if processMode.BatchMustBeClosed {
+	if processBatchResp != nil && err == nil && processMode.BatchMustBeClosed {
 		err = checkProcessBatchResultMatchExpected(processMode, processBatchResp.ProcessBatchResponse)
 		if err != nil {
 			log.Error("%s error verifying batch result!  Error: ", processMode.DebugPrefix, err)

--- a/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
+++ b/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_sync_test.go
@@ -1,6 +1,8 @@
 package test_l2_shared
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
@@ -9,6 +11,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/synchronizer/l2_sync/l2_shared"
 	mock_l2_shared "github.com/0xPolygonHermez/zkevm-node/synchronizer/l2_sync/l2_shared/mocks"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -320,4 +323,17 @@ func TestGetNextStatusUpdateExecutionResult(t *testing.T) {
 	newStatus, err := testData.sut.GetNextStatus(previousStatus, &ProcessResponse, false, "test")
 	require.NoError(t, err)
 	require.Equal(t, common.HexToHash("0x123"), newStatus.LastTrustedBatches[0].StateRoot)
+}
+
+func TestExecuteProcessBatchError(t *testing.T) {
+	testData := newTestDataForProcessorTrustedBatchSync(t)
+
+	data := l2_shared.ProcessData{
+		Mode:              l2_shared.NothingProcessMode,
+		BatchMustBeClosed: true,
+	}
+	returnedError := errors.New("error")
+	testData.mockExecutor.EXPECT().NothingProcess(mock.Anything, mock.Anything, mock.Anything).Return(nil, returnedError)
+	_, err := testData.sut.ExecuteProcessBatch(context.Background(), &data, nil)
+	require.ErrorIs(t, returnedError, err)
 }


### PR DESCRIPTION
* synchronizer avoid panic if process trusted batch fails

Closes #3203 
origin PR: https://github.com/0xPolygonHermez/zkevm-node/pull/3206

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
