### PR TITLE
Remove state.batch section from environments config files

### DIFF
--- a/config/environments/cardona/node.config.toml
+++ b/config/environments/cardona/node.config.toml
@@ -12,19 +12,6 @@ Outputs = ["stderr"]
 	Port = "5432"
 	EnableLog = false	
 	MaxConns = 200
-	[State.Batch]
-		[State.Batch.Constraints]
-		MaxTxsPerBatch = 300
-		MaxBatchBytesSize = 120000
-		MaxCumulativeGasUsed = 1125899906842624
-		MaxKeccakHashes = 2145
-		MaxPoseidonHashes = 252357
-		MaxPoseidonPaddings = 135191
-		MaxMemAligns = 236585
-		MaxArithmetics = 236585
-		MaxBinaries = 473170
-		MaxSteps = 7570538
-		MaxSHA256Hashes = 1596
 
 [Pool]
 IntervalToRefreshBlockedAddresses = "5m"

--- a/config/environments/mainnet/node.config.toml
+++ b/config/environments/mainnet/node.config.toml
@@ -12,19 +12,6 @@ Outputs = ["stderr"]
 	Port = "5432"
 	EnableLog = false	
 	MaxConns = 200
-	[State.Batch]
-		[State.Batch.Constraints]
-		MaxTxsPerBatch = 300
-		MaxBatchBytesSize = 120000
-		MaxCumulativeGasUsed = 1125899906842624
-		MaxKeccakHashes = 2145
-		MaxPoseidonHashes = 252357
-		MaxPoseidonPaddings = 135191
-		MaxMemAligns = 236585
-		MaxArithmetics = 236585
-		MaxBinaries = 473170
-		MaxSteps = 7570538
-		MaxSHA256Hashes = 1596
 
 [Pool]
 MaxTxBytesSize=100132

--- a/config/environments/testnet/node.config.toml
+++ b/config/environments/testnet/node.config.toml
@@ -12,19 +12,6 @@ Outputs = ["stderr"]
 	Port = "5432"
 	EnableLog = false	
 	MaxConns = 200
-	[State.Batch]
-		[State.Batch.Constraints]
-		MaxTxsPerBatch = 300
-		MaxBatchBytesSize = 120000
-		MaxCumulativeGasUsed = 1125899906842624
-		MaxKeccakHashes = 2145
-		MaxPoseidonHashes = 252357
-		MaxPoseidonPaddings = 135191
-		MaxMemAligns = 236585
-		MaxArithmetics = 236585
-		MaxBinaries = 473170
-		MaxSteps = 7570538
-		MaxSHA256Hashes = 1596
 
 [Pool]
 IntervalToRefreshBlockedAddresses = "5m"


### PR DESCRIPTION
### What does this PR do?

- Removes state.batch section from environments config files, since these parameters are not used in a permissionless node. In anycase is better to don't modify these values and keep the default values

### Reviewers

Main reviewers:

@joanestebanr 
@tclemos 
@ToniRamirezM 