### PR TITLE
remove unnecessary eventlog call when estimating tx gas

### DIFF
--- a/state/transaction.go
+++ b/state/transaction.go
@@ -1046,7 +1046,6 @@ func (s *State) internalTestGasEstimationTransactionV2(ctx context.Context, batc
 	}
 	if processBatchResponseV2.ErrorRom != executor.RomError_ROM_ERROR_NO_ERROR {
 		err = executor.RomErr(processBatchResponseV2.ErrorRom)
-		s.eventLog.LogExecutorErrorV2(ctx, processBatchResponseV2.Error, processBatchRequestV2)
 		return false, false, gasUsed, nil, err
 	}
 


### PR DESCRIPTION
Closes #3456.

### What does this PR do?

remove unnecessary eventlog call when estimating tx gas