### PR TITLE
docs: update RPC required services and components

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ This role can be performed by anyone.
 Required services and components:
 
 - JSON RPC: can run in a separated instance, and can have multiple instances
+- Pool DB: Postgres SQL that can be run in a separate instance
 - Synchronizer: single instance that can run on a separate instance
-- Executor & Merkletree: service that can run on a separate instance
 - State DB: Postgres SQL that can be run in a separate instance
+- Executor & Merkletree: service that can run on a separate instance
+- HashDB: service that stores the Merkletree, containing all the account information (balances, nonces, smart contract code, and smart contract storage)
 
 There must be only one synchronizer, and it's recommended that it has exclusive access to an executor instance, although it's not necessary. This role can perfectly be run in a single instance, however, the JSON RPC and executor services can benefit from running in multiple instances, if the performance decreases due to the number of requests received
 


### PR DESCRIPTION
The RPC section of the README is somewhat confusing for users.

It states that to run the zkEVM RPC, only the state DB is needed, but it doesn't mention the other necessary databases. The executor requires the hash DB, and the RPC needs the pool DB. This PR addresses this issue.