### PR TITLE
cherry-pick Fix/3233 the etrog event UpdateEtrogSequence doesnt store the GER in batch table (#3234)

### DIFF
--- a/synchronizer/actions/etrog/processor_l1_update_etrog_sequence.go
+++ b/synchronizer/actions/etrog/processor_l1_update_etrog_sequence.go
@@ -82,6 +82,7 @@ func (g *ProcessorL1UpdateEtrogSequence) processUpdateEtrogSequence(ctx context.
 		BatchL2Data:          &txs,
 		ForcedBlockHashL1:    forcedBlockHashL1,
 		SkipVerifyL1InfoRoot: 1,
+		GlobalExitRoot:       updateEtrogSequence.PolygonRollupBaseEtrogBatchData.ForcedGlobalExitRoot,
 	}
 
 	virtualBatch := state.VirtualBatch{
@@ -110,7 +111,8 @@ func (g *ProcessorL1UpdateEtrogSequence) processUpdateEtrogSequence(ctx context.
 	g.sync.PendingFlushID(flushID, proverID)
 
 	// Store virtualBatch
-	log.Debugf("processUpdateEtrogSequence: Storing virtualBatch. BatchNumber: %d, BlockNumber: %d", virtualBatch.BatchNumber, blockNumber)
+	log.Infof("processUpdateEtrogSequence: Storing virtualBatch. BatchNumber: %d, BlockNumber: %d GER:%s", virtualBatch.BatchNumber, blockNumber,
+		common.Hash(updateEtrogSequence.PolygonRollupBaseEtrogBatchData.ForcedGlobalExitRoot).String())
 	err = g.state.AddVirtualBatch(ctx, &virtualBatch, dbTx)
 	if err != nil {
 		log.Errorf("error storing virtualBatch. BatchNumber: %d, BlockNumber: %d, error: %v", virtualBatch.BatchNumber, blockNumber, err)


### PR DESCRIPTION
Closes #3233
Original PR over `0.5.7`: https://github.com/0xPolygonHermez/zkevm-node/pull/3234
Commit: [1d3f6eebd25ab1b8160d14cff710993f87c013c7](https://github.com/0xPolygonHermez/zkevm-node/commit/1d3f6eebd25ab1b8160d14cff710993f87c013c7)

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
