### PR TITLE
replace fmt.Errorf() with errors.New() if no param required

### DIFF
--- a/aggregator/config.go
+++ b/aggregator/config.go
@@ -1,7 +1,7 @@
 package aggregator
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 
 	"github.com/0xPolygonHermez/zkevm-node/config/types"
@@ -17,7 +17,7 @@ type TokenAmountWithDecimals struct {
 func (t *TokenAmountWithDecimals) UnmarshalText(data []byte) error {
 	amount, ok := new(big.Float).SetString(string(data))
 	if !ok {
-		return fmt.Errorf("failed to unmarshal string to float")
+		return errors.New("failed to unmarshal string to float")
 	}
 	coin := new(big.Float).SetInt(big.NewInt(encoding.TenToThePowerOf18))
 	bigval := new(big.Float).Mul(amount, coin)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -654,7 +654,7 @@ func forkIDIntervals(ctx context.Context, st *state.State, etherman *etherman.Cl
 			if err != nil {
 				return []state.ForkIDInterval{}, fmt.Errorf("error getting forks. Please check the configuration. Error: %v", err)
 			} else if len(forkIntervals) == 0 {
-				return []state.ForkIDInterval{}, fmt.Errorf("error: no forkID received. It should receive at least one, please check the configuration...")
+				return []state.ForkIDInterval{}, errors.New("error: no forkID received. It should receive at least one, please check the configuration...")
 			}
 
 			dbTx, err := st.BeginStateTransaction(ctx)
@@ -692,7 +692,7 @@ func forkIDIntervals(ctx context.Context, st *state.State, etherman *etherman.Cl
 			if err != nil {
 				return []state.ForkIDInterval{}, fmt.Errorf("error getting forks. Please check the configuration. Error: %v", err)
 			} else if len(forkIntervals) == 0 {
-				return []state.ForkIDInterval{}, fmt.Errorf("error: no forkID received. It should receive at least one, please check the configuration...")
+				return []state.ForkIDInterval{}, errors.New("error: no forkID received. It should receive at least one, please check the configuration...")
 			}
 			forkIDIntervals = forkIntervals
 		}

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -50,7 +51,7 @@ func DecodeUint256orHex(val *string) (*big.Int, error) {
 	}
 	b, ok := new(big.Int).SetString(str, base)
 	if !ok {
-		return nil, fmt.Errorf("could not parse")
+		return nil, errors.New("could not parse")
 	}
 	return b, nil
 }

--- a/etherman/eip4844/eip4844.go
+++ b/etherman/eip4844/eip4844.go
@@ -2,6 +2,7 @@ package eip4844
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	beaconclient "github.com/0xPolygonHermez/zkevm-node/beacon_client"
@@ -72,7 +73,7 @@ func (e *EthermanEIP4844) GetBlobSidecar(ctx context.Context, blockTime uint64, 
 			return sidecar.Blob, nil
 		}
 	}
-	err = fmt.Errorf("sidecar not found")
+	err = errors.New("sidecar not found")
 	log.Error(err.Error())
 	return nil, err
 }
