### PR TITLE
Add mined L1blocknumber to MonitoredTxResult

### DIFF
--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -184,9 +184,10 @@ func (c *Client) buildResult(ctx context.Context, mTx monitoredTx) (MonitoredTxR
 	}
 
 	result := MonitoredTxResult{
-		ID:     mTx.id,
-		Status: mTx.status,
-		Txs:    txs,
+		ID:          mTx.id,
+		Status:      mTx.status,
+		BlockNumber: mTx.blockNumber,
+		Txs:         txs,
 	}
 
 	return result, nil

--- a/ethtxmanager/monitoredtx.go
+++ b/ethtxmanager/monitoredtx.go
@@ -182,9 +182,10 @@ func (mTx *monitoredTx) blockNumberU64Ptr() *uint64 {
 
 // MonitoredTxResult represents the result of a execution of a monitored tx
 type MonitoredTxResult struct {
-	ID     string
-	Status MonitoredTxStatus
-	Txs    map[common.Hash]TxResult
+	ID          string
+	Status      MonitoredTxStatus
+	BlockNumber *big.Int
+	Txs         map[common.Hash]TxResult
 }
 
 // TxResult represents the result of a execution of a ethereum transaction in the block chain

--- a/state/forkid.go
+++ b/state/forkid.go
@@ -19,10 +19,6 @@ const (
 	FORKID_ELDERBERRY = 8
 	// FORKID_9 is the fork id 9
 	FORKID_9 = 9
-	// FORKID_10 is the fork id 10
-	FORKID_10 = 10
-	// FORKID_11 is the fork id 11
-	FORKID_11 = 11
 )
 
 // ForkIDInterval is a fork id interval

--- a/synchronizer/actions/forksids.go
+++ b/synchronizer/actions/forksids.go
@@ -14,10 +14,6 @@ const (
 	ForkIDElderberry = ForkIdType(8) //nolint:gomnd
 	// ForkID9 is the forkId for 9
 	ForkID9 = ForkIdType(9) //nolint:gomnd
-	// ForkID10 is the forkId for 10 (support more counters)
-	ForkID10 = ForkIdType(10) //nolint:gomnd
-	// ForkID11 is the forkId for 11 (support even more counters)
-	ForkID11 = ForkIdType(11) //nolint:gomnd
 )
 
 var (
@@ -26,7 +22,7 @@ var (
 	ForksIdAll = []ForkIdType{WildcardForkId}
 
 	// ForksIdOnlyElderberry support only elderberry forkId
-	ForksIdOnlyElderberry = []ForkIdType{ForkIDElderberry, ForkID9, ForkID10, ForkID11}
+	ForksIdOnlyElderberry = []ForkIdType{ForkIDElderberry, ForkID9}
 
 	// ForksIdOnlyEtrog support only etrog forkId
 	ForksIdOnlyEtrog = []ForkIdType{ForkIDEtrog}


### PR DESCRIPTION
### What does this PR do?

Adds mined L1blocknumber to MonitoredTxResult in eth-tx-manager. This info will be used by sequence-sender to perform the wait for L1Block confirmations

### Reviewers

Main reviewers:

@joanestebanr 
@ToniRamirezM 
@tclemos 