### PR TITLE
Reset balance in memory after OOG

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -762,6 +762,27 @@ func (f *finalizer) updateWorkerAfterSuccessfulProcessing(ctx context.Context, t
 		log.Debugf("tx %s deleted from address %s", txHash.String(), txFrom.Hex())
 	}
 
+	_, found := result.ReadWriteAddresses[txFrom]
+	exist := result.BlockResponses != nil && len(result.BlockResponses) > 0 && result.BlockResponses[0].TransactionResponses != nil && len(result.BlockResponses[0].TransactionResponses) > 0
+	if found && exist {
+		// Ensure consistency with Ethereum behavior.After OOG, reset the balance in memory.
+		txResponse := result.BlockResponses[0].TransactionResponses[0]
+		if executor.IsROMOutOfGasError(executor.RomErrorCode(txResponse.RomError)) {
+			// get latest balance and nonce.
+			root, err := f.stateIntf.GetLastStateRoot(ctx, nil)
+			if err != nil {
+				log.Error(err)
+			}
+
+			balance, err := f.stateIntf.GetBalanceByStateRoot(ctx, txFrom, root)
+			if err != nil {
+				log.Error(err)
+			}
+			log.Infof("Update worker after processing oog: address:%v, balance:%v, ", txFrom.Hex(), balance.String())
+			result.ReadWriteAddresses[txFrom].Balance = balance
+		}
+	}
+
 	txsToDelete := f.workerIntf.UpdateAfterSingleSuccessfulTxExecution(txFrom, result.ReadWriteAddresses)
 	for _, txToDelete := range txsToDelete {
 		err := f.poolIntf.UpdateTxStatus(ctx, txToDelete.Hash, pool.TxStatusFailed, false, txToDelete.FailedReason)


### PR DESCRIPTION
### What does this PR do?
Ensure consistency with Ethereum behavior.After OOG, reset the balance in memory.
Test cases:
A has 1 ETH, nonce is 1,  B is contract account, C is other account
1. Tx A to B, nonce 3 with 0.8 ETH,  will get an oog error
2. Tx A to C, nonce 4 with 0.8 ETH
3. Tx A to C, nonce 2 with 0.01 ETH
4. Tx C to A with 1 ETH

Both tx will be minted, order of execution: 3,1(oog),4,2

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
