### PR TITLE
cherry-pick: Synchronized inform field state.batch.closing_reason from DB

### DIFF
--- a/state/batch.go
+++ b/state/batch.go
@@ -60,6 +60,7 @@ type ProcessingContext struct {
 	GlobalExitRoot common.Hash
 	ForcedBatchNum *uint64
 	BatchL2Data    *[]byte
+	ClosingReason  ClosingReason
 }
 
 // ClosingReason represents the reason why a batch is closed.
@@ -82,6 +83,22 @@ const (
 	MaxDeltaTimestampClosingReason ClosingReason = "Max delta timestamp"
 	// NoTxFitsClosingReason is the closing reason used when any of the txs in the pool (worker) fits in the remaining resources of the batch
 	NoTxFitsClosingReason ClosingReason = "No transaction fits"
+
+	// Reason due Synchronizer
+	// ------------------------------------------------------------------------------------------
+
+	// SyncL1EventInitialBatchClosingReason is the closing reason used when a batch is closed by the synchronizer due to an initial batch (first batch mode forced)
+	SyncL1EventInitialBatchClosingReason ClosingReason = "Sync L1: initial"
+	// SyncL1EventSequencedBatchClosingReason is the closing reason used when a batch is closed by the synchronizer due to a sequenced batch event from L1
+	SyncL1EventSequencedBatchClosingReason ClosingReason = "Sync L1: sequenced"
+	// SyncL1EventSequencedForcedBatchClosingReason is the closing reason used when a batch is closed by the synchronizer due to a sequenced forced batch event from L1
+	SyncL1EventSequencedForcedBatchClosingReason ClosingReason = "Sync L1: forced"
+	// SyncL1EventUpdateEtrogSequenceClosingReason is the closing reason used when a batch is closed by the synchronizer due to an UpdateEtrogSequence event from L1 that inject txs
+	SyncL1EventUpdateEtrogSequenceClosingReason ClosingReason = "Sync L1: injected"
+	// SyncL2TrustedBatchClosingReason is the closing reason used when a batch is closed by the synchronizer due to a trusted batch from L2
+	SyncL2TrustedBatchClosingReason ClosingReason = "Sync L2: trusted"
+	// SyncGenesisBatchClosingReason is the closing reason used when genesis batch is created by synchronizer
+	SyncGenesisBatchClosingReason ClosingReason = "Sync: genesis"
 )
 
 // ProcessingReceipt indicates the outcome (StateRoot, AccInputHash) of processing a batch

--- a/state/batchV2.go
+++ b/state/batchV2.go
@@ -34,6 +34,7 @@ type ProcessingContextV2 struct {
 	SkipVerifyL1InfoRoot uint32
 	GlobalExitRoot       common.Hash // GlobalExitRoot is not use for execute but use to OpenBatch (data on  DB)
 	ExecutionMode        uint64
+	ClosingReason        ClosingReason
 }
 
 // ProcessBatchV2 processes a batch for forkID >= ETROG
@@ -415,5 +416,6 @@ func (s *State) ProcessAndStoreClosedBatchV2(ctx context.Context, processingCtx 
 		LocalExitRoot: processedBatch.NewLocalExitRoot,
 		AccInputHash:  processedBatch.NewAccInputHash,
 		BatchL2Data:   *BatchL2Data,
+		ClosingReason: processingCtx.ClosingReason,
 	}, dbTx)
 }

--- a/state/convertersV2.go
+++ b/state/convertersV2.go
@@ -370,6 +370,7 @@ func convertProcessingContext(p *ProcessingContextV2) (*ProcessingContext, error
 		BatchL2Data:    p.BatchL2Data,
 		Timestamp:      tstamp,
 		GlobalExitRoot: p.GlobalExitRoot,
+		ClosingReason:  p.ClosingReason,
 	}
 	return &result, nil
 }

--- a/state/genesis.go
+++ b/state/genesis.go
@@ -146,7 +146,7 @@ func (s *State) SetGenesis(ctx context.Context, block Block, genesis Genesis, m 
 		ForcedBatchNum: nil,
 	}
 
