### PR TITLE
Fix DSSendL2Block batch number

### DIFF
--- a/sequencer/l2block.go
+++ b/sequencer/l2block.go
@@ -491,7 +491,7 @@ func (f *finalizer) storeL2Block(ctx context.Context, l2Block *L2Block) error {
 	log.Infof("[ds-debug] l2 block %d [%d] transactions updated as selected in the pooldb", blockResponse.BlockNumber, l2Block.trackingNum)
 
 	// Send L2 block to data streamer
-	err = f.DSSendL2Block(f.wipBatch.batchNumber, blockResponse, l2Block.getL1InfoTreeIndex())
+	err = f.DSSendL2Block(l2Block.batch.batchNumber, blockResponse, l2Block.getL1InfoTreeIndex())
 	if err != nil {
 		//TODO: we need to halt/rollback the L2 block if we had an error sending to the data streamer?
 		log.Errorf("error sending L2 block %d [%d] to data streamer, error: %v", blockResponse.BlockNumber, l2Block.trackingNum, err)


### PR DESCRIPTION
### What does this PR do?

Fixes DSSendL2Block batch number. It must use batchNumber field from the l2Block.batch object, as in parallel mode the f.wipBatch can be different of the batch that is being stored (f.sipBatch). Therefore, to be safe, we must use the batchNumber of the batch to which the L2Block belongs (l2Block.batch)

### Reviewers

Main reviewers:

@ToniRamirezM 