### PR TITLE
cherry-pick: synchronizer adopt GetLastL2BlockByBatchNumber to check elderberry tstamp baches (#3340)

### DIFF
--- a/synchronizer/actions/elderberry/mocks/state_l1_sequence_batches_elderberry.go
+++ b/synchronizer/actions/elderberry/mocks/state_l1_sequence_batches_elderberry.go
@@ -25,24 +25,24 @@ func (_m *StateL1SequenceBatchesElderberry) EXPECT() *StateL1SequenceBatchesElde
 	return &StateL1SequenceBatchesElderberry_Expecter{mock: &_m.Mock}
 }
 
-// GetL2BlocksByBatchNumber provides a mock function with given fields: ctx, batchNumber, dbTx
-func (_m *StateL1SequenceBatchesElderberry) GetL2BlocksByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]state.L2Block, error) {
+// GetLastL2BlockByBatchNumber provides a mock function with given fields: ctx, batchNumber, dbTx
+func (_m *StateL1SequenceBatchesElderberry) GetLastL2BlockByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.L2Block, error) {
 	ret := _m.Called(ctx, batchNumber, dbTx)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetL2BlocksByBatchNumber")
+		panic("no return value specified for GetLastL2BlockByBatchNumber")
 	}
 
-	var r0 []state.L2Block
+	var r0 *state.L2Block
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) ([]state.L2Block, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) (*state.L2Block, error)); ok {
 		return rf(ctx, batchNumber, dbTx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) []state.L2Block); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) *state.L2Block); ok {
 		r0 = rf(ctx, batchNumber, dbTx)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]state.L2Block)
+			r0 = ret.Get(0).(*state.L2Block)
 		}
 	}
 
@@ -55,32 +55,32 @@ func (_m *StateL1SequenceBatchesElderberry) GetL2BlocksByBatchNumber(ctx context
 	return r0, r1
 }
 
-// StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetL2BlocksByBatchNumber'
-type StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call struct {
+// StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastL2BlockByBatchNumber'
+type StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call struct {
 	*mock.Call
 }
 
-// GetL2BlocksByBatchNumber is a helper method to define mock.On call
+// GetLastL2BlockByBatchNumber is a helper method to define mock.On call
 //   - ctx context.Context
 //   - batchNumber uint64
 //   - dbTx pgx.Tx
-func (_e *StateL1SequenceBatchesElderberry_Expecter) GetL2BlocksByBatchNumber(ctx interface{}, batchNumber interface{}, dbTx interface{}) *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call {
-	return &StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call{Call: _e.mock.On("GetL2BlocksByBatchNumber", ctx, batchNumber, dbTx)}
+func (_e *StateL1SequenceBatchesElderberry_Expecter) GetLastL2BlockByBatchNumber(ctx interface{}, batchNumber interface{}, dbTx interface{}) *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call {
+	return &StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call{Call: _e.mock.On("GetLastL2BlockByBatchNumber", ctx, batchNumber, dbTx)}
 }
 
-func (_c *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call) Run(run func(ctx context.Context, batchNumber uint64, dbTx pgx.Tx)) *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call {
+func (_c *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call) Run(run func(ctx context.Context, batchNumber uint64, dbTx pgx.Tx)) *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
 	})
 	return _c
 }
 
-func (_c *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call) Return(_a0 []state.L2Block, _a1 error) *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call {
+func (_c *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call) Return(_a0 *state.L2Block, _a1 error) *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) ([]state.L2Block, error)) *StateL1SequenceBatchesElderberry_GetL2BlocksByBatchNumber_Call {
+func (_c *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) (*state.L2Block, error)) *StateL1SequenceBatchesElderberry_GetLastL2BlockByBatchNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
+++ b/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
@@ -1216,66 +1216,6 @@ func (_c *StateFullInterface_GetL1InfoTreeDataFromBatchL2Data_Call) RunAndReturn
 	return _c
 }
 
