### PR TITLE
Cherry-pick #3430: Fix keep empty RPC.SequencerNodeURI config parameter to get node URI from the SC

### DIFF
--- a/config/environments/cardona/node.config.toml
+++ b/config/environments/cardona/node.config.toml
@@ -45,7 +45,7 @@ Port = 8545
 ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
-SequencerNodeURI = "https://rpc.devnet.zkevm-rpc.com"
+SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = false
 	[RPC.WebSockets]
 		Enabled = true

--- a/config/environments/mainnet/node.config.toml
+++ b/config/environments/mainnet/node.config.toml
@@ -43,7 +43,7 @@ Port = 8545
 ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
-SequencerNodeURI = "https://zkevm-rpc.com"
+SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = false
 	[RPC.WebSockets]
 		Enabled = true

--- a/config/environments/testnet/node.config.toml
+++ b/config/environments/testnet/node.config.toml
@@ -45,7 +45,7 @@ Port = 8545
 ReadTimeout = "60s"
 WriteTimeout = "60s"
 MaxRequestsPerIPAndSecond = 5000
-SequencerNodeURI = "https://rpc.public.zkevm-test.net/"
+SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = false
 	[RPC.WebSockets]
 		Enabled = true


### PR DESCRIPTION
### What does this PR do?

Cherry-pick from #3430 

### Reviewers

Main reviewers:

@joanestebanr 
@tclemos 