### PR TITLE
Disable delete addrQueue as temporary workaround

### DIFF
--- a/sequencer/worker.go
+++ b/sequencer/worker.go
@@ -361,9 +361,9 @@ func (w *Worker) ExpireTransactions(maxTime time.Duration) []*TxTracker {
 			w.txSortedList.delete(prevReadyTx)
 		}
 
-		if addrQueue.IsEmpty() {
+		/*if addrQueue.IsEmpty() {
 			delete(w.pool, addrQueue.fromStr)
-		}
+		}*/
 	}
 	log.Debugf("expire transactions ended, addrQueue length: %d, delete count: %d ", len(w.pool), len(txs))
 


### PR DESCRIPTION
### What does this PR do?

Disables delete addrQueue as temporary workaround. When expiring txs from the worker if an addrQueue is empty we also delete it from the worker. This can cause some issues (in edge cases) on etrog as maybe we are deleting an addrQueue that just has been update their nonce and balance in the worker (due a tx that is being processed in the wip L2 block). If after delete it just we receive a new tx from this address, we create again the addrQueue and we get the nonce/balance from the HashDB using the  SR of the last closed L2 block, but in this case we are not getting the updated nonce and balance for this address, as the last nonce/balance was modified by a txs that is in the WIP L2 block and it's still not closed.

### Reviewers

Main reviewers:

@ToniRamirezM 