### PR TITLE
Nonce too low fix

### DIFF
--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -36,6 +36,41 @@ var (
 	ErrExecutionReverted = errors.New("execution reverted")
 )
 
+// nonceMap is a struct that represents a mapping of Ethereum addresses to nonces.
+type nonceMap struct {
+	m map[common.Address]uint64
+
+	lock sync.RWMutex
+}
+
+// newNonceMap creates a new instance of nonceMap.
+// It returns a pointer to the newly created nonceMap.
+func newNonceMap() *nonceMap {
+	return &nonceMap{
+		m: make(map[common.Address]uint64, 0),
+	}
+}
+
+// get retrieves the nonce value for the given address.
+// It returns the nonce value and a boolean indicating whether the nonce exists in the map.
+func (n *nonceMap) get(addr common.Address) (uint64, bool) {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	nonce, hasNonce := n.m[addr]
+
+	return nonce, hasNonce
+}
+
+// set updates the nonce value for the given address in the nonceMap.
+// It acquires a lock to ensure thread safety and then updates the nonce value.
+func (n *nonceMap) set(addr common.Address, nonce uint64) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	n.m[addr] = nonce
+}
+
 // Client for eth tx manager
 type Client struct {
 	ctx    context.Context
@@ -61,13 +96,6 @@ func New(cfg Config, ethMan ethermanInterface, storage storageInterface, state s
 
 // Add a transaction to be sent and monitored
 func (c *Client) Add(ctx context.Context, owner, id string, from common.Address, to *common.Address, value *big.Int, data []byte, gasOffset uint64, dbTx pgx.Tx) error {
-	// get next nonce
-	nonce, err := c.etherman.CurrentNonce(ctx, from)
-	if err != nil {
-		err := fmt.Errorf("failed to get current nonce: %w", err)
-		log.Errorf(err.Error())
-		return err
-	}
 	// get gas
 	gas, err := c.etherman.EstimateGas(ctx, from, to, value, data)
 	if err != nil {
@@ -91,7 +119,7 @@ func (c *Client) Add(ctx context.Context, owner, id string, from common.Address,
 	// create monitored tx
 	mTx := monitoredTx{
 		owner: owner, id: id, from: from, to: to,
-		nonce: nonce, value: value, data: data,
+		value: value, data: data,
 		gas: gas, gasOffset: gasOffset, gasPrice: gasPrice,
 		status: MonitoredTxStatusCreated,
 	}
@@ -254,6 +282,8 @@ func (c *Client) monitorTxs(ctx context.Context) error {
 
 	log.Infof("found %v monitored tx to process", len(mTxs))
 
+	nonceMap := newNonceMap()
+
 	wg := sync.WaitGroup{}
 	wg.Add(len(mTxs))
 	for _, mTx := range mTxs {
@@ -266,7 +296,7 @@ func (c *Client) monitorTxs(ctx context.Context) error {
 				}
 				wg.Done()
 			}(mTx, mTxLogger)
-			c.monitorTx(ctx, mTx, mTxLogger)
+			c.monitorTx(ctx, mTx, mTxLogger, nonceMap)
 		}(c, mTx)
 	}
 	wg.Wait()
@@ -275,19 +305,13 @@ func (c *Client) monitorTxs(ctx context.Context) error {
 }
 
 // monitorTx does all the monitoring steps to the monitored tx
-func (c *Client) monitorTx(ctx context.Context, mTx monitoredTx, logger *log.Logger) {
+func (c *Client) monitorTx(ctx context.Context, mTx monitoredTx, logger *log.Logger, nonceMap *nonceMap) {
 	var err error
 	logger.Info("processing")
 	// check if any of the txs in the history was confirmed
 	var lastReceiptChecked types.Receipt
 	// monitored tx is confirmed until we find a successful receipt
 	confirmed := false
-	// monitored tx doesn't have a failed receipt until we find a failed receipt for any
-	// tx in the monitored tx history
-	hasFailedReceipts := false
-	// all history txs are considered mined until we can't find a receipt for any
-	// tx in the monitored tx history
-	allHistoryTxsWereMined := true
 	for txHash := range mTx.history {
 		mined, receipt, err := c.etherman.CheckTxWasMined(ctx, txHash)
 		if err != nil {
@@ -297,7 +321,6 @@ func (c *Client) monitorTx(ctx context.Context, mTx monitoredTx, logger *log.Log
 
 		// if the tx is not mined yet, check that not all the tx were mined and go to the next
 		if !mined {
-			allHistoryTxsWereMined = false
 			continue
 		}
 
@@ -313,7 +336,6 @@ func (c *Client) monitorTx(ctx context.Context, mTx monitoredTx, logger *log.Log
 		// and set that we have found a failed receipt. This info will be used later
 		// to check if nonce needs to be reviewed
 		confirmed = false
-		hasFailedReceipts = true
 	}
 
 	// we need to check if we need to review the nonce carefully, to avoid sending
@@ -327,9 +349,9 @@ func (c *Client) monitorTx(ctx context.Context, mTx monitoredTx, logger *log.Log
 	//
 	// in case of the monitored tx is not confirmed yet, all tx were mined and none of them were
 	// mined successfully, we need to review the nonce
-	if !confirmed && hasFailedReceipts && allHistoryTxsWereMined {
+	if !confirmed {
 		logger.Infof("nonce needs to be updated")
-		err := c.reviewMonitoredTxNonce(ctx, &mTx, logger)
+		err := c.reviewMonitoredTxNonce(ctx, &mTx, logger, nonceMap)
 		if err != nil {
 			logger.Errorf("failed to review monitored tx nonce: %v", err)
 			return
@@ -563,19 +585,34 @@ func (c *Client) reviewMonitoredTx(ctx context.Context, mTx *monitoredTx, mTxLog
 // IMPORTANT: Nonce is reviewed apart from the other fields because it is a very
 // sensible information and can make duplicated data to be sent to the blockchain,
 // causing possible side effects and wasting resources.
-func (c *Client) reviewMonitoredTxNonce(ctx context.Context, mTx *monitoredTx, mTxLogger *log.Logger) error {
+func (c *Client) reviewMonitoredTxNonce(ctx context.Context, mTx *monitoredTx, mTxLogger *log.Logger, nonceMap *nonceMap) error {
 	mTxLogger.Debug("reviewing nonce")
-	nonce, err := c.etherman.CurrentNonce(ctx, mTx.from)
-	if err != nil {
-		err := fmt.Errorf("failed to load current nonce for acc %v: %w", mTx.from.String(), err)
-		mTxLogger.Errorf(err.Error())
-		return err
+
+	var (
+		currentNonce uint64
+		err          error
+	)
+
+	currentNonce, hasNonce := nonceMap.get(mTx.from)
+	if !hasNonce {
+		// nonce map does not have the nonce, get it from the blockchain
+		currentNonce, err = c.etherman.CurrentNonce(ctx, mTx.from)
+		if err != nil {
+			err := fmt.Errorf("failed to load current nonce for acc %v: %w", mTx.from.String(), err)
+			mTxLogger.Errorf(err.Error())
+
+			return err
+		}
 	}
 
-	if nonce > mTx.nonce {
-		mTxLogger.Infof("monitored tx nonce updated from %v to %v", mTx.nonce, nonce)
-		mTx.nonce = nonce
+	if currentNonce > mTx.nonce {
+		mTxLogger.Infof("monitored tx nonce updated from %v to %v", mTx.nonce, currentNonce)
+		mTx.nonce = currentNonce
 	}
+
+	// update nonce map with the new nonce so that other txs for this account can use the map
+	// instead of querying the blockchain again
+	nonceMap.set(mTx.from, currentNonce+1)
 
 	return nil
 }

--- a/ethtxmanager/ethtxmanager_test.go
+++ b/ethtxmanager/ethtxmanager_test.go
@@ -167,7 +167,7 @@ func TestTxGetMinedAfterReviewed(t *testing.T) {
 	etherman.
 		On("CurrentNonce", ctx, from).
 		Return(currentNonce, nil).
-		Once()
+		Twice()
 
 	firstGasEstimation := uint64(1)
 	etherman.
@@ -333,7 +333,7 @@ func TestTxGetMinedAfterConfirmedAndReorged(t *testing.T) {
 	etherman.
 		On("CurrentNonce", ctx, from).
 		Return(currentNonce, nil).
-		Once()
+		Twice()
 
 	estimatedGas := uint64(1)
 	etherman.
@@ -749,12 +749,6 @@ func TestGasPriceMarginAndLimit(t *testing.T) {
 
 			ctx := context.Background()
 
-			currentNonce := uint64(1)
-			etherman.
-				On("CurrentNonce", ctx, from).
-				Return(currentNonce, nil).
-				Once()
-
 			estimatedGas := uint64(1)
 			etherman.
 				On("EstimateGas", ctx, from, to, value, data).
@@ -829,12 +823,6 @@ func TestGasOffset(t *testing.T) {
 			var data []byte = nil
 
 			ctx := context.Background()
-
-			currentNonce := uint64(1)
-			etherman.
-				On("CurrentNonce", ctx, from).
-				Return(currentNonce, nil).
-				Once()
 
 			etherman.
 				On("EstimateGas", ctx, from, to, value, data).


### PR DESCRIPTION
### What does this PR do?

While testing the CDK, a `nonce too low` error was quite frequent when agglayer was under load.

Basically, what happened was, there was a test account that was sending a number of transaction to the agglayer rpc in a short period of time. Since the agglayer uses the `ethTxManager` from the zkevm node, the behavior was like this:
- a transaction is sent to the agglayer rpc
- some validation is done on the agglayer
- agglayer adds the transaction to the `ethTxManager` using the `Add` function.
- `ethTxManager` sets the nonce of all the newly arrived transactions from the same account to the same nonce (CurrentNonce gotten from the L1 node), and those transactions are stored in postgress db to be then sent to the L1 node.
- a timer ticks and those newly stored transactions are now sent to the L1 node, but only the first one was successful, since the nonce was not updated for the other transactions from that account.

The solution is to always update the nonce of pending transactions (transactions to be either sent or resent), by using a local map of nonces. Only if the account does not exist in the map, the L1 node will be queried to return the current nonce for that account. This is of course only done for the one iteration of timer for monitoring transactions. The local nonce map is always recreated for each iteration of monitoring to avoid unnecessary memory consumption.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
