### PR TITLE
cherry-pick: fix #3613 timestamp needs to be greater or equal (#3614)

### DIFF
--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -163,4 +163,5 @@ type storage interface {
 	GetNotCheckedBatches(ctx context.Context, dbTx pgx.Tx) ([]*Batch, error)
 	GetLastL2BlockByBatchNumber(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*L2Block, error)
 	GetPreviousBlockToBlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*Block, error)
+	UpdateBatchTimestamp(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx) error
 }

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -8333,6 +8333,55 @@ func (_c *StorageMock_UpdateBatchL2Data_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// UpdateBatchTimestamp provides a mock function with given fields: ctx, batchNumber, timestamp, dbTx
+func (_m *StorageMock) UpdateBatchTimestamp(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx) error {
+	ret := _m.Called(ctx, batchNumber, timestamp, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateBatchTimestamp")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, time.Time, pgx.Tx) error); ok {
+		r0 = rf(ctx, batchNumber, timestamp, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StorageMock_UpdateBatchTimestamp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBatchTimestamp'
+type StorageMock_UpdateBatchTimestamp_Call struct {
+	*mock.Call
+}
+
+// UpdateBatchTimestamp is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchNumber uint64
+//   - timestamp time.Time
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) UpdateBatchTimestamp(ctx interface{}, batchNumber interface{}, timestamp interface{}, dbTx interface{}) *StorageMock_UpdateBatchTimestamp_Call {
+	return &StorageMock_UpdateBatchTimestamp_Call{Call: _e.mock.On("UpdateBatchTimestamp", ctx, batchNumber, timestamp, dbTx)}
+}
+
+func (_c *StorageMock_UpdateBatchTimestamp_Call) Run(run func(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx)) *StorageMock_UpdateBatchTimestamp_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(time.Time), args[3].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_UpdateBatchTimestamp_Call) Return(_a0 error) *StorageMock_UpdateBatchTimestamp_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *StorageMock_UpdateBatchTimestamp_Call) RunAndReturn(run func(context.Context, uint64, time.Time, pgx.Tx) error) *StorageMock_UpdateBatchTimestamp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateCheckedBlockByNumber provides a mock function with given fields: ctx, blockNumber, newCheckedStatus, dbTx
 func (_m *StorageMock) UpdateCheckedBlockByNumber(ctx context.Context, blockNumber uint64, newCheckedStatus bool, dbTx pgx.Tx) error {
 	ret := _m.Called(ctx, blockNumber, newCheckedStatus, dbTx)

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1092,3 +1092,11 @@ func (p *PostgresStorage) GetNotCheckedBatches(ctx context.Context, dbTx pgx.Tx)
 
 	return batches, nil
 }
+
+// UpdateBatchTimestamp updates the timestamp of the state.batch with the given number.
+func (p *PostgresStorage) UpdateBatchTimestamp(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx) error {
+	const sql = "UPDATE state.batch SET timestamp = $1 WHERE batch_num = $2"
+	e := p.getExecQuerier(dbTx)
+	_, err := e.Exec(ctx, sql, timestamp.UTC(), batchNumber)
+	return err
+}

--- a/synchronizer/actions/etrog/processor_l1_sequence_batches_test.go
+++ b/synchronizer/actions/etrog/processor_l1_sequence_batches_test.go
@@ -101,9 +101,12 @@ func TestL1SequenceBatchesTrustedBatchSequencedThatAlreadyExistsHappyPath(t *tes
 	expectationsPreExecution(t, mocks, ctx, batch, nil)
 	executionResponse := newProcessBatchResponseV2(batch)
 	expectationsForExecution(t, mocks, ctx, l1Block.SequencedBatches[1][0], l1Block.ReceivedAt, executionResponse)
+	mocks.State.EXPECT().UpdateBatchTimestamp(ctx, batch.BatchNumber, l1Block.ReceivedAt, mocks.DbTx).Return(nil)
 	mocks.State.EXPECT().AddAccumulatedInputHash(ctx, executionResponse.NewBatchNum, common.BytesToHash(executionResponse.NewAccInputHash), mocks.DbTx).Return(nil)
 	expectationsAddSequencedBatch(t, mocks, ctx, executionResponse)
+
 	err := sut.Process(ctx, etherman.Order{Pos: 1}, l1Block, mocks.DbTx)
+
 	require.NoError(t, err)
 }
 
@@ -117,9 +120,12 @@ func TestL1SequenceBatchesPermissionlessBatchSequencedThatAlreadyExistsHappyPath
 	expectationsPreExecution(t, mocks, ctx, batch, nil)
 	executionResponse := newProcessBatchResponseV2(batch)
 	expectationsForExecution(t, mocks, ctx, l1Block.SequencedBatches[1][0], l1Block.ReceivedAt, executionResponse)
+	mocks.State.EXPECT().UpdateBatchTimestamp(ctx, batch.BatchNumber, l1Block.ReceivedAt, mocks.DbTx).Return(nil)
 	mocks.State.EXPECT().AddAccumulatedInputHash(ctx, executionResponse.NewBatchNum, common.BytesToHash(executionResponse.NewAccInputHash), mocks.DbTx).Return(nil)
 	expectationsAddSequencedBatch(t, mocks, ctx, executionResponse)
+
 	err := sut.Process(ctx, etherman.Order{Pos: 1}, l1Block, mocks.DbTx)
+
 	require.NoError(t, err)
 }
 
