### PR TITLE
cherry-pick from 0.6.3 #3443 synchronizer: fix bug closing a batch when sync from L1

### DIFF
--- a/synchronizer/actions/etrog/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/etrog/processor_l1_sequence_batches.go
@@ -381,6 +381,11 @@ func (p *ProcessorL1SequenceBatchesEtrog) checkTrustedState(ctx context.Context,
 		log.Warnf(errMsg)
 		reorgReasons.WriteString(errMsg)
 	}
+	if tBatch.WIP {
+		errMsg := batchNumStr + "Trusted batch is WIP\n"
+		log.Warnf(errMsg)
+		reorgReasons.WriteString(errMsg)
+	}
 
 	if reorgReasons.Len() > 0 {
 		reason := reorgReasons.String()


### PR DESCRIPTION
Closes https://github.com/0xPolygonHermez/zkevm-node/issues/3441
previous PR: https://github.com/0xPolygonHermez/zkevm-node/pull/3443
getting from release v0.6.3

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers
@agnusmor 
@ARR552 
@tclemos 
