### PR TITLE
remove unnecessary eventlog call when processing unsigned txs (#3365)

### DIFF
--- a/state/transaction.go
+++ b/state/transaction.go
@@ -603,7 +603,6 @@ func (s *State) internalProcessUnsignedTransactionV2(ctx context.Context, tx *ty
 
 	if processBatchResponseV2.ErrorRom != executor.RomError_ROM_ERROR_NO_ERROR {
 		err = executor.RomErr(processBatchResponseV2.ErrorRom)
-		s.eventLog.LogExecutorErrorV2(ctx, processBatchResponseV2.Error, processBatchRequestV2)
 		if executor.IsROMOutOfCountersError(executor.RomErrorCode(err)) {
 			return response, err
 		}


### PR DESCRIPTION
Closes #3368.

remove unnecessary eventlog call when processing unsigned txs (#3365)