### PR TITLE
Skip wait L1 block confirmations after restart

### DIFF
--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -96,13 +96,6 @@ func (s *SequenceSender) tryToSendSequence(ctx context.Context) {
 	// process monitored sequences before starting a next cycle
 	s.ethTxManager.ProcessPendingMonitoredTxs(ctx, ethTxManagerOwner, func(result ethtxmanager.MonitoredTxResult, dbTx pgx.Tx) {
 		if result.Status == ethtxmanager.MonitoredTxStatusConfirmed {
-			if s.lastSequenceEndBatch == 0 {
-				// It's the first time we call that function after the restart of the sequence-sender and we are having the confirmation of a pending L1 tx sent
-				// before the sequence-sender was restarted. At this point we don't know which batch was the last sequenced, therefore we cannot wait for
-				// the L1 block confirmations and compare the last sequenced batch in the SC with the last sequenced from sequence-sender. We continue
-				return
-			}
-
 			if len(result.Txs) > 0 {
 				var txL1BlockNumber uint64
 				var txHash common.Hash
@@ -144,7 +137,10 @@ func (s *SequenceSender) tryToSendSequence(ctx context.Context) {
 					return
 				}
 
-				if lastSCBatchNum != s.lastSequenceEndBatch {
+				// If it's the first time we call that function after the restart of the sequence-sender (lastSequenceBatch is 0) and we are having the
+				// confirmation of a pending L1 tx sent before the sequence-sender was restarted, we don't know which batch was the last sequenced.
+				// Therefore we cannot compare the last sequenced batch in the SC with the last sequenced from sequence-sender. We skip this check
+				if s.lastSequenceEndBatch != 0 && (lastSCBatchNum != s.lastSequenceEndBatch) {
 					s.halt(ctx, fmt.Errorf("last sequenced batch from SC %d doesn't match last sequenced batch sent %d", lastSCBatchNum, s.lastSequenceEndBatch))
 				}
 			} else {


### PR DESCRIPTION
### What does this PR do?

Skips wait L1 block confirmations after sequence-sender restart. After the restart, if we have the confirmation of a pending L1 tx sent that was sent before the sequence-sender was restarted, we don't know which batch was the last sequenced, therefore we cannot wait for the L1 block confirmations and compare the last sequenced batch in the SC with the last sequenced from sequence-sender. In this case we skip to wait L1 block confirmations

### Reviewers

Main reviewers:

@tclemos 
@ToniRamirezM 