### PR TITLE
Fix adding tx that matches with tx that is being processed

### DIFF
--- a/sequencer/addrqueue.go
+++ b/sequencer/addrqueue.go
@@ -211,7 +211,7 @@ func (a *addrQueue) updateCurrentNonceBalance(nonce *uint64, balance *big.Int) (
 	if oldReadyTx != nil && oldReadyTx.Nonce > a.currentNonce {
 		log.Infof("set readyTx %s as notReadyTx from addrQueue %s", oldReadyTx.HashStr, a.fromStr)
 		a.notReadyTxs[oldReadyTx.Nonce] = oldReadyTx
-	} else { // if oldReadyTx doesn't have a valid nonce then we add it to the txsToDelete
+	} else if oldReadyTx != nil { // if oldReadyTx doesn't have a valid nonce then we add it to the txsToDelete
 		reason := runtime.ErrIntrinsicInvalidNonce.Error()
 		oldReadyTx.FailedReason = &reason
 		txsToDelete = append(txsToDelete, oldReadyTx)

--- a/sequencer/addrqueue.go
+++ b/sequencer/addrqueue.go
@@ -211,6 +211,10 @@ func (a *addrQueue) updateCurrentNonceBalance(nonce *uint64, balance *big.Int) (
 	if oldReadyTx != nil && oldReadyTx.Nonce > a.currentNonce {
 		log.Infof("set readyTx %s as notReadyTx from addrQueue %s", oldReadyTx.HashStr, a.fromStr)
 		a.notReadyTxs[oldReadyTx.Nonce] = oldReadyTx
+	} else { // if oldReadyTx doesn't have a valid nonce then we add it to the txsToDelete
+		reason := runtime.ErrIntrinsicInvalidNonce.Error()
+		oldReadyTx.FailedReason = &reason
+		txsToDelete = append(txsToDelete, oldReadyTx)
 	}
 
 	return a.readyTx, oldReadyTx, txsToDelete

--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -345,8 +345,8 @@ func (f *finalizer) checkL1InfoTreeUpdate(ctx context.Context) {
 		if firstL1InfoRootUpdate || l1InfoRoot.L1InfoTreeIndex > f.lastL1InfoTree.L1InfoTreeIndex {
 			log.Infof("received new l1InfoRoot %s, index: %d, l1Block: %d", l1InfoRoot.L1InfoTreeRoot, l1InfoRoot.L1InfoTreeIndex, l1InfoRoot.BlockNumber)
 
-			// Check if new l1InfoRoot is valid. We skip it if l1InfoRoot.BlockNumber == 0 (empty tree)
-			if l1InfoRoot.BlockNumber > 0 {
+			// Check if new l1InfoRoot is valid. We skip it if l1InfoTreeIndex is 0 (it's a special case)
+			if l1InfoRoot.L1InfoTreeIndex > 0 {
 				valid, err := f.checkValidL1InfoRoot(ctx, l1InfoRoot)
 				if err != nil {
 					log.Errorf("error validating new l1InfoRoot, index: %d, error: %v", l1InfoRoot.L1InfoTreeIndex, err)

--- a/test/Makefile
+++ b/test/Makefile
@@ -669,7 +669,7 @@ generate-mocks-sequencer: ## Generates mocks for sequencer , using mockery tool
 	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/mockery --name=stateInterface --dir=../sequencer --output=../sequencer --outpkg=sequencer --inpackage --structname=StateMock --filename=mock_state.go
 	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/mockery --name=txPool --dir=../sequencer --output=../sequencer --outpkg=sequencer --inpackage  --structname=PoolMock --filename=mock_pool.go
 	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/mockery --name=Tx --srcpkg=github.com/jackc/pgx/v4 --output=../sequencer --outpkg=sequencer --structname=DbTxMock --filename=mock_dbtx.go
-	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/mockery --name=etherman --dir=../sequencer --output=../sequencer --outpkg=sequencer --inpackage --structname=EthermanMock --filename=mock_etherman.go
+	export "GOROOT=$$(go env GOROOT)" && $$(go env GOPATH)/bin/mockery --name=ethermanInterface --dir=../sequencer --output=../sequencer --outpkg=sequencer --inpackage --structname=EthermanMock --filename=mock_etherman.go
 
 .PHONY: generate-mocks-sequencesender
 generate-mocks-sequencesender: ## Generates mocks for sequencesender , using mockery tool


### PR DESCRIPTION
### What does this PR do?

Fixes adding tx that matches (same address and nonce, but different hash) with tx that is being processed. In this case the tx is rejected as "duplicated nonce"

### Reviewers

Main reviewers:

@ToniRamirezM 
@dpunish3r 