### PR TITLE
use empty byte array instead of all zeros for receipt poststate (#3449)

### DIFF
--- a/jsonrpc/types/types.go
+++ b/jsonrpc/types/types.go
@@ -658,7 +658,7 @@ func NewReceipt(tx types.Transaction, r *types.Receipt, l2Hash *common.Hash) (Re
 		Type:              ArgUint64(r.Type),
 		TxL2Hash:          l2Hash,
 	}
-	if common.BytesToHash(r.PostState).String() != state.ZeroHash.String() {
+	if len(r.PostState) > 0 {
 		root := common.BytesToHash(r.PostState)
 		receipt.Root = &root
 	}

--- a/state/helper.go
+++ b/state/helper.go
@@ -293,7 +293,7 @@ func GenerateReceipt(blockNumber *big.Int, processedTx *ProcessTransactionRespon
 		receipt.PostState = processedTx.StateRoot.Bytes()
 		receipt.CumulativeGasUsed = processedTx.GasUsed
 	} else {
-		receipt.PostState = ZeroHash.Bytes()
+		receipt.PostState = []byte{}
 		receipt.CumulativeGasUsed = processedTx.CumulativeGasUsed
 	}
 	if processedTx.EffectiveGasPrice != "" {


### PR DESCRIPTION
Closes #3458.

### What does this PR do?

use empty byte array instead of all zeros for receipt poststate (#3449)