@@ -80,7 +81,7 @@ func (e *EthermanEIP4844) GetBlobSidecar(ctx context.Context, blockTime uint64, 
 // CalculateSlot calculates the slot for a given blockTime
 func (e *EthermanEIP4844) CalculateSlot(blockTime uint64) (uint64, error) {
 	if !e.IsInitialized() {
-		return 0, fmt.Errorf("EIP-4844 not initialized,please call Initialize(..) function first")
+		return 0, errors.New("EIP-4844 not initialized,please call Initialize(..) function first")
 	}
 	return (blockTime - e.genesisTime) / e.secondsPerSlot, nil
 }

--- a/etherman/errors_test.go
+++ b/etherman/errors_test.go
@@ -1,6 +1,7 @@
 package etherman
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestTryParseWithContains(t *testing.T) {
 }
 
 func TestTryParseWithNonExistingErr(t *testing.T) {
-	smartContractErr := fmt.Errorf("some non-existing err")
+	smartContractErr := errors.New("some non-existing err")
 
 	actualErr, ok := tryParseError(smartContractErr)
 

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -340,7 +340,7 @@ func (etherMan *Client) VerifyGenBlockNumber(ctx context.Context, genBlockNumber
 		return false, err
 	}
 	if len(logs) == 0 {
-		return false, fmt.Errorf("the specified genBlockNumber in config file does not contain any forkID event. Please use the proper blockNumber.")
+		return false, errors.New("the specified genBlockNumber in config file does not contain any forkID event. Please use the proper blockNumber.")
 	}
 	var zkevmVersion preetrogpolygonzkevm.PreetrogpolygonzkevmUpdateZkEVMVersion
 	switch logs[0].Topics[0] {
@@ -820,7 +820,7 @@ func (etherMan *Client) updateEtrogSequence(ctx context.Context, vLog types.Log,
 		(*blocks)[len(*blocks)-1].UpdateEtrogSequence = sequence
 	} else {
 		log.Error("Error processing UpdateEtrogSequence event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing UpdateEtrogSequence event")
+		return errors.New("error processing UpdateEtrogSequence event")
 	}
 	or := Order{
 		Name: UpdateEtrogSequenceOrder,
@@ -878,7 +878,7 @@ func (etherMan *Client) initialSequenceBatches(ctx context.Context, vLog types.L
 		(*blocks)[len(*blocks)-1].SequencedBatches = append((*blocks)[len(*blocks)-1].SequencedBatches, sequences)
 	} else {
 		log.Error("Error processing SequencedBatches event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing SequencedBatches event")
+		return errors.New("error processing SequencedBatches event")
 	}
 	or := Order{
 		Name: InitialSequenceBatchesOrder,
@@ -910,7 +910,7 @@ func (etherMan *Client) updateForkId(ctx context.Context, vLog types.Log, blocks
 		(*blocks)[len(*blocks)-1].ForkIDs = append((*blocks)[len(*blocks)-1].ForkIDs, fork)
 	} else {
 		log.Error("Error processing updateZkevmVersion event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing updateZkevmVersion event")
+		return errors.New("error processing updateZkevmVersion event")
 	}
 	or := Order{
 		Name: ForkIDsOrder,
@@ -1004,7 +1004,7 @@ func (etherMan *Client) processUpdateGlobalExitRootEvent(ctx context.Context, ma
 		(*blocks)[len(*blocks)-1].GlobalExitRoots = append((*blocks)[len(*blocks)-1].GlobalExitRoots, gExitRoot)
 	} else {
 		log.Error("Error processing UpdateGlobalExitRoot event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing UpdateGlobalExitRoot event")
+		return errors.New("error processing UpdateGlobalExitRoot event")
 	}
 	or := Order{
 		Name: GlobalExitRootsOrder,
@@ -1263,7 +1263,7 @@ func (etherMan *Client) forcedBatchEvent(ctx context.Context, vLog types.Log, bl
 		(*blocks)[len(*blocks)-1].ForcedBatches = append((*blocks)[len(*blocks)-1].ForcedBatches, forcedBatch)
 	} else {
 		log.Error("Error processing ForceBatch event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing ForceBatch event")
+		return errors.New("error processing ForceBatch event")
 	}
 	or := Order{
 		Name: ForcedBatchesOrder,
@@ -1333,7 +1333,7 @@ func (etherMan *Client) sequencedBatchesEvent(ctx context.Context, vLog types.Lo
 		(*blocks)[len(*blocks)-1].SequencedBatches = append((*blocks)[len(*blocks)-1].SequencedBatches, sequences)
 	} else {
 		log.Error("Error processing SequencedBatches event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing SequencedBatches event")
+		return errors.New("error processing SequencedBatches event")
 	}
 	or := Order{
 		Name: SequenceBatchesOrder,
@@ -1380,7 +1380,7 @@ func (etherMan *Client) sequencedBatchesPreEtrogEvent(ctx context.Context, vLog 
 		(*blocks)[len(*blocks)-1].SequencedBatches = append((*blocks)[len(*blocks)-1].SequencedBatches, sequences)
 	} else {
 		log.Error("Error processing SequencedBatches event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing SequencedBatches event")
+		return errors.New("error processing SequencedBatches event")
 	}
 	or := Order{
 		Name: SequenceBatchesOrder,
@@ -1586,7 +1586,7 @@ func (etherMan *Client) verifyBatches(
 		(*blocks)[len(*blocks)-1].VerifiedBatches = append((*blocks)[len(*blocks)-1].VerifiedBatches, verifyBatch)
 	} else {
 		log.Error("Error processing verifyBatch event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing verifyBatch event")
+		return errors.New("error processing verifyBatch event")
 	}
 	or := Order{
 		Name: orderName,
@@ -1633,7 +1633,7 @@ func (etherMan *Client) forceSequencedBatchesEvent(ctx context.Context, vLog typ
 		(*blocks)[len(*blocks)-1].SequencedForceBatches = append((*blocks)[len(*blocks)-1].SequencedForceBatches, sequencedForceBatch)
 	} else {
 		log.Error("Error processing ForceSequencedBatches event. BlockHash:", vLog.BlockHash, ". BlockNumber: ", vLog.BlockNumber)
-		return fmt.Errorf("error processing ForceSequencedBatches event")
+		return errors.New("error processing ForceSequencedBatches event")
 	}
 	or := Order{
 		Name: SequenceForceBatchesOrder,
@@ -1833,7 +1833,7 @@ func (etherMan *Client) GetL2ChainID() (uint64, error) {
 			log.Debug("error from EtrogRollupManager: ", err)
 			return 0, err
 		} else if rollupData.ChainID == 0 {
-			return rollupData.ChainID, fmt.Errorf("error: chainID received is 0!!")
+			return rollupData.ChainID, errors.New("error: chainID received is 0!!")
 		}
 		return rollupData.ChainID, nil
 	}

--- a/etherman/etherman_test.go
+++ b/etherman/etherman_test.go
@@ -3,7 +3,7 @@ package etherman
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
+	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -365,7 +365,7 @@ func TestErrorEthGasStationPrice(t *testing.T) {
 	etherman.GasProviders.Providers = []ethereum.GasPricer{etherman.EthClient, ethGasStationM}
 	ctx := context.Background()
 
-	ethGasStationM.On("SuggestGasPrice", ctx).Return(big.NewInt(0), fmt.Errorf("error getting gasPrice from ethGasStation"))
+	ethGasStationM.On("SuggestGasPrice", ctx).Return(big.NewInt(0), errors.New("error getting gasPrice from ethGasStation"))
 	gp := etherman.GetL1GasPrice(ctx)
 	assert.Equal(t, big.NewInt(1392695906), gp)
 
@@ -385,7 +385,7 @@ func TestErrorEtherScanPrice(t *testing.T) {
 	etherman.GasProviders.Providers = []ethereum.GasPricer{etherman.EthClient, etherscanM, ethGasStationM}
 	ctx := context.Background()
 
-	etherscanM.On("SuggestGasPrice", ctx).Return(big.NewInt(0), fmt.Errorf("error getting gasPrice from etherscan"))
+	etherscanM.On("SuggestGasPrice", ctx).Return(big.NewInt(0), errors.New("error getting gasPrice from etherscan"))
 	ethGasStationM.On("SuggestGasPrice", ctx).Return(big.NewInt(1448795321), nil)
 	gp := etherman.GetL1GasPrice(ctx)
 	assert.Equal(t, big.NewInt(1448795321), gp)

--- a/etherman/events_helper_test.go
+++ b/etherman/events_helper_test.go
@@ -3,7 +3,7 @@ package etherman_test
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -124,7 +124,7 @@ func TestCallDataExtractorExtarctCallDataTransactionInBlockReturnsErr(t *testing
 	mockChainRetriever := etherman.NewChainReaderMock(t)
 	blockHash := common.HexToHash("0x1")
 	indexTx := uint(12)
-	errReturned := fmt.Errorf("mock error")
+	errReturned := errors.New("mock error")
 	mockChainRetriever.EXPECT().TransactionInBlock(context.TODO(), blockHash, indexTx).Return(nil, errReturned).Once()
 	callDataExtractor := etherman.NewCallDataExtratorGeth(mockChainRetriever)
 	_, err := callDataExtractor.ExtractCallData(context.TODO(), blockHash, common.Hash{}, indexTx)

--- a/etherman/feijoa_event_sequence_blobs.go
+++ b/etherman/feijoa_event_sequence_blobs.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/0xPolygonHermez/zkevm-node/etherman/smartcontracts/feijoapolygonzkevm"
@@ -68,7 +68,7 @@ func (e *EventFeijoaSequenceBlobsProcessor) AddEventDataToBlock(ctx context.Cont
 
 	if inputData.thereIsAnyBlobType() {
 		// TODO:Retrieve blobs
-		return nil, fmt.Errorf("data-availability in blobs: not supported yet")
+		return nil, errors.New("data-availability in blobs: not supported yet")
 	}
 	// Add the blobs to the block list
 	block.SequenceBlobs = append(block.SequenceBlobs, *inputData)
@@ -120,9 +120,9 @@ func (e *EventFeijoaSequenceBlobsProcessor) parseCallData(callData *CallData) (*
 				return nil, err
 			}
 		case TypeBlobTransaction:
-			return nil, fmt.Errorf("blobType 'BlobTransaction' not supported yet")
+			return nil, errors.New("blobType 'BlobTransaction' not supported yet")
 		default:
-			return nil, fmt.Errorf("blobType not supported")
+			return nil, errors.New("blobType not supported")
 		}
 		blobs = append(blobs, SequenceBlob{
 			Type:               BlobType(blobsRaw[i].BlobType),

--- a/ethtxmanager/ethtxmanager_test.go
+++ b/ethtxmanager/ethtxmanager_test.go
@@ -893,7 +893,7 @@ func TestFailedToEstimateTxWithForcedGasGetMined(t *testing.T) {
 	// forces the estimate gas to fail
 	etherman.
 		On("EstimateGas", ctx, from, to, value, data).
-		Return(uint64(0), fmt.Errorf("failed to estimate gas")).
+		Return(uint64(0), errors.New("failed to estimate gas")).
 		Once()
 
 	// set estimated gas as the config ForcedGas

--- a/jsonrpc/endpoints_eth_test.go
+++ b/jsonrpc/endpoints_eth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -5142,7 +5141,7 @@ func TestSubscribeNewHeads(t *testing.T) {
 			SetupMocks: func(m *mocksWrapper, tc testCase) {
 				m.Storage.
 					On("NewBlockFilter", mock.IsType(&concurrentWsConn{})).
-					Return("", fmt.Errorf("failed to add filter to storage")).
+					Return("", errors.New("failed to add filter to storage")).
 					Once()
 			},
 		},
@@ -5235,7 +5234,7 @@ func TestSubscribeNewLogs(t *testing.T) {
 
 				m.Storage.
 					On("NewLogFilter", mock.IsType(&concurrentWsConn{}), mock.IsType(LogFilter{})).
-					Return("", fmt.Errorf("failed to add filter to storage")).
+					Return("", errors.New("failed to add filter to storage")).
 					Once()
 			},
 		},

--- a/jsonrpc/endpoints_zkevm_test.go
+++ b/jsonrpc/endpoints_zkevm_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -2563,7 +2562,7 @@ func TestGetExitRootsByGER(t *testing.T) {
 
 				m.State.
 					On("GetExitRootByGlobalExitRoot", context.Background(), tc.GER, m.DbTx).
-					Return(nil, fmt.Errorf("failed to load exit roots from state"))
+					Return(nil, errors.New("failed to load exit roots from state"))
 			},
 		},
 		{
@@ -2654,7 +2653,7 @@ func TestGetLatestGlobalExitRoot(t *testing.T) {
 
 				m.State.
 					On("GetLatestBatchGlobalExitRoot", context.Background(), m.DbTx).
-					Return(nil, fmt.Errorf("failed to load GER from state")).
+					Return(nil, errors.New("failed to load GER from state")).
 					Once()
 			},
 		},

--- a/jsonrpc/handler.go
+++ b/jsonrpc/handler.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -243,7 +244,7 @@ func (h *Handler) getFnHandler(req types.Request) (*serviceData, *funcData, type
 
 func validateFunc(funcName string, fv reflect.Value, isMethod bool) (inNum int, reqt []reflect.Type, err error) {
 	if funcName == "" {
-		err = fmt.Errorf("getBlockNumByArg cannot be empty")
+		err = errors.New("getBlockNumByArg cannot be empty")
 		return
 	}
 

--- a/jsonrpc/query.go
+++ b/jsonrpc/query.go
@@ -3,6 +3,7 @@ package jsonrpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -243,12 +244,12 @@ func (f *LogFilter) UnmarshalJSON(data []byte) error {
 						return err
 					}
 				} else {
-					return fmt.Errorf("address expected")
+					return errors.New("address expected")
 				}
 			}
 
 		default:
-			return fmt.Errorf("failed to decode address. Expected either '' or ['', '']")
+			return errors.New("failed to decode address. Expected either '' or ['', '']")
 		}
 	}
 
@@ -270,7 +271,7 @@ func (f *LogFilter) UnmarshalJSON(data []byte) error {
 					if item, ok := i.(string); ok {
 						res = append(res, item)
 					} else {
-						return fmt.Errorf("hash expected")
+						return errors.New("hash expected")
 					}
 				}
 
@@ -285,7 +286,7 @@ func (f *LogFilter) UnmarshalJSON(data []byte) error {
 				}
 
 			default:
-				return fmt.Errorf("failed to decode topics. Expected '' or [''] or null")
+				return errors.New("failed to decode topics. Expected '' or [''] or null")
 			}
 		}
 	}

--- a/jsonrpc/server.go
+++ b/jsonrpc/server.go
@@ -106,7 +106,7 @@ func (s *Server) Start() error {
 // startHTTP starts a server to respond http requests
 func (s *Server) startHTTP() error {
 	if s.srv != nil {
-		return fmt.Errorf("server already started")
+		return errors.New("server already started")
 	}
 
 	address := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
@@ -287,7 +287,7 @@ func (s *Server) isSingleRequest(data []byte) (bool, error) {
 	x := bytes.TrimLeft(data, " \t\r\n")
 
 	if len(x) == 0 {
-		return false, fmt.Errorf("empty request body")
+		return false, errors.New("empty request body")
 	}
 
 	return x[0] != '[', nil
@@ -360,7 +360,7 @@ func (s *Server) parseRequest(data []byte) (types.Request, error) {
 	var req types.Request
 
 	if err := json.Unmarshal(data, &req); err != nil {
-		return types.Request{}, fmt.Errorf("invalid json object request body")
+		return types.Request{}, errors.New("invalid json object request body")
 	}
 
 	return req, nil
@@ -370,7 +370,7 @@ func (s *Server) parseRequests(data []byte) ([]types.Request, error) {
 	var requests []types.Request
 
 	if err := json.Unmarshal(data, &requests); err != nil {
-		return nil, fmt.Errorf("invalid json array request body")
+		return nil, errors.New("invalid json array request body")
 	}
 
 	return requests, nil

--- a/jsonrpc/types/codec.go
+++ b/jsonrpc/types/codec.go
@@ -393,7 +393,7 @@ func (b *BlockNumberOrHash) UnmarshalJSON(buffer []byte) error {
 			}
 			return nil
 		} else {
-			return fmt.Errorf("invalid block or hash")
+			return errors.New("invalid block or hash")
 		}
 	}
 

--- a/jsonrpc/types/codec_test.go
+++ b/jsonrpc/types/codec_test.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strconv"
 	"testing"
 
@@ -412,17 +412,17 @@ func TestBlockNumberOrHashMarshaling(t *testing.T) {
 		{`{"blockHash":"0x1"}`, &BlockNumberOrHash{hash: argHashPtr(common.HexToHash("0x1"))}, nil},
 		{`{"blockHash":"0x1", "requireCanonical":true}`, &BlockNumberOrHash{hash: argHashPtr(common.HexToHash("0x1")), requireCanonical: true}, nil},
 		// float wrong value
-		{`{"blockNumber":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
-		{`{"blockHash":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
-		{`{"blockHash":"0x1", "requireCanonical":1.0}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+		{`{"blockNumber":1.0}`, &BlockNumberOrHash{}, errors.New("invalid blockNumber")},
+		{`{"blockHash":1.0}`, &BlockNumberOrHash{}, errors.New("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":1.0}`, &BlockNumberOrHash{}, errors.New("invalid requireCanonical")},
 		// int wrong value
-		{`{"blockNumber":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
-		{`{"blockHash":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
-		{`{"blockHash":"0x1", "requireCanonical":1}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+		{`{"blockNumber":1}`, &BlockNumberOrHash{}, errors.New("invalid blockNumber")},
+		{`{"blockHash":1}`, &BlockNumberOrHash{}, errors.New("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":1}`, &BlockNumberOrHash{}, errors.New("invalid requireCanonical")},
 		// string wrong value
-		{`{"blockNumber":"aaa"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockNumber")},
-		{`{"blockHash":"ggg"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid blockHash")},
-		{`{"blockHash":"0x1", "requireCanonical":"aaa"}`, &BlockNumberOrHash{}, fmt.Errorf("invalid requireCanonical")},
+		{`{"blockNumber":"aaa"}`, &BlockNumberOrHash{}, errors.New("invalid blockNumber")},
+		{`{"blockHash":"ggg"}`, &BlockNumberOrHash{}, errors.New("invalid blockHash")},
+		{`{"blockHash":"0x1", "requireCanonical":"aaa"}`, &BlockNumberOrHash{}, errors.New("invalid requireCanonical")},
 	}
 
 	for _, testCase := range testCases {

--- a/jsonrpc/types/errors.go
+++ b/jsonrpc/types/errors.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	// DefaultErrorCode rpc default error code
@@ -20,11 +23,11 @@ const (
 var (
 	// ErrBatchRequestsDisabled returned by the server when a batch request
 	// is detected and the batch requests are disabled via configuration
-	ErrBatchRequestsDisabled = fmt.Errorf("batch requests are disabled")
+	ErrBatchRequestsDisabled = errors.New("batch requests are disabled")
 
 	// ErrBatchRequestsLimitExceeded returned by the server when a batch request
 	// is detected and the number of requests are greater than the configured limit.
-	ErrBatchRequestsLimitExceeded = fmt.Errorf("batch requests limit exceeded")
+	ErrBatchRequestsLimitExceeded = errors.New("batch requests limit exceeded")
 )
 
 // Error interface

--- a/jsonrpc/types/types.go
+++ b/jsonrpc/types/types.go
@@ -3,7 +3,7 @@ package types
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"math/big"
 	"strconv"
 	"strings"
@@ -135,7 +135,7 @@ type ArgHash common.Hash
 // UnmarshalText unmarshals from text
 func (arg *ArgHash) UnmarshalText(input []byte) error {
 	if !hex.IsValid(string(input)) {
-		return fmt.Errorf("invalid hash, it needs to be a hexadecimal value")
+		return errors.New("invalid hash, it needs to be a hexadecimal value")
 	}
 
 	str := strings.TrimPrefix(string(input), "0x")
@@ -159,7 +159,7 @@ type ArgAddress common.Address
 // UnmarshalText unmarshals from text
 func (b *ArgAddress) UnmarshalText(input []byte) error {
 	if !hex.IsValid(string(input)) {
-		return fmt.Errorf("invalid address, it needs to be a hexadecimal value")
+		return errors.New("invalid address, it needs to be a hexadecimal value")
 	}
 
 	str := strings.TrimPrefix(string(input), "0x")
@@ -217,7 +217,7 @@ func (args *TxArgs) ToTransaction(ctx context.Context, st StateInterface, maxCum
 	} else if args.Input != nil {
 		data = *args.Input
 	} else if args.To == nil {
-		return common.Address{}, nil, fmt.Errorf("contract creation without data provided")
+		return common.Address{}, nil, errors.New("contract creation without data provided")
 	}
 
 	gas := maxCumulativeGasUsed

--- a/jsonrpc/types/types_test.go
+++ b/jsonrpc/types/types_test.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/hex"
@@ -42,13 +42,13 @@ func TestArgHashUnmarshalFromShortString(t *testing.T) {
 			name:           "invalid hex value starting with 0x",
 			input:          "0xG",
 			expectedResult: "0x0000000000000000000000000000000000000000000000000000000000000000",
-			expectedError:  fmt.Errorf("invalid hash, it needs to be a hexadecimal value"),
+			expectedError:  errors.New("invalid hash, it needs to be a hexadecimal value"),
 		},
 		{
 			name:           "invalid hex value starting without 0x",
 			input:          "G",
 			expectedResult: "0x0000000000000000000000000000000000000000000000000000000000000000",
-			expectedError:  fmt.Errorf("invalid hash, it needs to be a hexadecimal value"),
+			expectedError:  errors.New("invalid hash, it needs to be a hexadecimal value"),
 		},
 	}
 
@@ -92,13 +92,13 @@ func TestArgAddressUnmarshalFromShortString(t *testing.T) {
 			name:           "invalid hex value starting with 0x",
 			input:          "0xG",
 			expectedResult: "0x0000000000000000000000000000000000000000",
-			expectedError:  fmt.Errorf("invalid address, it needs to be a hexadecimal value"),
+			expectedError:  errors.New("invalid address, it needs to be a hexadecimal value"),
 		},
 		{
 			name:           "invalid hex value starting without 0x",
 			input:          "G",
 			expectedResult: "0x0000000000000000000000000000000000000000",
-			expectedError:  fmt.Errorf("invalid address, it needs to be a hexadecimal value"),
+			expectedError:  errors.New("invalid address, it needs to be a hexadecimal value"),
 		},
 	}
 

--- a/l1infotree/tree.go
+++ b/l1infotree/tree.go
@@ -1,6 +1,7 @@
 package l1infotree
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/0xPolygonHermez/zkevm-node/log"
@@ -172,7 +173,7 @@ func (mt *L1InfoTree) AddLeaf(index uint32, leaf [32]byte) (common.Hash, error) 
 // it is used to initialize the siblings array in the beginning.
 func (mt *L1InfoTree) initSiblings(initialLeaves [][32]byte) ([][32]byte, common.Hash, error) {
 	if mt.count != uint32(len(initialLeaves)) {
-		return nil, [32]byte{}, fmt.Errorf("error: mt.count and initialLeaves length mismatch")
+		return nil, [32]byte{}, errors.New("error: mt.count and initialLeaves length mismatch")
 	}
 	if mt.count == 0 {
 		var siblings [][32]byte

--- a/merkletree/tree.go
+++ b/merkletree/tree.go
@@ -2,7 +2,7 @@ package merkletree
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"strings"
 
@@ -129,7 +129,7 @@ func (tree *StateTree) GetStorageAt(ctx context.Context, address common.Address,
 // SetBalance sets balance.
 func (tree *StateTree) SetBalance(ctx context.Context, address common.Address, balance *big.Int, root []byte, uuid string) (newRoot []byte, proof *UpdateProof, err error) {
 	if balance.Cmp(big.NewInt(0)) == -1 {
-		return nil, nil, fmt.Errorf("invalid balance")
+		return nil, nil, errors.New("invalid balance")
 	}
 
 	r := new(big.Int).SetBytes(root)
@@ -152,7 +152,7 @@ func (tree *StateTree) SetBalance(ctx context.Context, address common.Address, b
 // SetNonce sets nonce.
 func (tree *StateTree) SetNonce(ctx context.Context, address common.Address, nonce *big.Int, root []byte, uuid string) (newRoot []byte, proof *UpdateProof, err error) {
 	if nonce.Cmp(big.NewInt(0)) == -1 {
-		return nil, nil, fmt.Errorf("invalid nonce")
+		return nil, nil, errors.New("invalid nonce")
 	}
 
 	r := new(big.Int).SetBytes(root)

--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -3,6 +3,7 @@ package sequencer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -352,7 +353,7 @@ func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initi
 			}
 		}
 
-		f.Halt(ctx, fmt.Errorf("batch sanity check error. Check previous errors in logs to know which was the cause"), false)
+		f.Halt(ctx, errors.New("batch sanity check error. Check previous errors in logs to know which was the cause"), false)
 	}
 
 	log.Debugf("batch %d sanity check: initialStateRoot: %s, expectedNewStateRoot: %s", batchNum, initialStateRoot, expectedNewStateRoot)

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -2,7 +2,7 @@ package sequencer
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -956,7 +956,7 @@ func TestFinalizer_closeWIPBatch(t *testing.T) {
 		ClosingReason:  f.wipBatch.closingReason,
 	}
 
-	managerErr := fmt.Errorf("some err")
+	managerErr := errors.New("some err")
 
 	testCases := []struct {
 		name        string

--- a/sequencer/sequencer.go
+++ b/sequencer/sequencer.go
@@ -2,6 +2,7 @@ package sequencer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -129,7 +130,7 @@ func (s *Sequencer) checkStateInconsistency(ctx context.Context) {
 		}
 
 		if stateInconsistenciesDetected != s.numberOfStateInconsistencies {
-			s.finalizer.Halt(ctx, fmt.Errorf("state inconsistency detected, halting finalizer"), false)
+			s.finalizer.Halt(ctx, errors.New("state inconsistency detected, halting finalizer"), false)
 		}
 
 		time.Sleep(s.cfg.StateConsistencyCheckInterval.Duration)

--- a/state/converters.go
+++ b/state/converters.go
@@ -2,7 +2,7 @@ package state
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"time"
 
@@ -95,7 +95,7 @@ func convertToReadWriteAddresses(addresses map[string]*executor.InfoReadWrite) (
 			bigNonce, ok := new(big.Int).SetString(addrInfo.Nonce, encoding.Base10)
 			if !ok {
 				log.Debugf("received nonce as string: %v", addrInfo.Nonce)
-				return nil, fmt.Errorf("error while parsing address nonce")
+				return nil, errors.New("error while parsing address nonce")
 			}
 			nonceNp := bigNonce.Uint64()
 			nonce = &nonceNp
@@ -105,7 +105,7 @@ func convertToReadWriteAddresses(addresses map[string]*executor.InfoReadWrite) (
 			balance, ok = new(big.Int).SetString(addrInfo.Balance, encoding.Base10)
 			if !ok {
 				log.Debugf("received balance as string: %v", addrInfo.Balance)
-				return nil, fmt.Errorf("error while parsing address balance")
+				return nil, errors.New("error while parsing address balance")
 			}
 		}
 

--- a/state/convertersV2.go
+++ b/state/convertersV2.go
@@ -332,7 +332,7 @@ func convertToReadWriteAddressesV2(addresses map[string]*executor.InfoReadWriteV
 			bigNonce, ok := new(big.Int).SetString(addrInfo.Nonce, encoding.Base10)
 			if !ok {
 				log.Debugf("received nonce as string: %v", addrInfo.Nonce)
-				return nil, fmt.Errorf("error while parsing address nonce")
+				return nil, errors.New("error while parsing address nonce")
 			}
 			nonceNp := bigNonce.Uint64()
 			nonce = &nonceNp
@@ -342,7 +342,7 @@ func convertToReadWriteAddressesV2(addresses map[string]*executor.InfoReadWriteV
 			balance, ok = new(big.Int).SetString(addrInfo.Balance, encoding.Base10)
 			if !ok {
 				log.Debugf("received balance as string: %v", addrInfo.Balance)
-				return nil, fmt.Errorf("error while parsing address balance")
+				return nil, errors.New("error while parsing address balance")
 			}
 		}
 

--- a/state/errors.go
+++ b/state/errors.go
@@ -21,9 +21,9 @@ var (
 	// ErrAlreadyInitializedDBTransaction indicates the db transaction was already initialized
 	ErrAlreadyInitializedDBTransaction = errors.New("database transaction already initialized")
 	// ErrNotEnoughIntrinsicGas indicates the gas is not enough to cover the intrinsic gas cost
-	ErrNotEnoughIntrinsicGas = fmt.Errorf("not enough gas supplied for intrinsic gas costs")
+	ErrNotEnoughIntrinsicGas = errors.New("not enough gas supplied for intrinsic gas costs")
 	// ErrParsingExecutorTrace indicates an error occurred while parsing the executor trace
-	ErrParsingExecutorTrace = fmt.Errorf("error while parsing executor trace")
+	ErrParsingExecutorTrace = errors.New("error while parsing executor trace")
 	// ErrInvalidBatchNumber indicates the provided batch number is not the latest in db
 	ErrInvalidBatchNumber = errors.New("provided batch number is not latest")
 	// ErrLastBatchShouldBeClosed indicates that last batch needs to be closed before adding a new one

--- a/state/pgstatestorage/forkid_external_test.go
+++ b/state/pgstatestorage/forkid_external_test.go
@@ -2,7 +2,7 @@ package pgstatestorage_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/state"
@@ -32,17 +32,17 @@ func TestAddForkIDInterval(t *testing.T) {
 		{
 			name:          "fails to add because forkID already exists",
 			forkIDToAdd:   state.ForkIDInterval{ForkId: 3},
-			expectedError: fmt.Errorf("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 3"),
+			expectedError: errors.New("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 3"),
 		},
 		{
 			name:          "fails to add because forkID is smaller than the latest forkID",
 			forkIDToAdd:   state.ForkIDInterval{ForkId: 5},
-			expectedError: fmt.Errorf("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 5"),
+			expectedError: errors.New("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 5"),
 		},
 		{
 			name:          "fails to add because forkID is equal to the latest forkID",
 			forkIDToAdd:   state.ForkIDInterval{ForkId: 6},
-			expectedError: fmt.Errorf("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 6"),
+			expectedError: errors.New("error checking forkID sequence. Last ForkID stored: 6. New ForkID received: 6"),
 		},
 		{
 			name:          "adds successfully",

--- a/state/queue.go
+++ b/state/queue.go
@@ -1,13 +1,13 @@
 package state
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 )
 
 // ErrQueueEmpty is returned when a queue operation
 // depends on the queue to not be empty, but it is empty
-var ErrQueueEmpty = fmt.Errorf("queue is empty")
+var ErrQueueEmpty = errors.New("queue is empty")
 
 // Queue is a generic queue implementation that implements FIFO
 type Queue[T any] struct {

--- a/state/runtime/executor/errors.go
+++ b/state/runtime/executor/errors.go
@@ -1,7 +1,7 @@
 package executor
 
 import (
-	"fmt"
+	"errors"
 	"math"
 
 	"github.com/0xPolygonHermez/zkevm-node/state/runtime"
@@ -9,22 +9,22 @@ import (
 
 var (
 	// ErrExecutorUnspecified indicates an unspecified executor error
-	ErrExecutorUnspecified = fmt.Errorf("unspecified executor error")
+	ErrExecutorUnspecified = errors.New("unspecified executor error")
 	// ErrROMUnspecified indicates an unspecified ROM error
-	ErrROMUnspecified = fmt.Errorf("unspecified ROM error")
+	ErrROMUnspecified = errors.New("unspecified ROM error")
 	// ErrExecutorUnknown indicates an unknown executor error
-	ErrExecutorUnknown = fmt.Errorf("unknown executor error")
+	ErrExecutorUnknown = errors.New("unknown executor error")
 	// ErrCodeExecutorUnknown indicates an unknown executor error
 	ErrCodeExecutorUnknown = ExecutorError(math.MaxInt32)
 	// ErrROMUnknown indicates an unknown ROM error
-	ErrROMUnknown = fmt.Errorf("unknown ROM error")
+	ErrROMUnknown = errors.New("unknown ROM error")
 	// ErrCodeROMUnknown indicates an unknown ROM error
 	ErrCodeROMUnknown = RomError(math.MaxInt32)
 
 	// ErrROMBlobUnspecified indicates an unspecified ROM blob error
-	ErrROMBlobUnspecified = fmt.Errorf("unspecified ROM blob error")
+	ErrROMBlobUnspecified = errors.New("unspecified ROM blob error")
 	// ErrROMBlobUnknown indicates an unknown ROM blob error
-	ErrROMBlobUnknown = fmt.Errorf("unknown ROM blob error")
+	ErrROMBlobUnknown = errors.New("unknown ROM blob error")
 	// ErrCodeROMBlobUnknown indicates an unknown ROM blob error
 	ErrCodeROMBlobUnknown = RomBlobError(math.MaxInt32)
 )

--- a/state/runtime/instrumentation/js/goja.go
+++ b/state/runtime/instrumentation/js/goja.go
@@ -88,7 +88,7 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 		b := obj.Get("buffer").Export().(goja.ArrayBuffer).Bytes()
 		return b, nil
 	}
-	return nil, fmt.Errorf("invalid buffer type")
+	return nil, errors.New("invalid buffer type")
 }
 
 // jsTracer is an implementation of the Tracer interface which evaluates

--- a/state/runtime/instrumentation/tracers/tracers.go
+++ b/state/runtime/instrumentation/tracers/tracers.go
@@ -19,6 +19,7 @@ package tracers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -105,7 +106,7 @@ const (
 // It zero-pads the slice if it extends beyond memory bounds.
 func GetMemoryCopyPadded(m *fakevm.Memory, offset, size int64) ([]byte, error) {
 	if offset < 0 || size < 0 {
-		return nil, fmt.Errorf("offset or size must not be negative")
+		return nil, errors.New("offset or size must not be negative")
 	}
 	if int(offset+size) < m.Len() { // slice fully inside memory
 		return m.GetCopy(offset, size), nil

--- a/state/test/forkid_dragonfruit/dragonfruit_test.go
+++ b/state/test/forkid_dragonfruit/dragonfruit_test.go
@@ -3,6 +3,7 @@ package dragonfruit_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -1520,7 +1521,7 @@ func TestExecutorRevert(t *testing.T) {
 	result, err := testState.ProcessUnsignedTransaction(ctx, unsignedTx, auth.From, &lastL2BlockNumber, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Err)
-	assert.Equal(t, fmt.Errorf("execution reverted: Today is not juernes").Error(), result.Err.Error())
+	assert.Equal(t, errors.New("execution reverted: Today is not juernes").Error(), result.Err.Error())
 }
 
 func TestExecutorTransfer(t *testing.T) {

--- a/state/trace.go
+++ b/state/trace.go
@@ -333,7 +333,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 	// Sanity check
 	log.Debugf(response.TxHash.String())
 	if response.TxHash != transactionHash {
-		return nil, fmt.Errorf("tx hash not found in executor response")
+		return nil, errors.New("tx hash not found in executor response")
 	}
 
 	result := &runtime.ExecutionResult{
@@ -377,7 +377,7 @@ func (s *State) DebugTransaction(ctx context.Context, transactionHash common.Has
 	gasPrice, ok := new(big.Int).SetString(context.GasPrice, encoding.Base10)
 	if !ok {
 		log.Errorf("debug transaction: failed to parse gasPrice")
-		return nil, fmt.Errorf("failed to parse gasPrice")
+		return nil, errors.New("failed to parse gasPrice")
 	}
 
 	// select and prepare tracer

--- a/state/transaction.go
+++ b/state/transaction.go
@@ -171,7 +171,7 @@ func (s *State) StoreTransactions(ctx context.Context, batchNumber uint64, proce
 
 			receipt := GenerateReceipt(header.Number, processedTx, uint(txIndex), forkID)
 			if !CheckLogOrder(receipt.Logs) {
-				return fmt.Errorf("error: logs received from executor are not in order")
+				return errors.New("error: logs received from executor are not in order")
 			}
 			receipts := []*types.Receipt{receipt}
 			imStateRoots := []common.Hash{processedTx.StateRoot}

--- a/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
+++ b/synchronizer/actions/elderberry/processor_l1_sequence_batches.go
@@ -111,7 +111,7 @@ func (g *ProcessorL1SequenceBatchesElderberry) sanityCheckTstampLastL2Block(time
 	}
 	if uint64(lastL2Block.ReceivedAt.Unix()) > timeLimit {
 		log.Errorf("The last L2 block timestamp can't be greater than timeLimit. Expected: %d (L1 event), got: %d (last L2Block)", timeLimit, lastL2Block.ReceivedAt.Unix())
-		return fmt.Errorf("wrong timestamp of  last L2 block timestamp with L1 event timestamp")
+		return errors.New("wrong timestamp of  last L2 block timestamp with L1 event timestamp")
 	}
 	return nil
 }

--- a/synchronizer/actions/feijoa/processor_l1_sequence_blobs.go
+++ b/synchronizer/actions/feijoa/processor_l1_sequence_blobs.go
@@ -2,7 +2,7 @@ package feijoa
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
@@ -53,7 +53,7 @@ func (p *ProcessorSequenceBlobs) Process(ctx context.Context, order etherman.Ord
 
 func (p *ProcessorSequenceBlobs) storeBlobSequence(ctx context.Context, dbTx pgx.Tx, seqBlobs *etherman.SequenceBlobs, createAt time.Time) error {
 	if seqBlobs == nil || seqBlobs.EventData == nil {
-		return fmt.Errorf("sequence blobs is nil or EventData is nil")
+		return errors.New("sequence blobs is nil or EventData is nil")
 	}
 
 	nextIndex := uint64(1)

--- a/synchronizer/actions/incaberry/processor_l1_forkid.go
+++ b/synchronizer/actions/incaberry/processor_l1_forkid.go
@@ -195,7 +195,7 @@ func (s *ProcessorForkId) processForkID(ctx context.Context, forkID etherman.For
 	}
 	log.Infof("%s new ForkID detected, committed reverting state", debugPrefix)
 
-	return fmt.Errorf("new ForkID detected, reseting synchronizarion")
+	return errors.New("new ForkID detected, reseting synchronizarion")
 }
 
 func (s *ProcessorForkId) commit(ctx context.Context, debugPrefix string, dbTx pgx.Tx) error {

--- a/synchronizer/actions/incaberry/processor_l1_sequence_force_batches.go
+++ b/synchronizer/actions/incaberry/processor_l1_sequence_force_batches.go
@@ -2,6 +2,7 @@ package incaberry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
@@ -104,7 +105,7 @@ func (s *ProcessL1SequenceForcedBatches) processSequenceForceBatch(ctx context.C
 			return rollbackErr
 		}
 		log.Error("error number of forced batches doesn't match")
-		return fmt.Errorf("error number of forced batches doesn't match")
+		return errors.New("error number of forced batches doesn't match")
 	}
 	for i, fbatch := range sequenceForceBatch {
 		if uint64(forcedBatches[i].ForcedAt.Unix()) != fbatch.ForcedTimestamp ||

--- a/synchronizer/l1_parallel_sync/l1_worker_etherman_test.go
+++ b/synchronizer/l1_parallel_sync/l1_worker_etherman_test.go
@@ -3,7 +3,6 @@ package l1_parallel_sync
 import (
 	context "context"
 	"errors"
-	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -162,7 +161,7 @@ func TestIfRollupInfoFailGettingLastBlockContainBlockRange(t *testing.T) {
 
 	mockEtherman.
 		On("EthBlockByNumber", mock.Anything, blockRange.toBlock).
-		Return(ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: big.NewInt(int64(blockRange.toBlock))}), fmt.Errorf("error")).
+		Return(ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: big.NewInt(int64(blockRange.toBlock))}), errors.New("error")).
 		Once()
 	mockEtherman.
 		On("GetRollupInfoByBlockRange", mock.Anything, blockRange.fromBlock, mock.Anything).
@@ -193,7 +192,7 @@ func TestIfRollupInfoFailGettingRollupContainBlockRange(t *testing.T) {
 		Maybe()
 	mockEtherman.
 		On("GetRollupInfoByBlockRange", mock.Anything, blockRange.fromBlock, mock.Anything).
-		Return([]etherman.Block{}, map[common.Hash][]etherman.Order{}, fmt.Errorf("error")).
+		Return([]etherman.Block{}, map[common.Hash][]etherman.Order{}, errors.New("error")).
 		Once()
 
 	err := sut.asyncRequestRollupInfoByBlockRange(ctx, ch, &wg, request)
@@ -224,7 +223,7 @@ func TestIfRollupInfoFailPreviousBlockContainBlockRange(t *testing.T) {
 		Maybe()
 	mockEtherman.
 		On("EthBlockByNumber", mock.Anything, blockRange.fromBlock-1).
-		Return(ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: big.NewInt(int64(blockRange.fromBlock - 1))}), fmt.Errorf("error")).
+		Return(ethTypes.NewBlockWithHeader(&ethTypes.Header{Number: big.NewInt(int64(blockRange.fromBlock - 1))}), errors.New("error")).
 		Once()
 
 	err := sut.asyncRequestRollupInfoByBlockRange(ctx, ch, &wg, request)

--- a/synchronizer/l2_sync/l2_shared/post_closed_batch_check_l2block.go
+++ b/synchronizer/l2_sync/l2_shared/post_closed_batch_check_l2block.go
@@ -2,6 +2,7 @@ package l2_shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -45,7 +46,7 @@ func (p *PostClosedBatchCheckL2Block) CheckPostClosedBatch(ctx context.Context, 
 		return err
 	}
 	if statelastL2Block == nil {
-		return fmt.Errorf("last L2Block in the database is nil")
+		return errors.New("last L2Block in the database is nil")
 	}
 	trustedLastL2Block := processData.TrustedBatch.Blocks[len(processData.TrustedBatch.Blocks)-1].Block
 	log.Info(trustedLastL2Block)

--- a/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_shared/processor_trusted_batch_sync.go
@@ -2,6 +2,7 @@ package l2_shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -30,7 +31,7 @@ const (
 
 var (
 	// ErrFatalBatchDesynchronized is the error when the batch is desynchronized
-	ErrFatalBatchDesynchronized = fmt.Errorf("batch desynchronized")
+	ErrFatalBatchDesynchronized = errors.New("batch desynchronized")
 )
 
 // ProcessData contains the data required to process a batch
@@ -98,18 +99,18 @@ func (p *ProcessResponse) UpdateCurrentBatchWithExecutionResult(UpdateBatch *sta
 func (p *ProcessResponse) CheckSanity() error {
 	if p.UpdateBatchWithProcessBatchResponse {
 		if p.ProcessBatchResponse == nil {
-			return fmt.Errorf("UpdateBatchWithProcessBatchResponse is true but ProcessBatchResponse is nil")
+			return errors.New("UpdateBatchWithProcessBatchResponse is true but ProcessBatchResponse is nil")
 		}
 		if p.UpdateBatch == nil {
-			return fmt.Errorf("UpdateBatchWithProcessBatchResponse is true but UpdateBatch is nil")
+			return errors.New("UpdateBatchWithProcessBatchResponse is true but UpdateBatch is nil")
 		}
 		if p.ClearCache {
-			return fmt.Errorf("UpdateBatchWithProcessBatchResponse is true but ClearCache is true")
+			return errors.New("UpdateBatchWithProcessBatchResponse is true but ClearCache is true")
 		}
 	}
 	if p.UpdateBatch != nil {
 		if p.ClearCache {
-			return fmt.Errorf("UpdateBatch is not nil but ClearCache is true")
+			return errors.New("UpdateBatch is not nil but ClearCache is true")
 		}
 	}
 	return nil
@@ -306,7 +307,7 @@ func updateStatus(status TrustedState, response *ProcessResponse, closedBatch bo
 func (s *ProcessorTrustedBatchSync) GetModeForProcessBatch(trustedNodeBatch *types.Batch, stateBatch *state.Batch, statePreviousBatch *state.Batch, debugPrefix string) (ProcessData, error) {
 	// Check parameters
 	if trustedNodeBatch == nil || statePreviousBatch == nil {
-		return ProcessData{}, fmt.Errorf("trustedNodeBatch and statePreviousBatch can't be nil")
+		return ProcessData{}, errors.New("trustedNodeBatch and statePreviousBatch can't be nil")
 	}
 
 	var result ProcessData = ProcessData{}

--- a/synchronizer/l2_sync/l2_sync_etrog/check_sync_status_to_process_batch_test.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/check_sync_status_to_process_batch_test.go
@@ -2,7 +2,7 @@ package l2_sync_etrog
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
@@ -17,7 +17,7 @@ import (
 
 var (
 	globalExitRootNonZero = common.HexToHash("0x723e5c4c7ee7890e1e66c2e391d553ee792d2204ecb4fe921830f12f8dcd1a92")
-	randomError           = fmt.Errorf("random error")
+	randomError           = errors.New("random error")
 )
 
 type testData struct {

--- a/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
+++ b/synchronizer/l2_sync/l2_sync_etrog/executor_trusted_batch_sync.go
@@ -184,7 +184,7 @@ func (b *SyncTrustedBatchExecutorForEtrog) FullProcess(ctx context.Context, data
 func (b *SyncTrustedBatchExecutorForEtrog) IncrementalProcess(ctx context.Context, data *l2_shared.ProcessData, dbTx pgx.Tx) (*l2_shared.ProcessResponse, error) {
 	var err error
 	if data == nil || data.TrustedBatch == nil || data.StateBatch == nil {
-		return nil, fmt.Errorf("data is nil")
+		return nil, errors.New("data is nil")
 	}
 	if err := checkThatL2DataIsIncremental(data); err != nil {
 		log.Errorf("%s error checkThatL2DataIsIncremental. Error: %v", data.DebugPrefix, err)

--- a/synchronizer/l2_sync/l2_sync_incaberry/sync_trusted_state.go
+++ b/synchronizer/l2_sync/l2_sync_incaberry/sync_trusted_state.go
@@ -3,6 +3,7 @@ package l2_sync_incaberry
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -178,7 +179,7 @@ func (s *SyncTrustedBatchesAction) processTrustedBatch(ctx context.Context, trus
 		log.Infof("Coinbase. stored:  %s. synced: %s", batches[0].Coinbase.String(), trustedBatch.Coinbase.String())
 		log.Infof("Timestamp. stored:  %d. synced: %d", uint64(batches[0].Timestamp.Unix()), uint64(trustedBatch.Timestamp))
 		log.Infof("BatchL2Data. stored: %s. synced: %s", common.Bytes2Hex(batches[0].BatchL2Data), common.Bytes2Hex(trustedBatchL2Data))
-		return nil, nil, fmt.Errorf("error: inconsistency in data received from trustedNode")
+		return nil, nil, errors.New("error: inconsistency in data received from trustedNode")
 	}
 
 	if s.TrustedState.LastStateRoot == nil && (batches[0] == nil || (batches[0].StateRoot == common.Hash{})) {

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -188,7 +188,7 @@ func decodeSyncBlockProtection(sBP string) (rpc.BlockNumber, error) {
 	case "safe":
 		return rpc.SafeBlockNumber, nil
 	default:
-		return 0, fmt.Errorf("error decoding SyncBlockProtection. Unknown value")
+		return 0, errors.New("error decoding SyncBlockProtection. Unknown value")
 	}
 }
 
@@ -269,7 +269,7 @@ func (s *ClientSynchronizer) processGenesis() error {
 		return err
 	} else if !valid {
 		log.Error("genesis Block number configured is not valid. It is required the block number where the PolygonZkEVM smc was deployed")
-		return fmt.Errorf("genesis Block number configured is not valid. It is required the block number where the PolygonZkEVM smc was deployed")
+		return errors.New("genesis Block number configured is not valid. It is required the block number where the PolygonZkEVM smc was deployed")
 	}
 	// Sync pre genesis rollup events
 	s.syncPreRollup.(*SyncPreRollup).GenesisBlockNumber = s.genesis.BlockNumber
@@ -526,11 +526,11 @@ func (s *ClientSynchronizer) RequestAndProcessRollupGenesisBlock(dbTx pgx.Tx, la
 func sanityCheckForGenesisBlockRollupInfo(blocks []etherman.Block, order map[common.Hash][]etherman.Order) error {
 	if len(blocks) != 1 || len(order) < 1 || len(order[blocks[0].BlockHash]) < 1 {
 		log.Errorf("error getting rollupInfoByBlockRange after set the genesis. Expected 1 block with 2 orders")
-		return fmt.Errorf("error getting rollupInfoByBlockRange after set the genesis. Expected 1 block with 2 orders")
+		return errors.New("error getting rollupInfoByBlockRange after set the genesis. Expected 1 block with 2 orders")
 	}
 	if order[blocks[0].BlockHash][0].Name != etherman.ForkIDsOrder {
 		log.Errorf("error getting rollupInfoByBlockRange after set the genesis. Expected ForkIDsOrder, got %s", order[blocks[0].BlockHash][0].Name)
-		return fmt.Errorf("error getting rollupInfoByBlockRange after set the genesis. Expected ForkIDsOrder")
+		return errors.New("error getting rollupInfoByBlockRange after set the genesis. Expected ForkIDsOrder")
 	}
 
 	return nil
@@ -543,7 +543,7 @@ func (s *ClientSynchronizer) syncBlocksParallel(lastEthBlockSynced *state.Block)
 	block, err := s.checkReorg(lastEthBlockSynced)
 	if err != nil {
 		log.Errorf("error checking reorgs. Retrying... Err: %v", err)
-		return lastEthBlockSynced, fmt.Errorf("error checking reorgs")
+		return lastEthBlockSynced, errors.New("error checking reorgs")
 	}
 	if block != nil {
 		log.Infof("reorg detected. Resetting the state from block %v to block %v", lastEthBlockSynced.BlockNumber, block.BlockNumber)
@@ -551,7 +551,7 @@ func (s *ClientSynchronizer) syncBlocksParallel(lastEthBlockSynced *state.Block)
 		if err != nil {
 			log.Errorf("error resetting the state to a previous block. Retrying... Err: %v", err)
 			s.l1SyncOrchestration.Reset(lastEthBlockSynced.BlockNumber)
-			return lastEthBlockSynced, fmt.Errorf("error resetting the state to a previous block")
+			return lastEthBlockSynced, errors.New("error resetting the state to a previous block")
 		}
 		return block, nil
 	}
@@ -573,13 +573,13 @@ func (s *ClientSynchronizer) syncBlocksSequential(lastEthBlockSynced *state.Bloc
 	block, err := s.checkReorg(lastEthBlockSynced)
 	if err != nil {
 		log.Errorf("error checking reorgs. Retrying... Err: %v", err)
-		return lastEthBlockSynced, fmt.Errorf("error checking reorgs")
+		return lastEthBlockSynced, errors.New("error checking reorgs")
 	}
 	if block != nil {
 		err = s.resetState(block.BlockNumber)
 		if err != nil {
 			log.Errorf("error resetting the state to a previous block. Retrying... Err: %v", err)
-			return lastEthBlockSynced, fmt.Errorf("error resetting the state to a previous block")
+			return lastEthBlockSynced, errors.New("error resetting the state to a previous block")
 		}
 		return block, nil
 	}
@@ -612,13 +612,13 @@ func (s *ClientSynchronizer) syncBlocksSequential(lastEthBlockSynced *state.Bloc
 		block, err := s.checkReorg(lastEthBlockSynced)
 		if err != nil {
 			log.Errorf("error checking reorgs. Retrying... Err: %v", err)
-			return lastEthBlockSynced, fmt.Errorf("error checking reorgs")
+			return lastEthBlockSynced, errors.New("error checking reorgs")
 		}
 		if block != nil {
 			err = s.resetState(block.BlockNumber)
 			if err != nil {
 				log.Errorf("error resetting the state to a previous block. Retrying... Err: %v", err)
-				return lastEthBlockSynced, fmt.Errorf("error resetting the state to a previous block")
+				return lastEthBlockSynced, errors.New("error resetting the state to a previous block")
 			}
 			return block, nil
 		}

--- a/test/operations/wait.go
+++ b/test/operations/wait.go
@@ -40,7 +40,7 @@ const (
 var (
 	// ErrTimeoutReached is thrown when the timeout is reached and
 	// because the condition is not matched
-	ErrTimeoutReached = fmt.Errorf("timeout has been reached")
+	ErrTimeoutReached = errors.New("timeout has been reached")
 )
 
 // Wait handles polliing until conditions are met.
@@ -186,7 +186,7 @@ func WaitBatchToBeConsolidated(batchNum uint64, timeout time.Duration, state *st
 
 func WaitTxReceipt(ctx context.Context, txHash common.Hash, timeout time.Duration, client *ethclient.Client) (*types.Receipt, error) {
 	if client == nil {
-		return nil, fmt.Errorf("client is nil")
+		return nil, errors.New("client is nil")
 	}
 	var receipt *types.Receipt
 	pollErr := Poll(DefaultInterval, timeout, func() (bool, error) {

--- a/test/testutils/utils.go
+++ b/test/testutils/utils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -57,10 +58,10 @@ func CheckError(err error, expected bool, msg string) error {
 	}
 	if expected {
 		if err == nil {
-			return fmt.Errorf("Expected error didn't happen")
+			return errors.New("Expected error didn't happen")
 		}
 		if msg == "" {
-			return fmt.Errorf("Expected error message not defined")
+			return errors.New("Expected error message not defined")
 		}
 		if !strings.HasPrefix(err.Error(), msg) {
 			return fmt.Errorf("Wrong error, expected %q, got %q", msg, err.Error())
@@ -75,7 +76,7 @@ func ReadBytecode(contractPath string) (string, error) {
 
 	_, currentFilename, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", fmt.Errorf("Could not get name of current file")
+		return "", errors.New("Could not get name of current file")
 	}
 	fullBasePath := path.Join(path.Dir(currentFilename), basePath)
 

--- a/tools/datastreamer/main.go
+++ b/tools/datastreamer/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -1008,7 +1009,7 @@ func setGenesis(ctx context.Context, tree *merkletree.StateTree, genesis state.G
 	)
 
 	if tree == nil {
-		return newRoot, fmt.Errorf("state tree is nil")
+		return newRoot, errors.New("state tree is nil")
 	}
 
 	uuid := uuid.New().String()


### PR DESCRIPTION

### What does this PR do?

use `errors.New()` instead of `fmt.Errorf()` when no params required

### Reviewers

Main reviewers:


- @John
- @Doe

Codeowner reviewers:


- @-Alice
- @-Bob
