### PR TITLE
synchronizer: fix bug closing a batch when sync from L1

### DIFF
--- a/synchronizer/actions/etrog/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/etrog/processor_l1_sequence_batches.go
@@ -381,6 +381,11 @@ func (p *ProcessorL1SequenceBatchesEtrog) checkTrustedState(ctx context.Context,
 		log.Warnf(errMsg)
 		reorgReasons.WriteString(errMsg)
 	}
+	if tBatch.WIP {
+		errMsg := batchNumStr + "Trusted batch is WIP\n"
+		log.Warnf(errMsg)
+		reorgReasons.WriteString(errMsg)
+	}
 
 	if reorgReasons.Len() > 0 {
 		reason := reorgReasons.String()


### PR DESCRIPTION
Closes #3441

### What does this PR do?
If a batch is open in local DB it's reprocessed

### Reviewers

Main reviewers:

- @agnusmor 
- @ARR552 
- @tclemos 

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
