### PR TITLE
Fix timestamp when querying zkevm_getBatchByNumer and the batch is only in trusted state

### DIFF
--- a/state/batch.go
+++ b/state/batch.go
@@ -568,14 +568,11 @@ func (s *State) GetLastBatch(ctx context.Context, dbTx pgx.Tx) (*Batch, error) {
 	return batches[0], nil
 }
 
-// GetBatchTimestamp returns the batch timestamp.
-// if batch >= etrog
-//
-//	if the batch is virtualized it will return virtual_batch.timestamp value
-//	if the batch is not virtualized (only in trusted state) and the batch doesn't have L2 blocks it will return batch.timestamp value
-//	if the batch has blocks it will return the timestamp of the last L2 block of the batch
-//
-// if batch < etrog it will return batch.timestamp value
+// GetBatchTimestamp returns the batch timestamp
+// If batch >= etrog and it's virtualized it will return virtual_batch.timestamp field value, otherwise it will return batchTimestamp (trusted state)
+// If batch < etrog it will return batchTimestamp value
+// The function GetRawBatchTimestamps will return as batchTimestamp the timestamp of the last L2 block of the batch,
+// if the batch doesn't have blocks it will return batch.timestamp field value
 func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, forcedForkId *uint64, dbTx pgx.Tx) (*time.Time, error) {
 	var forkid uint64
 	if forcedForkId != nil {

--- a/state/batch.go
+++ b/state/batch.go
@@ -569,10 +569,9 @@ func (s *State) GetLastBatch(ctx context.Context, dbTx pgx.Tx) (*Batch, error) {
 }
 
 // GetBatchTimestamp returns the batch timestamp
-// If batch >= etrog and it's virtualized it will return virtual_batch.timestamp field value, otherwise it will return batchTimestamp (trusted state)
+// If batch >= etrog and it's virtualized it will return virtual_batch.timestamp_batch_etrog field value, otherwise it will return batchTimestamp (trusted state)
 // If batch < etrog it will return batchTimestamp value
-// The function GetRawBatchTimestamps will return as batchTimestamp the timestamp of the last L2 block of the batch,
-// if the batch doesn't have blocks it will return batch.timestamp field value
+// The function GetRawBatchTimestamps will return as batchTimestamp the timestamp of the last L2 block of the batch
 func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, forcedForkId *uint64, dbTx pgx.Tx) (*time.Time, error) {
 	var forkid uint64
 	if forcedForkId != nil {
@@ -586,6 +585,17 @@ func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, force
 	}
 	if forkid >= FORKID_ETROG {
 		if virtualTimestamp == nil {
+			lastL2Block, err := s.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
+			if err != nil && !errors.Is(err, ErrNotFound) {
+				return nil, err
+			}
+
+			// If the batch has L2 blocks we will return the timestamp of the last L2 block as the timestamp of the batch
+			// else we will return the batchTimestamp value (timestamp of batch creation)
+			if lastL2Block != nil {
+				return &lastL2Block.ReceivedAt, nil
+			}
+
 			return batchTimestamp, nil
 		}
 		return virtualTimestamp, nil

--- a/state/batch.go
+++ b/state/batch.go
@@ -569,9 +569,13 @@ func (s *State) GetLastBatch(ctx context.Context, dbTx pgx.Tx) (*Batch, error) {
 }
 
 // GetBatchTimestamp returns the batch timestamp.
+// if batch >= etrog
 //
-//	   for >= etrog is stored on virtual_batch.batch_timestamp
-//		  previous batches is stored on batch.timestamp
+//	if the batch is virtualized it will return virtual_batch.timestamp value
+//	if the batch is not virtualized (only in trusted state) and the batch doesn't have L2 blocks it will return batch.timestamp value
+//	if the batch has blocks it will return the timestamp of the last L2 block of the batch
+//
+// if batch < etrog it will return batch.timestamp value
 func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, forcedForkId *uint64, dbTx pgx.Tx) (*time.Time, error) {
 	var forkid uint64
 	if forcedForkId != nil {
@@ -584,6 +588,9 @@ func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, force
 		return nil, err
 	}
 	if forkid >= FORKID_ETROG {
+		if virtualTimestamp == nil {
+			return batchTimestamp, nil
+		}
 		return virtualTimestamp, nil
 	}
 	return batchTimestamp, nil

--- a/state/batch.go
+++ b/state/batch.go
@@ -569,9 +569,12 @@ func (s *State) GetLastBatch(ctx context.Context, dbTx pgx.Tx) (*Batch, error) {
 }
 
 // GetBatchTimestamp returns the batch timestamp
-// If batch >= etrog and it's virtualized it will return virtual_batch.timestamp_batch_etrog field value, otherwise it will return batchTimestamp (trusted state)
+// If batch >= etrog
+//
+//	if the batch it's virtualized it will return virtual_batch.timestamp_batch_etrog field value
+//	if the batch if's only trusted and it has L2 blocks it will return the timestamp of the last L2 block, otherwise it will return batchTimestamp
+//
 // If batch < etrog it will return batchTimestamp value
-// The function GetRawBatchTimestamps will return as batchTimestamp the timestamp of the last L2 block of the batch
 func (s *State) GetBatchTimestamp(ctx context.Context, batchNumber uint64, forcedForkId *uint64, dbTx pgx.Tx) (*time.Time, error) {
 	var forkid uint64
 	if forcedForkId != nil {

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -995,7 +995,7 @@ func (p *PostgresStorage) BuildChangeL2Block(deltaTimestamp uint32, l1InfoTreeIn
 }
 
 // GetRawBatchTimestamps returns the timestamp of the batch with the given number.
-// it returns batch_num.tstamp and virtual_batch.batch_timestamp
+// it returns batch.timestamp and virtual_batch.timestamp_batch_etrog
 func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber uint64, dbTx pgx.Tx) (*time.Time, *time.Time, error) {
 	const sql = `
 	SELECT b.timestamp AS batch_timestamp, v.timestamp_batch_etrog AS virtual_batch_timestamp

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1013,7 +1013,7 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	}
 
 	lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !errors.Is(err, state.ErrNotFound) {
 		return nil, nil, err
 	}
 

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1008,8 +1008,23 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	err := e.QueryRow(ctx, sql, batchNumber).Scan(&batchTimestamp, &virtualBatchTimestamp)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, nil
+	} else if err != nil {
+		return nil, nil, err
 	}
-	return batchTimestamp, virtualBatchTimestamp, err
+
+	if virtualBatchTimestamp == nil {
+		lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if lastL2Block != nil {
+			virtualBatchTimestamp = &lastL2Block.ReceivedAt
+		} else {
+			virtualBatchTimestamp = batchTimestamp
+		}
+	}
+
+	return batchTimestamp, virtualBatchTimestamp, nil
 }
 
 // GetVirtualBatchParentHash returns the parent hash of the virtual batch with the given number.

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1013,7 +1013,7 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	}
 
 	lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
-	if !errors.Is(err, state.ErrNotFound) {
+	if err != nil && !errors.Is(err, state.ErrNotFound) {
 		return nil, nil, err
 	}
 

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1012,16 +1012,15 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 		return nil, nil, err
 	}
 
-	if virtualBatchTimestamp == nil {
-		lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
-		if err != nil {
-			return nil, nil, err
-		}
-		if lastL2Block != nil {
-			virtualBatchTimestamp = &lastL2Block.ReceivedAt
-		} else {
-			virtualBatchTimestamp = batchTimestamp
-		}
+	lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, err
+	}
+
+	// If the batch has L2 blocks we will return the timestamp of the last L2 block as the timestamp of the batch
+	// else we will return the batch.timestamp value (timestamp of batch creation)
+	if lastL2Block != nil {
+		batchTimestamp = &lastL2Block.ReceivedAt
 	}
 
 	return batchTimestamp, virtualBatchTimestamp, nil

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1008,21 +1008,7 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	err := e.QueryRow(ctx, sql, batchNumber).Scan(&batchTimestamp, &virtualBatchTimestamp)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
 	}
-
-	lastL2Block, err := p.GetLastL2BlockByBatchNumber(ctx, batchNumber, dbTx)
-	if err != nil && !errors.Is(err, state.ErrNotFound) {
-		return nil, nil, err
-	}
-
-	// If the batch has L2 blocks we will return the timestamp of the last L2 block as the timestamp of the batch
-	// else we will return the batch.timestamp value (timestamp of batch creation)
-	if lastL2Block != nil {
-		batchTimestamp = &lastL2Block.ReceivedAt
-	}
-
 	return batchTimestamp, virtualBatchTimestamp, nil
 }
 

--- a/state/pgstatestorage/batch.go
+++ b/state/pgstatestorage/batch.go
@@ -1009,7 +1009,7 @@ func (p *PostgresStorage) GetRawBatchTimestamps(ctx context.Context, batchNumber
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, nil
 	}
-	return batchTimestamp, virtualBatchTimestamp, nil
+	return batchTimestamp, virtualBatchTimestamp, err
 }
 
 // GetVirtualBatchParentHash returns the parent hash of the virtual batch with the given number.


### PR DESCRIPTION
### What does this PR do?

When querying zkevm_getBatchByNumber endpoint and the batch requested was only in trusted state (not sequenced/virtualized) the timestamp returned in the response for the batch was wrong. The function assigned a "nil" value for the timestamp and this was intrepreted as a very high timestamp value in the json response (future timestamp).

Now the issue is fixed and in the case the batch is only in trusted state it returns the timestamp of the last L2 block in the batch.

### Reviewers

Main reviewers:

@ToniRamirezM 
@tclemos 
@ARR552 