### PR TITLE
Fix potential nil pointer for worker

### DIFF
--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -97,6 +97,7 @@ func (s *Sequencer) Start(ctx context.Context) {
 	s.worker = NewWorker(s.stateIntf, s.batchCfg.Constraints, s.workerReadyTxsCond)
 	s.finalizer = newFinalizer(s.cfg.Finalizer, s.poolCfg, s.worker, s.pool, s.stateIntf, s.etherman, s.address, s.isSynced, s.batchCfg.Constraints, s.eventLog, s.streamServer, s.workerReadyTxsCond, s.dataToStream)
 
+	
 	go s.loadFromPool(ctx)
 
 	if s.streamServer != nil {

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -96,7 +96,6 @@ func (s *Sequencer) Start(ctx context.Context) {
 	s.workerReadyTxsCond = newTimeoutCond(&sync.Mutex{})
 	s.worker = NewWorker(s.stateIntf, s.batchCfg.Constraints, s.workerReadyTxsCond)
 	s.finalizer = newFinalizer(s.cfg.Finalizer, s.poolCfg, s.worker, s.pool, s.stateIntf, s.etherman, s.address, s.isSynced, s.batchCfg.Constraints, s.eventLog, s.streamServer, s.workerReadyTxsCond, s.dataToStream)
-
 	
 	go s.loadFromPool(ctx)
 


### PR DESCRIPTION

### What does this PR do?

It fixs potential nil pointer for `Sequencer.worker`

1. line 96  loadFromPool-->addTxToWorker-->`s.worker`
2. line 103 `s.worker = xxx`

If `1` finishes before `2`, there will be a panic.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
