### PR TITLE
Fix gaslimit and cumulativeGasUsed for Elderberry transactions

### DIFF
--- a/state/convertersV2.go
+++ b/state/convertersV2.go
@@ -127,6 +127,7 @@ func (s *State) convertToProcessTransactionResponseV2(responses []*executor.Proc
 		result.ReturnValue = response.ReturnValue
 		result.GasLeft = response.GasLeft
 		result.GasUsed = response.GasUsed
+		result.CumulativeGasUsed = response.CumulativeGasUsed
 		result.GasRefunded = response.GasRefunded
 		result.RomError = executor.RomErr(response.Error)
 		result.CreateAddress = common.HexToAddress(response.CreateAddress)

--- a/state/helper.go
+++ b/state/helper.go
@@ -281,19 +281,20 @@ func DecodeTx(encodedTx string) (*types.Transaction, error) {
 // GenerateReceipt generates a receipt from a processed transaction
 func GenerateReceipt(blockNumber *big.Int, processedTx *ProcessTransactionResponse, txIndex uint, forkID uint64) *types.Receipt {
 	receipt := &types.Receipt{
-		Type:              uint8(processedTx.Type),
-		CumulativeGasUsed: processedTx.GasUsed,
-		BlockNumber:       blockNumber,
-		GasUsed:           processedTx.GasUsed,
-		TxHash:            processedTx.Tx.Hash(),
-		TransactionIndex:  txIndex,
-		ContractAddress:   processedTx.CreateAddress,
-		Logs:              processedTx.Logs,
+		Type:             uint8(processedTx.Type),
+		BlockNumber:      blockNumber,
+		GasUsed:          processedTx.GasUsed,
+		TxHash:           processedTx.Tx.Hash(),
+		TransactionIndex: txIndex,
+		ContractAddress:  processedTx.CreateAddress,
+		Logs:             processedTx.Logs,
 	}
 	if forkID <= FORKID_ETROG {
 		receipt.PostState = processedTx.StateRoot.Bytes()
+		receipt.CumulativeGasUsed = processedTx.GasUsed
 	} else {
 		receipt.PostState = ZeroHash.Bytes()
+		receipt.CumulativeGasUsed = processedTx.CumulativeGasUsed
 	}
 	if processedTx.EffectiveGasPrice != "" {
 		effectiveGasPrice, ok := big.NewInt(0).SetString(processedTx.EffectiveGasPrice, 0)

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -211,12 +211,13 @@ func (s *State) StoreL2Block(ctx context.Context, batchNumber uint64, l2Block *P
 		return err
 	}
 
+	forkID := s.GetForkIDByBatchNumber(batchNumber)
+
 	gasLimit := l2Block.GasLimit
-	if gasLimit > MaxL2BlockGasLimit {
+	// We check/set the maximum value of gasLimit for batches <= to ETROG fork. For batches >= to ELDERBERRY fork we use always the value returned by the executor
+	if forkID <= FORKID_ETROG && gasLimit > MaxL2BlockGasLimit {
 		gasLimit = MaxL2BlockGasLimit
 	}
-
-	forkID := s.GetForkIDByBatchNumber(batchNumber)
 
 	header := &types.Header{
 		Number:     new(big.Int).SetUint64(l2Block.BlockNumber),

--- a/state/types.go
+++ b/state/types.go
@@ -100,6 +100,8 @@ type ProcessTransactionResponse struct {
 	GasLeft uint64
 	// GasUsed is the total gas used as result of execution or gas estimation
 	GasUsed uint64
+	// CumulativeGasUsed is the accumulated gas used (sum of tx GasUsed and CumulativeGasUsed of the previous tx in the L2 block)
+	CumulativeGasUsed uint64
 	// GasRefunded is the total gas refunded as result of execution
 	GasRefunded uint64
 	// RomError represents any error encountered during the execution


### PR DESCRIPTION
Closes #3418, #3426, #3425 

### What does this PR do?

- Use always gasLimit returned by the executor in tx receipt for Elderberry txs (apply only MaxL2BlockGasLimit for txs <= Etrog)
- Fix CumulativeGasUsed in tx receipt

### Reviewers

Main reviewers:

@ToniRamirezM 
@tclemos 
@joan-esteban 