-	err = s.StoreGenesisBatch(ctx, batch, dbTx)
+	err = s.StoreGenesisBatch(ctx, batch, string(SyncGenesisBatchClosingReason), dbTx)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -15,7 +15,7 @@ type storage interface {
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
 	Begin(ctx context.Context) (pgx.Tx, error)
-	StoreGenesisBatch(ctx context.Context, batch Batch, dbTx pgx.Tx) error
+	StoreGenesisBatch(ctx context.Context, batch Batch, closingReason string, dbTx pgx.Tx) error
 	ResetToL1BlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) error
 	ResetForkID(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error
 	ResetTrustedState(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) error

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -8004,17 +8004,17 @@ func (_c *StorageMock_SetLastBatchInfoSeenOnEthereum_Call) RunAndReturn(run func
 	return _c
 }
 
-// StoreGenesisBatch provides a mock function with given fields: ctx, batch, dbTx
-func (_m *StorageMock) StoreGenesisBatch(ctx context.Context, batch state.Batch, dbTx pgx.Tx) error {
-	ret := _m.Called(ctx, batch, dbTx)
+// StoreGenesisBatch provides a mock function with given fields: ctx, batch, closingReason, dbTx
+func (_m *StorageMock) StoreGenesisBatch(ctx context.Context, batch state.Batch, closingReason string, dbTx pgx.Tx) error {
+	ret := _m.Called(ctx, batch, closingReason, dbTx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StoreGenesisBatch")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, state.Batch, pgx.Tx) error); ok {
-		r0 = rf(ctx, batch, dbTx)
+	if rf, ok := ret.Get(0).(func(context.Context, state.Batch, string, pgx.Tx) error); ok {
+		r0 = rf(ctx, batch, closingReason, dbTx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -8030,14 +8030,15 @@ type StorageMock_StoreGenesisBatch_Call struct {
 // StoreGenesisBatch is a helper method to define mock.On call
 //   - ctx context.Context
 //   - batch state.Batch
+//   - closingReason string
 //   - dbTx pgx.Tx
-func (_e *StorageMock_Expecter) StoreGenesisBatch(ctx interface{}, batch interface{}, dbTx interface{}) *StorageMock_StoreGenesisBatch_Call {
-	return &StorageMock_StoreGenesisBatch_Call{Call: _e.mock.On("StoreGenesisBatch", ctx, batch, dbTx)}
+func (_e *StorageMock_Expecter) StoreGenesisBatch(ctx interface{}, batch interface{}, closingReason interface{}, dbTx interface{}) *StorageMock_StoreGenesisBatch_Call {
+	return &StorageMock_StoreGenesisBatch_Call{Call: _e.mock.On("StoreGenesisBatch", ctx, batch, closingReason, dbTx)}
 }
 
-func (_c *StorageMock_StoreGenesisBatch_Call) Run(run func(ctx context.Context, batch state.Batch, dbTx pgx.Tx)) *StorageMock_StoreGenesisBatch_Call {
+func (_c *StorageMock_StoreGenesisBatch_Call) Run(run func(ctx context.Context, batch state.Batch, closingReason string, dbTx pgx.Tx)) *StorageMock_StoreGenesisBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(state.Batch), args[2].(pgx.Tx))
+		run(args[0].(context.Context), args[1].(state.Batch), args[2].(string), args[3].(pgx.Tx))
 	})
 	return _c
 }
@@ -8047,7 +8048,7 @@ func (_c *StorageMock_StoreGenesisBatch_Call) Return(_a0 error) *StorageMock_Sto
 	return _c
 }
 
-func (_c *StorageMock_StoreGenesisBatch_Call) RunAndReturn(run func(context.Context, state.Batch, pgx.Tx) error) *StorageMock_StoreGenesisBatch_Call {
+func (_c *StorageMock_StoreGenesisBatch_Call) RunAndReturn(run func(context.Context, state.Batch, string, pgx.Tx) error) *StorageMock_StoreGenesisBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -558,8 +558,8 @@ func (p *PostgresStorage) GetVirtualBatch(ctx context.Context, batchNumber uint6
 	return &virtualBatch, nil
 }
 
-func (p *PostgresStorage) StoreGenesisBatch(ctx context.Context, batch state.Batch, dbTx pgx.Tx) error {
-	const addGenesisBatchSQL = "INSERT INTO state.batch (batch_num, global_exit_root, local_exit_root, acc_input_hash, state_root, timestamp, coinbase, raw_txs_data, forced_batch_num, wip) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, FALSE)"
+func (p *PostgresStorage) StoreGenesisBatch(ctx context.Context, batch state.Batch, closingReason string, dbTx pgx.Tx) error {
+	const addGenesisBatchSQL = "INSERT INTO state.batch (batch_num, global_exit_root, local_exit_root, acc_input_hash, state_root, timestamp, coinbase, raw_txs_data, forced_batch_num,closing_reason, wip) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,$10, FALSE)"
 
 	if batch.BatchNumber != 0 {
 		return fmt.Errorf("%w. Got %d, should be 0", state.ErrUnexpectedBatch, batch.BatchNumber)
@@ -577,6 +577,7 @@ func (p *PostgresStorage) StoreGenesisBatch(ctx context.Context, batch state.Bat
 		batch.Coinbase.String(),
 		batch.BatchL2Data,
 		batch.ForcedBatchNum,
+		closingReason,
 	)
 
 	return err

--- a/synchronizer/actions/etrog/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/etrog/processor_l1_sequence_batches.go
@@ -157,6 +157,7 @@ func (p *ProcessorL1SequenceBatchesEtrog) ProcessSequenceBatches(ctx context.Con
 				ForcedBlockHashL1:    forcedBlockHashL1,
 				SkipVerifyL1InfoRoot: 1,
 				ExecutionMode:        executor.ExecutionMode1,
+				ClosingReason:        state.SyncL1EventSequencedForcedBatchClosingReason,
 			}
 		} else if sbatch.PolygonRollupBaseEtrogBatchData.ForcedTimestamp > 0 && sbatch.BatchNumber == 1 {
 			log.Debug("Processing initial batch")
@@ -174,6 +175,7 @@ func (p *ProcessorL1SequenceBatchesEtrog) ProcessSequenceBatches(ctx context.Con
 				ForcedBlockHashL1:    forcedBlockHashL1,
 				SkipVerifyL1InfoRoot: 1,
 				ExecutionMode:        executor.ExecutionMode1,
+				ClosingReason:        state.SyncL1EventInitialBatchClosingReason,
 			}
 		} else {
 			var maxGER common.Hash
@@ -199,6 +201,7 @@ func (p *ProcessorL1SequenceBatchesEtrog) ProcessSequenceBatches(ctx context.Con
 				SkipVerifyL1InfoRoot: 1,
 				GlobalExitRoot:       batch.GlobalExitRoot,
 				ExecutionMode:        executor.ExecutionMode1,
+				ClosingReason:        state.SyncL1EventSequencedBatchClosingReason,
 			}
 			if batch.GlobalExitRoot == (common.Hash{}) {
 				if len(leaves) > 0 {

--- a/synchronizer/actions/etrog/processor_l1_update_etrog_sequence.go
+++ b/synchronizer/actions/etrog/processor_l1_update_etrog_sequence.go
@@ -85,6 +85,7 @@ func (g *ProcessorL1UpdateEtrogSequence) processUpdateEtrogSequence(ctx context.
 		SkipVerifyL1InfoRoot: 1,
 		GlobalExitRoot:       updateEtrogSequence.PolygonRollupBaseEtrogBatchData.ForcedGlobalExitRoot,
 		ExecutionMode:        executor.ExecutionMode1,
+		ClosingReason:        state.SyncL1EventUpdateEtrogSequenceClosingReason,
 	}
 
 	virtualBatch := state.VirtualBatch{

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
@@ -324,6 +324,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) CloseBatch(ctx context.Context, trust
 		LocalExitRoot: trustedBatch.LocalExitRoot,
 		BatchL2Data:   trustedBatch.BatchL2Data,
 		AccInputHash:  trustedBatch.AccInputHash,
+		ClosingReason: state.SyncL2TrustedBatchClosingReason,
 	}
 	log.Debugf("%s closing batch %v", debugStr, trustedBatch.Number)
 	// This update SET state_root = $1, local_exit_root = $2, acc_input_hash = $3, raw_txs_data = $4, batch_resources = $5, closing_reason = $6, wip = FALSE


### PR DESCRIPTION
Close #3243
original PR: https://github.com/0xPolygonHermez/zkevm-node/pull/3245

The field `state.batch.closing_reason` is use by `sequencer` to report the reason that close this batch. Make sense that `syncrhonizer` when close a batch also report this value. 

The suggested values are: 
- `Sync: genesis` : Batch genesis
- `Sync L1: sequenced` : a batch have been created and closed due a sequencedBatch event
- `Sync L1: injected` injected batch (update etrog batch event)
- `Sync L2: trusted` : a batch synchronized from TrustedNodeAnd so on....
And so on....

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @tclemos 
- @agnusmor 
- @ToniRamirezM 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