@@ -139,6 +145,7 @@ func TestL1SequenceBatchesPermissionlessBatchSequencedThatAlreadyExistsMismatch(
 	executionResponse := newProcessBatchResponseV2(batch)
 	executionResponse.NewStateRoot = common.HexToHash(hashExamplesValues[2]).Bytes()
 	expectationsForExecution(t, mocks, ctx, l1Block.SequencedBatches[1][0], l1Block.ReceivedAt, executionResponse)
+	mocks.State.EXPECT().UpdateBatchTimestamp(ctx, batch.BatchNumber, l1Block.ReceivedAt, mocks.DbTx).Return(nil)
 	mocks.State.EXPECT().AddAccumulatedInputHash(ctx, executionResponse.NewBatchNum, common.BytesToHash(executionResponse.NewAccInputHash), mocks.DbTx).Return(nil)
 	mocks.Synchronizer.EXPECT().IsTrustedSequencer().Return(false)
 	mocks.State.EXPECT().AddTrustedReorg(ctx, mock.Anything, mocks.DbTx).Return(nil)
@@ -177,6 +184,7 @@ func TestL1SequenceBatchesTrustedBatchSequencedThatAlreadyExistsMismatch(t *test
 	executionResponse := newProcessBatchResponseV2(batch)
 	executionResponse.NewStateRoot = common.HexToHash(hashExamplesValues[2]).Bytes()
 	expectationsForExecution(t, mocks, ctx, l1Block.SequencedBatches[1][0], l1Block.ReceivedAt, executionResponse)
+	mocks.State.EXPECT().UpdateBatchTimestamp(ctx, batch.BatchNumber, l1Block.ReceivedAt, mocks.DbTx).Return(nil)
 	mocks.State.EXPECT().AddAccumulatedInputHash(ctx, executionResponse.NewBatchNum, common.BytesToHash(executionResponse.NewAccInputHash), mocks.DbTx).Return(nil)
 	mocks.Synchronizer.EXPECT().IsTrustedSequencer().Return(true)
 
@@ -295,7 +303,7 @@ func newL1Block(mocks *mocksEtrogProcessorL1, batch *state.Batch, l1InfoRoot com
 func newComposedL1Block(mocks *mocksEtrogProcessorL1, forcedBatch *etherman.SequencedBatch, l1InfoRoot common.Hash) *etherman.Block {
 	l1Block := etherman.Block{
 		BlockNumber:      123,
-		ReceivedAt:       mocks.TimeProvider.Now(),
+		ReceivedAt:       time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC),
 		SequencedBatches: [][]etherman.SequencedBatch{},
 	}
 	l1Block.SequencedBatches = append(l1Block.SequencedBatches, []etherman.SequencedBatch{})

--- a/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
+++ b/synchronizer/common/syncinterfaces/mocks/state_full_interface.go
@@ -2963,6 +2963,55 @@ func (_c *StateFullInterface_UpdateBatchL2Data_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// UpdateBatchTimestamp provides a mock function with given fields: ctx, batchNumber, timestamp, dbTx
+func (_m *StateFullInterface) UpdateBatchTimestamp(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx) error {
+	ret := _m.Called(ctx, batchNumber, timestamp, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateBatchTimestamp")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, time.Time, pgx.Tx) error); ok {
+		r0 = rf(ctx, batchNumber, timestamp, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StateFullInterface_UpdateBatchTimestamp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBatchTimestamp'
+type StateFullInterface_UpdateBatchTimestamp_Call struct {
+	*mock.Call
+}
+
+// UpdateBatchTimestamp is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchNumber uint64
+//   - timestamp time.Time
+//   - dbTx pgx.Tx
+func (_e *StateFullInterface_Expecter) UpdateBatchTimestamp(ctx interface{}, batchNumber interface{}, timestamp interface{}, dbTx interface{}) *StateFullInterface_UpdateBatchTimestamp_Call {
+	return &StateFullInterface_UpdateBatchTimestamp_Call{Call: _e.mock.On("UpdateBatchTimestamp", ctx, batchNumber, timestamp, dbTx)}
+}
+
+func (_c *StateFullInterface_UpdateBatchTimestamp_Call) Run(run func(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx)) *StateFullInterface_UpdateBatchTimestamp_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(time.Time), args[3].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StateFullInterface_UpdateBatchTimestamp_Call) Return(_a0 error) *StateFullInterface_UpdateBatchTimestamp_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *StateFullInterface_UpdateBatchTimestamp_Call) RunAndReturn(run func(context.Context, uint64, time.Time, pgx.Tx) error) *StateFullInterface_UpdateBatchTimestamp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateCheckedBlockByNumber provides a mock function with given fields: ctx, blockNumber, newCheckedStatus, dbTx
 func (_m *StateFullInterface) UpdateCheckedBlockByNumber(ctx context.Context, blockNumber uint64, newCheckedStatus bool, dbTx pgx.Tx) error {
 	ret := _m.Called(ctx, blockNumber, newCheckedStatus, dbTx)

--- a/synchronizer/common/syncinterfaces/state.go
+++ b/synchronizer/common/syncinterfaces/state.go
@@ -78,4 +78,5 @@ type StateFullInterface interface {
 	GetL2BlockByNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*state.L2Block, error)
 	GetUncheckedBlocks(ctx context.Context, fromBlockNumber uint64, toBlockNumber uint64, dbTx pgx.Tx) ([]*state.Block, error)
 	GetPreviousBlockToBlockNumber(ctx context.Context, blockNumber uint64, dbTx pgx.Tx) (*state.Block, error)
+	UpdateBatchTimestamp(ctx context.Context, batchNumber uint64, timestamp time.Time, dbTx pgx.Tx) error
 }

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -368,6 +368,8 @@ func TestForcedBatchEtrog(t *testing.T) {
 				Return(nil).
 				Once()
 
+			m.State.EXPECT().UpdateBatchTimestamp(ctx, sequencedBatch.BatchNumber, fb[0].ForcedAt, m.DbTx).Return(nil)
+
 			m.State.
 				On("AddAccumulatedInputHash", ctx, sequencedBatch.BatchNumber, common.Hash{}, m.DbTx).
 				Return(nil).


### PR DESCRIPTION
syncrhonizer update the tstamp from table state.batch when the batch is sequenced

Closes #3613.
Parent PR #3614 

### What does this PR do?

Synchronizer updates state.batch.tstamp when sync from L1

### Reviewers

Main reviewers:

- @ARR552 
- @agnusmor 
- @tclemos 


