### PR TITLE
Stop syncing l1inforoot when invalid l1inforoot is detected

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -48,6 +48,8 @@ const (
 	EventID_UsedZKCountersOverflow EventID = "USED ZKCOUNTERS OVERFLOW"
 	// EventID_ReservedZKCountersOverflow is triggered when reserved ZK counters exceeds remaining batch ZK counters
 	EventID_ReservedZKCountersOverflow EventID = "RESERVED ZKCOUNTERS OVERFLOW"
+	// EventID_InvalidInfoRoot is triggered when an invalid l1InfoRoot was synced
+	EventID_InvalidInfoRoot EventID = "INVALID INFOROOT"
 	// Source_Node is the source of the event
 	Source_Node Source = "node"
 

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -224,6 +224,17 @@ func (f *finalizer) checkL1InfoTreeUpdate(ctx context.Context) {
 	firstL1InfoRootUpdate := true
 	skipFirstSleep := true
 
+	if f.cfg.L1InfoTreeCheckInterval.Duration.Seconds() == 999999 {
+		if !f.lastL1InfoTreeValid {
+			f.lastL1InfoTreeCond.L.Lock()
+			f.lastL1InfoTreeValid = true
+			f.lastL1InfoTreeCond.Broadcast()
+			f.lastL1InfoTreeCond.L.Unlock()
+		}
+
+		return
+	}
+
 	for {
 		if skipFirstSleep {
 			skipFirstSleep = false
@@ -271,9 +282,11 @@ func (f *finalizer) checkL1InfoTreeUpdate(ctx context.Context) {
 					continue
 				}
 				if l1BlockState.BlockHash != l1BlockEth.Hash() {
-					log.Warnf("skipping use of l1InfoTreeIndex %d, L1 block %d blockhash %s doesn't match blockhash on ethereum %s (L1 reorg?)",
+					warnmsg := fmt.Sprintf("invalid l1InfoTreeIndex %d, L1 block %d blockhash %s doesn't match blockhash on ethereum %s (L1 reorg?). Stopping syncing l1IntroTreeIndex",
 						l1InfoRoot.L1InfoTreeIndex, l1InfoRoot.BlockNumber, l1BlockState.BlockHash, l1BlockEth.Hash())
-					continue
+					log.Warn(warnmsg)
+					f.LogEvent(ctx, event.Level_Critical, event.EventID_InvalidInfoRoot, warnmsg, nil)
+					return
 				}
 			}
 

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -224,7 +224,7 @@ func (f *finalizer) checkL1InfoTreeUpdate(ctx context.Context) {
 	firstL1InfoRootUpdate := true
 	skipFirstSleep := true
 
-	if f.cfg.L1InfoTreeCheckInterval.Duration.Seconds() == 999999 {
+	if f.cfg.L1InfoTreeCheckInterval.Duration.Seconds() == 999999 { //nolint:gomnd
 		if !f.lastL1InfoTreeValid {
 			f.lastL1InfoTreeCond.L.Lock()
 			f.lastL1InfoTreeValid = true


### PR DESCRIPTION
### What does this PR do?

Stop syncing l1inforoot when invalid l1inforoot is detected (L1 reorg)

### Reviewers

Main reviewers:

@ToniRamirezM 
@joanestebanr 
@ARR552 