### PR TITLE
sort logs by tx hash and then by log index (#3476)

### DIFF
--- a/state/pgstatestorage/pgstatestorage.go
+++ b/state/pgstatestorage/pgstatestorage.go
@@ -119,7 +119,7 @@ func (p *PostgresStorage) GetStateRootByBatchNumber(ctx context.Context, batchNu
 	return common.HexToHash(stateRootStr), nil
 }
 
-// GetLogsByBlockNumber get all the logs from a specific block ordered by log index
+// GetLogsByBlockNumber get all the logs from a specific block ordered by tx index and log index
 func (p *PostgresStorage) GetLogsByBlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) ([]*types.Log, error) {
 	const query = `
       SELECT t.l2_block_num, b.block_hash, l.tx_hash, r.tx_index, l.log_index, l.address, l.data, l.topic0, l.topic1, l.topic2, l.topic3
@@ -128,7 +128,7 @@ func (p *PostgresStorage) GetLogsByBlockNumber(ctx context.Context, blockNumber 
        INNER JOIN state.l2block b ON b.block_num = t.l2_block_num
        INNER JOIN state.receipt r ON r.tx_hash = t.hash
        WHERE b.block_num = $1
-       ORDER BY l.log_index ASC`
+       ORDER BY r.tx_index ASC, l.log_index ASC`
 
 	q := p.getExecQuerier(dbTx)
 	rows, err := q.Query(ctx, query, blockNumber)
@@ -159,7 +159,7 @@ func (p *PostgresStorage) GetLogs(ctx context.Context, fromBlock uint64, toBlock
 	const queryFilterByBlockHash = `AND b.block_hash = $7 `
 	const queryFilterByBlockNumbers = `AND b.block_num BETWEEN $7 AND $8 `
 
-	const queryOrder = `ORDER BY b.block_num ASC, l.log_index ASC`
+	const queryOrder = `ORDER BY b.block_num ASC, r.tx_index ASC, l.log_index ASC`
 
 	// count queries
 	const queryToCountLogsByBlockHash = "" +


### PR DESCRIPTION
Closes #3527.

### What does this PR do?

sort logs by tx hash and then by log index (#3476)