### PR TITLE
remove unnecessary eventlog call when processing unsigned txs

### DIFF
--- a/state/transaction.go
+++ b/state/transaction.go
@@ -604,7 +604,6 @@ func (s *State) internalProcessUnsignedTransactionV2(ctx context.Context, tx *ty
 
 	if processBatchResponseV2.ErrorRom != executor.RomError_ROM_ERROR_NO_ERROR {
 		err = executor.RomErr(processBatchResponseV2.ErrorRom)
-		s.eventLog.LogExecutorErrorV2(ctx, processBatchResponseV2.Error, processBatchRequestV2)
 		if executor.IsROMOutOfCountersError(executor.RomErrorCode(err)) {
 			return response, err
 		}


### PR DESCRIPTION
Closes #3363.

### What does this PR do?

remove unnecessary eventlog call when processing unsigned txs