### PR TITLE
Fix DSSendBatchEnd batch values

### DIFF
--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -406,7 +406,7 @@ func (f *finalizer) closeSIPBatch(ctx context.Context, dbTx pgx.Tx) error {
 	}
 
 	// Sent batch to DS
-	f.DSSendBatchEnd(f.wipBatch.batchNumber, f.wipBatch.finalStateRoot, f.wipBatch.finalLocalExitRoot)
+	f.DSSendBatchEnd(f.sipBatch.batchNumber, f.sipBatch.finalStateRoot, f.sipBatch.finalLocalExitRoot)
 
 	log.Infof("sip batch %d closed in statedb, closing reason: %s", f.sipBatch.batchNumber, f.sipBatch.closingReason)
 


### PR DESCRIPTION
### What does this PR do?

Fixes DSSendBatchEnd batch values. It must use the values from f.sipBatch instead to use f.wipBatch

### Reviewers

Main reviewers:

@ToniRamirezM 