### PR TITLE
use dbTx in SequentialBatchSanityCheck

### DIFF
--- a/sequencer/batch.go
+++ b/sequencer/batch.go
@@ -57,7 +57,7 @@ func (f *finalizer) processBatchesPendingtoCheck(ctx context.Context) {
 	oldStateRoot := prevBatch.StateRoot
 
 	for _, notCheckedBatch := range notCheckedBatches {
-		_, _ = f.batchSanityCheck(ctx, notCheckedBatch.BatchNumber, oldStateRoot, notCheckedBatch.StateRoot)
+		_, _ = f.batchSanityCheck(ctx, notCheckedBatch.BatchNumber, oldStateRoot, notCheckedBatch.StateRoot, nil)
 		oldStateRoot = notCheckedBatch.StateRoot
 	}
 }
@@ -397,11 +397,11 @@ func (f *finalizer) closeSIPBatch(ctx context.Context, dbTx pgx.Tx) error {
 	// Reprocess full batch as sanity check
 	if f.cfg.SequentialBatchSanityCheck {
 		// Do the full batch reprocess now
-		_, _ = f.batchSanityCheck(ctx, batchNumber, initialStateRoot, finalStateRoot)
+		_, _ = f.batchSanityCheck(ctx, batchNumber, initialStateRoot, finalStateRoot, dbTx)
 	} else {
 		// Do the full batch reprocess in parallel
 		go func() {
-			_, _ = f.batchSanityCheck(ctx, batchNumber, initialStateRoot, finalStateRoot)
+			_, _ = f.batchSanityCheck(ctx, batchNumber, initialStateRoot, finalStateRoot, nil)
 		}()
 	}
 
@@ -416,7 +416,7 @@ func (f *finalizer) closeSIPBatch(ctx context.Context, dbTx pgx.Tx) error {
 }
 
 // batchSanityCheck reprocesses a batch used as sanity check
-func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initialStateRoot common.Hash, expectedNewStateRoot common.Hash) (*state.ProcessBatchResponse, error) {
+func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initialStateRoot common.Hash, expectedNewStateRoot common.Hash, dbTx pgx.Tx) (*state.ProcessBatchResponse, error) {
 	reprocessError := func(batch *state.Batch) {
 		rawL2Blocks, err := state.DecodeBatchV2(batch.BatchL2Data)
 		if err != nil {
@@ -442,7 +442,7 @@ func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initi
 
 	log.Debugf("batch %d sanity check: initialStateRoot: %s, expectedNewStateRoot: %s", batchNum, initialStateRoot, expectedNewStateRoot)
 
-	batch, err := f.stateIntf.GetBatchByNumber(ctx, batchNum, nil)
+	batch, err := f.stateIntf.GetBatchByNumber(ctx, batchNum, dbTx)
 	if err != nil {
 		log.Errorf("failed to get batch %d, error: %v", batchNum, err)
 		return nil, ErrGetBatchByNumber
@@ -459,7 +459,7 @@ func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initi
 		SkipVerifyL1InfoRoot_V2: true,
 		Caller:                  stateMetrics.DiscardCallerLabel,
 	}
-	batchRequest.L1InfoTreeData_V2, _, _, err = f.stateIntf.GetL1InfoTreeDataFromBatchL2Data(ctx, batch.BatchL2Data, nil)
+	batchRequest.L1InfoTreeData_V2, _, _, err = f.stateIntf.GetL1InfoTreeDataFromBatchL2Data(ctx, batch.BatchL2Data, dbTx)
 	if err != nil {
 		log.Errorf("failed to get L1InfoTreeData for batch %d, error: %v", batch.BatchNumber, err)
 		reprocessError(nil)
@@ -502,7 +502,7 @@ func (f *finalizer) batchSanityCheck(ctx context.Context, batchNum uint64, initi
 		return nil, ErrStateRootNoMatch
 	}
 
-	err = f.stateIntf.UpdateBatchAsChecked(ctx, batch.BatchNumber, nil)
+	err = f.stateIntf.UpdateBatchAsChecked(ctx, batch.BatchNumber, dbTx)
 	if err != nil {
 		log.Errorf("failed to update batch %d as checked, error: %v", batch.BatchNumber, err)
 		reprocessError(batch)

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -986,9 +986,9 @@ func TestFinalizer_finalizeSIPBatch(t *testing.T) {
 			if tc.managerErr == nil {
 				stateMock.On("GetBatchByNumber", ctx, f.sipBatch.batchNumber, mock.Anything).Return(&state.Batch{BatchNumber: f.sipBatch.batchNumber}, nilErr).Once()
 				stateMock.On("GetForkIDByBatchNumber", f.wipBatch.batchNumber).Return(uint64(9)).Once()
-				stateMock.On("GetL1InfoTreeDataFromBatchL2Data", ctx, mock.Anything, nil).Return(map[uint32]state.L1DataV2{}, state.ZeroHash, state.ZeroHash, nil)
+				stateMock.On("GetL1InfoTreeDataFromBatchL2Data", ctx, mock.Anything, mock.Anything).Return(map[uint32]state.L1DataV2{}, state.ZeroHash, state.ZeroHash, nil)
 				stateMock.On("ProcessBatchV2", ctx, mock.Anything, false).Return(&state.ProcessBatchResponse{}, "", nil)
-				stateMock.On("UpdateBatchAsChecked", ctx, f.sipBatch.batchNumber, nil).Return(nil)
+				stateMock.On("UpdateBatchAsChecked", ctx, f.sipBatch.batchNumber, mock.Anything).Return(nil)
 				dbTxMock.On("Commit", ctx).Return(nilErr).Once()
 			} else {
 				dbTxMock.On("Rollback", ctx).Return(nilErr).Once()

--- a/sequencer/finalizer_test.go
+++ b/sequencer/finalizer_test.go
@@ -984,7 +984,7 @@ func TestFinalizer_finalizeSIPBatch(t *testing.T) {
 			stateMock.On("CloseWIPBatch", ctx, receipt, mock.Anything).Return(tc.managerErr).Once()
 
 			if tc.managerErr == nil {
-				stateMock.On("GetBatchByNumber", ctx, f.sipBatch.batchNumber, nil).Return(&state.Batch{BatchNumber: f.sipBatch.batchNumber}, nilErr).Once()
+				stateMock.On("GetBatchByNumber", ctx, f.sipBatch.batchNumber, mock.Anything).Return(&state.Batch{BatchNumber: f.sipBatch.batchNumber}, nilErr).Once()
 				stateMock.On("GetForkIDByBatchNumber", f.wipBatch.batchNumber).Return(uint64(9)).Once()
 				stateMock.On("GetL1InfoTreeDataFromBatchL2Data", ctx, mock.Anything, nil).Return(map[uint32]state.L1DataV2{}, state.ZeroHash, state.ZeroHash, nil)
 				stateMock.On("ProcessBatchV2", ctx, mock.Anything, false).Return(&state.ProcessBatchResponse{}, "", nil)


### PR DESCRIPTION
### What does this PR do?

Use dbTx in SequentialBatchSanityCheck to avoid sequencer halting

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @agnusmor 