### PR TITLE
add selector for trusted sync to prevent from executing from an old trusted node 

### DIFF
--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -123,9 +123,6 @@ func TestForcedBatchEvent(t *testing.T) {
 	assert.Equal(t, auth.From, blocks[0].ForcedBatches[0].Sequencer)
 }
 
-// TODO: Review tests with Joan
-
-/*
 func TestSequencedBatchesEvent(t *testing.T) {
 	// Set up testing environment
 	etherman, ethBackend, auth, _, br := newTestingEnv()
@@ -165,8 +162,7 @@ func TestSequencedBatchesEvent(t *testing.T) {
 	}, polygonzkevm.PolygonRollupBaseEtrogBatchData{
 		Transactions: common.Hex2Bytes(rawTxs),
 	})
-	// TODO: Fix params
-	_, err = etherman.ZkEVM.SequenceBatches(auth, sequences, 0, 0, auth.From)
+	_, err = etherman.ZkEVM.SequenceBatches(auth, sequences, uint64(time.Now().Unix()), uint64(1), auth.From)
 	require.NoError(t, err)
 
 	// Mine the tx in a block
@@ -205,7 +201,7 @@ func TestVerifyBatchEvent(t *testing.T) {
 		Transactions: common.Hex2Bytes(rawTxs),
 	}
 	//TODO: Fix params
-	_, err = etherman.ZkEVM.SequenceBatches(auth, []polygonzkevm.PolygonRollupBaseEtrogBatchData{tx}, 0, 0, auth.From)
+	_, err = etherman.ZkEVM.SequenceBatches(auth, []polygonzkevm.PolygonRollupBaseEtrogBatchData{tx}, uint64(time.Now().Unix()), uint64(1), auth.From)
 	require.NoError(t, err)
 
 	// Mine the tx in a block
@@ -233,7 +229,6 @@ func TestVerifyBatchEvent(t *testing.T) {
 	assert.Equal(t, 0, order[blocks[1].BlockHash][0].Pos)
 	assert.Equal(t, 0, order[blocks[1].BlockHash][1].Pos)
 }
-*/
 
 func TestSequenceForceBatchesEvent(t *testing.T) {
 	// Set up testing environment

--- a/state/forkid.go
+++ b/state/forkid.go
@@ -15,6 +15,8 @@ const (
 	FORKID_INCABERRY = 6
 	// FORKID_ETROG is the fork id 7
 	FORKID_ETROG = 7
+	// FORKID_ELDERBERRY is the fork id 8
+	FORKID_ELDERBERRY = 8
 )
 
 // ForkIDInterval is a fork id interval

--- a/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
@@ -118,7 +118,7 @@ func (g *ProcessorL1SequenceBatchesElderberry) sanityCheckTstampLastL2Block(time
 		return nil
 	}
 	lastL2Block := l2blocks[len(l2blocks)-1]
-	if uint64(lastL2Block.ReceivedAt.Unix()) <= timeLimit {
+	if uint64(lastL2Block.ReceivedAt.Unix()) > timeLimit {
 		log.Errorf("The last L2 block timestamp can't be greater than timeLimit. Expected: %d (L1 event), got: %d (last L2Block)", timeLimit, lastL2Block.ReceivedAt.Unix())
 		return fmt.Errorf("wrong timestamp of  last L2 block timestamp with L1 event timestamp")
 	}

--- a/synchronizer/common/syncinterfaces/sync_trusted_state_executor.go
+++ b/synchronizer/common/syncinterfaces/sync_trusted_state_executor.go
@@ -12,6 +12,8 @@ var (
 	ErrMissingSyncFromL1 = errors.New("must sync from L1")
 	// ErrFatalDesyncFromL1 is returned when trusted node and permissionless node have different data
 	ErrFatalDesyncFromL1 = errors.New("fatal situation: the TrustedNode have another data!. Halt or do something")
+	// ErrCantSyncFromL2 is returned when can't sync from L2, for example the forkid is not supported by L2 sync
+	ErrCantSyncFromL2 = errors.New("can't sync from L2")
 )
 
 // SyncTrustedStateExecutor is the interface that class that synchronize permissionless with a trusted node

--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_selector.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_selector.go
@@ -13,8 +13,6 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/synchronizer/common/syncinterfaces"
 )
 
-const etrogForkId = uint64(7)
-
 type stateSyncTrustedStateExecutorSelector interface {
 	GetForkIDInMemory(forkId uint64) *state.ForkIDInterval
 	GetForkIDByBatchNumber(batchNumber uint64) uint64
@@ -74,7 +72,6 @@ func (s *SyncTrustedStateExecutorSelector) CleanTrustedState() {
 	for _, executor := range s.supportedForks {
 		executor.CleanTrustedState()
 	}
-
 }
 
 // GetCachedBatch implements syncinterfaces.SyncTrustedStateExecutor. Returns a cached batch

--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_selector.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_selector.go
@@ -62,7 +62,7 @@ func (s *SyncTrustedStateExecutorSelector) SyncTrustedState(ctx context.Context,
 	if executor == nil {
 		log.Warnf("No executor available, skipping SyncTrustedState: latestSyncedBatch:%d, maximumBatchNumberToProcess:%d",
 			latestSyncedBatch, maximumBatchNumberToProcess)
-		return nil
+		return syncinterfaces.ErrCantSyncFromL2
 	}
 	return executor.SyncTrustedState(ctx, latestSyncedBatch, maxBatchNumber)
 }

--- a/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_selector_test.go
+++ b/synchronizer/l2_sync/l2_shared/tests/processor_trusted_batch_selector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/state"
+	"github.com/0xPolygonHermez/zkevm-node/synchronizer/common/syncinterfaces"
 	mock_syncinterfaces "github.com/0xPolygonHermez/zkevm-node/synchronizer/common/syncinterfaces/mocks"
 	"github.com/0xPolygonHermez/zkevm-node/synchronizer/l2_sync/l2_shared"
 	"github.com/stretchr/testify/require"
@@ -14,29 +15,41 @@ import (
 // expected:
 // -
 
-func TestExecutorSelectorIncaberryBatchNoForkId7(t *testing.T) {
+func TestExecutorSelectorFirstConfiguredExecutor(t *testing.T) {
 	mockIncaberry := mock_syncinterfaces.NewSyncTrustedStateExecutor(t)
 	mock1Etrog := mock_syncinterfaces.NewSyncTrustedStateExecutor(t)
 	mockState := mock_syncinterfaces.NewStateFullInterface(t)
-	mockState.EXPECT().GetForkIDInMemory(uint64(7)).Return(nil)
-	sut := l2_shared.NewSyncTrustedStateExecutorSelector(mockIncaberry, mock1Etrog, mockState)
+	mockState.EXPECT().GetForkIDByBatchNumber(uint64(1 + 1)).Return(uint64(6))
+	forkIdInterval := state.ForkIDInterval{
+		FromBatchNumber: 0,
+		ToBatchNumber:   ^uint64(0),
+	}
+	mockState.EXPECT().GetForkIDInMemory(uint64(6)).Return(&forkIdInterval)
+	sut := l2_shared.NewSyncTrustedStateExecutorSelector(map[uint64]syncinterfaces.SyncTrustedStateExecutor{
+		uint64(6): mockIncaberry,
+		uint64(7): mock1Etrog,
+	}, mockState)
 
 	executor, maxBatch := sut.GetExecutor(1, 200)
 	require.Equal(t, mockIncaberry, executor)
 	require.Equal(t, uint64(200), maxBatch)
 }
 
-func TestExecutorSelectorIncaberryBatchForkId7(t *testing.T) {
+func TestExecutorSelectorFirstExecutorCapped(t *testing.T) {
 	mockIncaberry := mock_syncinterfaces.NewSyncTrustedStateExecutor(t)
 	mock1Etrog := mock_syncinterfaces.NewSyncTrustedStateExecutor(t)
 	mockState := mock_syncinterfaces.NewStateFullInterface(t)
 	interval := state.ForkIDInterval{
-		FromBatchNumber: 100,
-		ToBatchNumber:   200,
-		ForkId:          7,
+		FromBatchNumber: 1,
+		ToBatchNumber:   99,
+		ForkId:          6,
 	}
-	mockState.EXPECT().GetForkIDInMemory(uint64(7)).Return(&interval)
-	sut := l2_shared.NewSyncTrustedStateExecutorSelector(mockIncaberry, mock1Etrog, mockState)
+	mockState.EXPECT().GetForkIDByBatchNumber(uint64(1 + 1)).Return(uint64(6))
+	mockState.EXPECT().GetForkIDInMemory(uint64(6)).Return(&interval)
+	sut := l2_shared.NewSyncTrustedStateExecutorSelector(map[uint64]syncinterfaces.SyncTrustedStateExecutor{
+		uint64(6): mockIncaberry,
+		uint64(7): mock1Etrog,
+	}, mockState)
 
 	executor, maxBatch := sut.GetExecutor(1, 200)
 	require.Equal(t, mockIncaberry, executor)
@@ -52,8 +65,12 @@ func TestExecutorSelectorEtrogBatchForkId7(t *testing.T) {
 		ToBatchNumber:   300,
 		ForkId:          7,
 	}
+	mockState.EXPECT().GetForkIDByBatchNumber(uint64(100 + 1)).Return(uint64(7))
 	mockState.EXPECT().GetForkIDInMemory(uint64(7)).Return(&interval)
-	sut := l2_shared.NewSyncTrustedStateExecutorSelector(mockIncaberry, mock1Etrog, mockState)
+	sut := l2_shared.NewSyncTrustedStateExecutorSelector(map[uint64]syncinterfaces.SyncTrustedStateExecutor{
+		uint64(6): mockIncaberry,
+		uint64(7): mock1Etrog,
+	}, mockState)
 
 	executor, maxBatch := sut.GetExecutor(100, 200)
 	require.Equal(t, mockIncaberry, executor)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -114,7 +114,11 @@ func NewSynchronizer(
 	syncTrustedStateEtrog := l2_sync_etrog.NewSyncTrustedBatchExecutorForEtrog(res.zkEVMClient, res.state, res.state, res,
 		syncCommon.DefaultTimeProvider{}, L1SyncChecker)
 
-	res.syncTrustedStateExecutor = syncTrustedStateEtrog
+	res.syncTrustedStateExecutor = l2_shared.NewSyncTrustedStateExecutorSelector(map[uint64]syncinterfaces.SyncTrustedStateExecutor{
+		uint64(state.FORKID_ETROG):      syncTrustedStateEtrog,
+		uint64(state.FORKID_ELDERBERRY): syncTrustedStateEtrog,
+	}, res.state)
+
 	res.l1EventProcessors = defaultsL1EventProcessors(res)
 	switch cfg.L1SynchronizationMode {
 	case ParallelMode:

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -387,6 +387,8 @@ func (s *ClientSynchronizer) Sync() error {
 							}
 						} else if errors.Is(err, syncinterfaces.ErrMissingSyncFromL1) {
 							log.Info("Syncing from trusted node need data from L1")
+						} else if errors.Is(err, syncinterfaces.ErrCantSyncFromL2) {
+							log.Info("Can't sync from L2, going to sync from L1")
 						} else {
 							// We break for resync from Trusted
 							log.Debug("Sleeping for 1 second to avoid respawn too fast, error: ", err)

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -56,6 +56,13 @@ func TestGivenPermissionlessNodeWhenSyncronizeAgainSameBatchThenUseTheOneInMemor
 	batch10With3Tx := createBatch(t, lastBatchNumber, 3, ETROG_MODE_FLAG)
 	previousBatch09 := createBatch(t, lastBatchNumber-1, 1, ETROG_MODE_FLAG)
 
+	forkIdInterval := state.ForkIDInterval{
+		FromBatchNumber: 0,
+		ToBatchNumber:   ^uint64(0),
+	}
+	m.State.EXPECT().GetForkIDInMemory(uint64(7)).Return(&forkIdInterval)
+	m.State.EXPECT().GetForkIDByBatchNumber(lastBatchNumber + 1).Return(uint64(7))
+
 	expectedCallsForsyncTrustedState(t, m, sync, nil, batch10With2Tx, previousBatch09, RETRIEVE_BATCH_FROM_DB_FLAG, ETROG_MODE_FLAG)
 	// Is the first time that appears this batch, so it need to OpenBatch
 	expectedCallsForOpenBatch(t, m, sync, lastBatchNumber)
@@ -88,6 +95,13 @@ func TestGivenPermissionlessNodeWhenSyncronizeFirstTimeABatchThenStoreItInALocal
 	batch10With1Tx := createBatch(t, lastBatchNumber, 1, ETROG_MODE_FLAG)
 	batch10With2Tx := createBatch(t, lastBatchNumber, 2, ETROG_MODE_FLAG)
 	previousBatch09 := createBatch(t, lastBatchNumber-1, 1, ETROG_MODE_FLAG)
+
+	forkIdInterval := state.ForkIDInterval{
+		FromBatchNumber: 0,
+		ToBatchNumber:   ^uint64(0),
+	}
+	m.State.EXPECT().GetForkIDInMemory(uint64(7)).Return(&forkIdInterval)
+	m.State.EXPECT().GetForkIDByBatchNumber(lastBatchNumber + 1).Return(uint64(7))
 
 	// This is a incremental process, permissionless have batch10With1Tx and we add a new block
 	// but the cache doesnt have this information so it need to get from db
@@ -126,6 +140,11 @@ func TestForcedBatchEtrog(t *testing.T) {
 
 	// state preparation
 	ctxMatchBy := mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })
+	forkIdInterval := state.ForkIDInterval{
+		FromBatchNumber: 0,
+		ToBatchNumber:   ^uint64(0),
+	}
+	m.State.EXPECT().GetForkIDInMemory(uint64(7)).Return(&forkIdInterval)
 
 	m.State.
 		On("BeginStateTransaction", ctxMatchBy).


### PR DESCRIPTION

### What does this PR do?
* Fix commented etherman tests
* Don't assume the forkid that belongs the batch that receive from a trusted node, check that is supported before execute it.
### Reviewers

Main reviewers:

- @agnusmor 
- @ToniRamirezM 
- @tclemos 
- @ARR552 
- 
Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