-// GetL2BlocksByBatchNumber provides a mock function with given fields: ctx, batchNumber, dbTx
-func (_m *StateFullInterface) GetL2BlocksByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]state.L2Block, error) {
-	ret := _m.Called(ctx, batchNumber, dbTx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetL2BlocksByBatchNumber")
-	}
-
-	var r0 []state.L2Block
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) ([]state.L2Block, error)); ok {
-		return rf(ctx, batchNumber, dbTx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) []state.L2Block); ok {
-		r0 = rf(ctx, batchNumber, dbTx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]state.L2Block)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
-		r1 = rf(ctx, batchNumber, dbTx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// StateFullInterface_GetL2BlocksByBatchNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetL2BlocksByBatchNumber'
-type StateFullInterface_GetL2BlocksByBatchNumber_Call struct {
-	*mock.Call
-}
-
-// GetL2BlocksByBatchNumber is a helper method to define mock.On call
-//   - ctx context.Context
-//   - batchNumber uint64
-//   - dbTx pgx.Tx
-func (_e *StateFullInterface_Expecter) GetL2BlocksByBatchNumber(ctx interface{}, batchNumber interface{}, dbTx interface{}) *StateFullInterface_GetL2BlocksByBatchNumber_Call {
-	return &StateFullInterface_GetL2BlocksByBatchNumber_Call{Call: _e.mock.On("GetL2BlocksByBatchNumber", ctx, batchNumber, dbTx)}
-}
-
-func (_c *StateFullInterface_GetL2BlocksByBatchNumber_Call) Run(run func(ctx context.Context, batchNumber uint64, dbTx pgx.Tx)) *StateFullInterface_GetL2BlocksByBatchNumber_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
-	})
-	return _c
-}
-
-func (_c *StateFullInterface_GetL2BlocksByBatchNumber_Call) Return(_a0 []state.L2Block, _a1 error) *StateFullInterface_GetL2BlocksByBatchNumber_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *StateFullInterface_GetL2BlocksByBatchNumber_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) ([]state.L2Block, error)) *StateFullInterface_GetL2BlocksByBatchNumber_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetLastBatchNumber provides a mock function with given fields: ctx, dbTx
 func (_m *StateFullInterface) GetLastBatchNumber(ctx context.Context, dbTx pgx.Tx) (uint64, error) {
 	ret := _m.Called(ctx, dbTx)
@@ -1388,6 +1328,66 @@ func (_c *StateFullInterface_GetLastBlock_Call) Return(_a0 *state.Block, _a1 err
 }
 
 func (_c *StateFullInterface_GetLastBlock_Call) RunAndReturn(run func(context.Context, pgx.Tx) (*state.Block, error)) *StateFullInterface_GetLastBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetLastL2BlockByBatchNumber provides a mock function with given fields: ctx, batchNumber, dbTx
+func (_m *StateFullInterface) GetLastL2BlockByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.L2Block, error) {
+	ret := _m.Called(ctx, batchNumber, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastL2BlockByBatchNumber")
+	}
+
+	var r0 *state.L2Block
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) (*state.L2Block, error)); ok {
+		return rf(ctx, batchNumber, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) *state.L2Block); ok {
+		r0 = rf(ctx, batchNumber, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*state.L2Block)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, batchNumber, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StateFullInterface_GetLastL2BlockByBatchNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastL2BlockByBatchNumber'
+type StateFullInterface_GetLastL2BlockByBatchNumber_Call struct {
+	*mock.Call
+}
+
+// GetLastL2BlockByBatchNumber is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchNumber uint64
+//   - dbTx pgx.Tx
+func (_e *StateFullInterface_Expecter) GetLastL2BlockByBatchNumber(ctx interface{}, batchNumber interface{}, dbTx interface{}) *StateFullInterface_GetLastL2BlockByBatchNumber_Call {
+	return &StateFullInterface_GetLastL2BlockByBatchNumber_Call{Call: _e.mock.On("GetLastL2BlockByBatchNumber", ctx, batchNumber, dbTx)}
+}
+
+func (_c *StateFullInterface_GetLastL2BlockByBatchNumber_Call) Run(run func(ctx context.Context, batchNumber uint64, dbTx pgx.Tx)) *StateFullInterface_GetLastL2BlockByBatchNumber_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StateFullInterface_GetLastL2BlockByBatchNumber_Call) Return(_a0 *state.L2Block, _a1 error) *StateFullInterface_GetLastL2BlockByBatchNumber_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *StateFullInterface_GetLastL2BlockByBatchNumber_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) (*state.L2Block, error)) *StateFullInterface_GetLastL2BlockByBatchNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/synchronizer/common/syncinterfaces/state.go
+++ b/synchronizer/common/syncinterfaces/state.go
@@ -69,5 +69,5 @@ type StateFullInterface interface {
 	GetL1InfoTreeDataFromBatchL2Data(ctx context.Context, batchL2Data []byte, dbTx pgx.Tx) (map[uint32]state.L1DataV2, common.Hash, common.Hash, error)
 	GetExitRootByGlobalExitRoot(ctx context.Context, ger common.Hash, dbTx pgx.Tx) (*state.GlobalExitRoot, error)
 	GetForkIDInMemory(forkId uint64) *state.ForkIDInterval
-	GetL2BlocksByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) ([]state.L2Block, error)
+	GetLastL2BlockByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*state.L2Block, error)
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -122,7 +122,7 @@ test-full-non-e2e: stop ## Runs non-e2e tests checking race conditions
 	sleep 15
 	docker ps -a
 	docker logs $(DOCKERCOMPOSEZKPROVER)
-	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -short -race -p 1 -covermode=atomic -coverprofile=../coverage.out -timeout 70s ../...
+	trap '$(STOP)' EXIT; MallocNanoZone=0 go test -count=1 -short -race -p 1 -covermode=atomic -coverprofile=../coverage.out  -coverpkg ./... -timeout 70s ../...
 
 .PHONY: test-e2e-group-1
 test-e2e-group-1: stop ## Runs group 1 e2e tests checking race conditions


### PR DESCRIPTION
PR: https://github.com/0xPolygonHermez/zkevm-node/pull/3340 
branch: `release/v0.6.0`

### What does this PR do?

* synchronizer adopt GetLastL2BlockByBatchNumber to check elderberry bacthes tstamp





Main reviewers:

- @agnusmor 
- @ToniRamirezM 
- @dpunish3r 
- @tclemos 
-