### PR TITLE
cherry-pick: end-point eth_syncing avoid returning a 2^64-1 that is not compatible with javascript

### DIFF
--- a/state/syncinginfo.go
+++ b/state/syncinginfo.go
@@ -57,8 +57,13 @@ func (p *State) GetSyncingInfo(ctx context.Context, dbTx pgx.Tx) (SyncingInfo, e
 		return SyncingInfo{}, err
 	}
 
-	info.EstimatedHighestBlock = ^uint64(0)
 	info.IsSynchronizing = syncData.LastBatchNumberSeen > lastBatchNumber
+	if info.IsSynchronizing {
+		// Estimation of block counting 1 l2block per missing batch
+		info.EstimatedHighestBlock = lastBlockNumber + (syncData.LastBatchNumberConsolidated - lastBatchNumber)
+	} else {
+		info.EstimatedHighestBlock = lastBlockNumber
+	}
 
 	return info, nil
 }

--- a/state/syncinginfo_test.go
+++ b/state/syncinginfo_test.go
@@ -88,7 +88,7 @@ func TestGetSyncingInfoOk(t *testing.T) {
 	require.Equal(t, state.SyncingInfo{
 		InitialSyncingBlock:   uint64(123),
 		CurrentBlockNumber:    uint64(567),
-		EstimatedHighestBlock: ^uint64(0),
+		EstimatedHighestBlock: uint64(597),
 		IsSynchronizing:       true,
 	}, res)
 }


### PR DESCRIPTION
Closes #3217 
Incomming PR (v0.5.5): #3220 


### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
