### PR TITLE
[RPC] Add Fork endpoints

### DIFF
--- a/jsonrpc/endpoints_zkevm.go
+++ b/jsonrpc/endpoints_zkevm.go
@@ -640,7 +640,7 @@ func (z *ZKEVMEndpoints) GetLatestGlobalExitRoot() (interface{}, types.Error) {
 	return ger.String(), nil
 }
 
-// GetForkId returns the network current fork ID
+// GetForkId returns the network's current fork ID
 func (z *ZKEVMEndpoints) GetForkId() (interface{}, types.Error) {
 	ctx := context.Background()
 	forkID, err := z.state.GetCurrentForkID(ctx, nil)
@@ -651,7 +651,7 @@ func (z *ZKEVMEndpoints) GetForkId() (interface{}, types.Error) {
 	return hex.EncodeUint64(forkID), nil
 }
 
-// GetForkById returns the network fork ID interval given the fork id
+// GetForkById returns the network fork ID interval given the provided fork id
 func (z *ZKEVMEndpoints) GetForkById(forkID types.ArgUint64) (interface{}, types.Error) {
 	ctx := context.Background()
 	forkIDInterval, err := z.state.GetForkByID(ctx, uint64(forkID), nil)
@@ -678,7 +678,7 @@ func (z *ZKEVMEndpoints) GetForkIdByBatchNumber(batchNumber types.BatchNumber) (
 	return hex.EncodeUint64(forkID), nil
 }
 
-// GetForkIds returns the network fork ID intervals
+// GetForks returns the network fork ID intervals
 func (z *ZKEVMEndpoints) GetForks() (interface{}, types.Error) {
 	ctx := context.Background()
 	forkIDIntervals, err := z.state.GetForkIDIntervals(ctx, nil)

--- a/jsonrpc/endpoints_zkevm.openrpc.json
+++ b/jsonrpc/endpoints_zkevm.openrpc.json
@@ -471,6 +471,126 @@
           "$ref": "#/components/schemas/Integer"
         }
       }
+    },
+    {
+      "name": "zkevm_forkId",
+      "summary": "Returns the network's current fork ID.",
+      "params": [],
+      "result": {
+        "$ref": "#/components/contentDescriptors/ForkID"
+      },
+      "examples": [
+        {
+          "name": "example",
+          "description": "",
+          "params": [],
+          "result": {
+            "name": "exampleResult",
+            "description": "",
+            "value": "0x1"
+          }
+        }
+      ]
+    },
+    {
+      "name": "zkevm_getForkById",
+      "summary": "returns the network fork ID interval given the provided fork id",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/ForkID"
+        }
+      ],
+      "result": {
+        "$ref": "#/components/contentDescriptors/Fork"
+      },
+      "examples": [
+        {
+          "name": "example",
+          "description": "",
+          "params": [
+            {
+              "name": "fork id",
+              "value": "0x1"
+            }
+          ],
+          "result": {
+            "name": "Fork",
+            "value": {
+              "forkId": "0x8",
+              "fromBatchNumber": "0x1",
+              "toBatchNumber": "0xffffffffffffffff",
+              "version": "",
+              "blockNumber": "0x88"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "zkevm_getForkIdByBatchNumber",
+      "summary": "returns the fork ID given the provided batch number",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/BatchNumber"
+        }
+      ],
+      "result": {
+        "$ref": "#/components/contentDescriptors/ForkID"
+      },
+      "examples": [
+        {
+          "name": "example",
+          "description": "",
+          "params": [],
+          "result": {
+            "name": "exampleResult",
+            "description": "",
+            "value": "0x1"
+          }
+        }
+      ]
+    },
+    {
+      "name": "zkevm_getForks",
+      "summary": "returns the network fork ID interval given the provided fork id",
+      "params": [],
+      "result": {
+        "name": "result",
+        "schema": {
+          "description": "Array of forks",
+          "type": "array",
+          "items": {
+            "title": "fork",
+            "$ref": "#/components/contentDescriptors/Fork"
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "example",
+          "description": "",
+          "params": [],
+          "result": {
+            "name": "Fork",
+            "value": [
+              {
+                "forkId": "0x8",
+                "fromBatchNumber": "0x1",
+                "toBatchNumber": "0xa",
+                "version": "",
+                "blockNumber": "0x88"
+              },
+              {
+                "forkId": "0x9",
+                "fromBatchNumber": "0xb",
+                "toBatchNumber": "0xffffffffffffffff",
+                "version": "",
+                "blockNumber": "0x188"
+              }
+            ] 
+          }
+        }
+      ]
     }
   ],
   "components": {
@@ -520,6 +640,14 @@
           "$ref": "#/components/schemas/Block"
         }
       },
+      "Fork": {
+        "name": "fork",
+        "description": "fork",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Fork"
+        }
+      },
       "Transaction": {
         "required": true,
         "name": "transaction",
@@ -547,6 +675,13 @@
               "$ref": "#/components/schemas/Null"
             }
           ]
+        }
+      },
+      "ForkID": {
+        "name": "forkID",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ForkID"
         }
       }
     },
@@ -1435,6 +1570,36 @@
           },
           "data": {
             "$ref": "#/components/schemas/Integer"
+          }
+        }
+      },
+      "ForkID": {
+        "title": "forkID",
+        "type": "string",
+        "description": "The hex representation of the fork's id",
+        "$ref": "#/components/schemas/Integer"
+      },
+      "Fork": {
+        "title": "Fork",
+        "type": "object",
+        "readOnly": true,
+        "properties": {
+          "forkId": {
+            "$ref": "#/components/schemas/ForkID"
+          },
+          "fromBatchNumber": {
+            "$ref": "#/components/schemas/BatchNumber"
+          },
+          "toBatchNumber": {
+            "$ref": "#/components/schemas/BatchNumber"
+          },
+          "Version": {
+            "title": "batchNumberTag",
+            "type": "string",
+            "description": "fork version"
+          },
+          "BlockNumber": {
+            "$ref": "#/components/schemas/BlockNumber"
           }
         }
       }

--- a/jsonrpc/mocks/mock_state.go
+++ b/jsonrpc/mocks/mock_state.go
@@ -271,6 +271,34 @@ func (_m *StateMock) GetCode(ctx context.Context, address common.Address, root c
 	return r0, r1
 }
 
+// GetCurrentForkID provides a mock function with given fields: ctx, dbTx
+func (_m *StateMock) GetCurrentForkID(ctx context.Context, dbTx pgx.Tx) (uint64, error) {
+	ret := _m.Called(ctx, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCurrentForkID")
+	}
+
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) (uint64, error)); ok {
+		return rf(ctx, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) uint64); ok {
+		r0 = rf(ctx, dbTx)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pgx.Tx) error); ok {
+		r1 = rf(ctx, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetExitRootByGlobalExitRoot provides a mock function with given fields: ctx, ger, dbTx
 func (_m *StateMock) GetExitRootByGlobalExitRoot(ctx context.Context, ger common.Hash, dbTx pgx.Tx) (*state.GlobalExitRoot, error) {
 	ret := _m.Called(ctx, ger, dbTx)
@@ -294,6 +322,84 @@ func (_m *StateMock) GetExitRootByGlobalExitRoot(ctx context.Context, ger common
 
 	if rf, ok := ret.Get(1).(func(context.Context, common.Hash, pgx.Tx) error); ok {
 		r1 = rf(ctx, ger, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetForkByID provides a mock function with given fields: ctx, forkID, dbTx
+func (_m *StateMock) GetForkByID(ctx context.Context, forkID uint64, dbTx pgx.Tx) (*state.ForkIDInterval, error) {
+	ret := _m.Called(ctx, forkID, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForkByID")
+	}
+
+	var r0 *state.ForkIDInterval
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) (*state.ForkIDInterval, error)); ok {
+		return rf(ctx, forkID, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) *state.ForkIDInterval); ok {
+		r0 = rf(ctx, forkID, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*state.ForkIDInterval)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, forkID, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetForkIDByBatchNumber provides a mock function with given fields: batchNumber
+func (_m *StateMock) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
+	ret := _m.Called(batchNumber)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForkIDByBatchNumber")
+	}
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(uint64) uint64); ok {
+		r0 = rf(batchNumber)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// GetForkIDIntervals provides a mock function with given fields: ctx, dbTx
+func (_m *StateMock) GetForkIDIntervals(ctx context.Context, dbTx pgx.Tx) ([]state.ForkIDInterval, error) {
+	ret := _m.Called(ctx, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForkIDIntervals")
+	}
+
+	var r0 []state.ForkIDInterval
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) ([]state.ForkIDInterval, error)); ok {
+		return rf(ctx, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) []state.ForkIDInterval); ok {
+		r0 = rf(ctx, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]state.ForkIDInterval)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pgx.Tx) error); ok {
+		r1 = rf(ctx, dbTx)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/jsonrpc/types/interfaces.go
+++ b/jsonrpc/types/interfaces.go
@@ -76,6 +76,10 @@ type StateInterface interface {
 	GetLatestBatchGlobalExitRoot(ctx context.Context, dbTx pgx.Tx) (common.Hash, error)
 	GetL2TxHashByTxHash(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (*common.Hash, error)
 	PreProcessUnsignedTransaction(ctx context.Context, tx *types.Transaction, sender common.Address, l2BlockNumber *uint64, dbTx pgx.Tx) (*state.ProcessBatchResponse, error)
+	GetCurrentForkID(ctx context.Context, dbTx pgx.Tx) (uint64, error)
+	GetForkIDByBatchNumber(batchNumber uint64) uint64
+	GetForkByID(ctx context.Context, forkID uint64, dbTx pgx.Tx) (*state.ForkIDInterval, error)
+	GetForkIDIntervals(ctx context.Context, dbTx pgx.Tx) ([]state.ForkIDInterval, error)
 }
 
 // EthermanInterface provides integration with L1

--- a/jsonrpc/types/types.go
+++ b/jsonrpc/types/types.go
@@ -773,3 +773,24 @@ func NewZKCountersResponse(zkCounters state.ZKCounters, limits ZKCountersLimits,
 		OOCError:       oocErrMsg,
 	}
 }
+
+// ForkIDInterval provides fork id information
+type ForkIDInterval struct {
+	ForkId          ArgUint64 `json:"forkId"`
+	FromBatchNumber ArgUint64 `json:"fromBatchNumber"`
+	ToBatchNumber   ArgUint64 `json:"toBatchNumber"`
+	Version         string    `json:"version"`
+	BlockNumber     ArgUint64 `json:"blockNumber"`
+}
+
+// NewForkIDInterval creates a new instance of ForkIDInterval
+// given a state.ForkIDInterval instance
+func NewForkIDInterval(forkIDInterval state.ForkIDInterval) *ForkIDInterval {
+	return &ForkIDInterval{
+		ForkId:          ArgUint64(forkIDInterval.ForkId),
+		FromBatchNumber: ArgUint64(forkIDInterval.FromBatchNumber),
+		ToBatchNumber:   ArgUint64(forkIDInterval.ToBatchNumber),
+		Version:         forkIDInterval.Version,
+		BlockNumber:     ArgUint64(forkIDInterval.BlockNumber),
+	}
+}

--- a/state/forkid.go
+++ b/state/forkid.go
@@ -49,3 +49,18 @@ func (s *State) GetForkIDByBatchNumber(batchNumber uint64) uint64 {
 func (s *State) GetForkIDByBlockNumber(blockNumber uint64) uint64 {
 	return s.storage.GetForkIDByBlockNumber(blockNumber)
 }
+
+// GetCurrentForkID gets the current fork id
+func (s *State) GetCurrentForkID(ctx context.Context, dbTx pgx.Tx) (uint64, error) {
+	return s.storage.GetCurrentForkID(ctx, dbTx)
+}
+
+// GetForkByID gets the fork id interval by fork id number
+func (s *State) GetForkByID(ctx context.Context, forkID uint64, dbTx pgx.Tx) (*ForkIDInterval, error) {
+	return s.storage.GetForkByID(ctx, forkID, dbTx)
+}
+
+// GetForkIDIntervals gets all fork id intervals
+func (s *State) GetForkIDIntervals(ctx context.Context, dbTx pgx.Tx) ([]ForkIDInterval, error) {
+	return s.storage.GetForkIDs(ctx, dbTx)
+}

--- a/state/interfaces.go
+++ b/state/interfaces.go
@@ -123,6 +123,8 @@ type storage interface {
 	GetLatestGer(ctx context.Context, maxBlockNumber uint64) (GlobalExitRoot, time.Time, error)
 	GetBatchByForcedBatchNum(ctx context.Context, forcedBatchNumber uint64, dbTx pgx.Tx) (*Batch, error)
 	AddForkID(ctx context.Context, forkID ForkIDInterval, dbTx pgx.Tx) error
+	GetCurrentForkID(ctx context.Context, dbTx pgx.Tx) (uint64, error)
+	GetForkByID(ctx context.Context, forkID uint64, dbTx pgx.Tx) (*ForkIDInterval, error)
 	GetForkIDs(ctx context.Context, dbTx pgx.Tx) ([]ForkIDInterval, error)
 	UpdateForkIDToBatchNumber(ctx context.Context, forkID ForkIDInterval, dbTx pgx.Tx) error
 	UpdateForkIDBlockNumber(ctx context.Context, forkdID uint64, newBlockNumber uint64, updateMemCache bool, dbTx pgx.Tx) error

--- a/state/mocks/mock_storage.go
+++ b/state/mocks/mock_storage.go
@@ -1950,6 +1950,63 @@ func (_c *StorageMock_GetBlockNumVirtualBatchByBatchNum_Call) RunAndReturn(run f
 	return _c
 }
 
+// GetCurrentForkID provides a mock function with given fields: ctx, dbTx
+func (_m *StorageMock) GetCurrentForkID(ctx context.Context, dbTx pgx.Tx) (uint64, error) {
+	ret := _m.Called(ctx, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCurrentForkID")
+	}
+
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) (uint64, error)); ok {
+		return rf(ctx, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pgx.Tx) uint64); ok {
+		r0 = rf(ctx, dbTx)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pgx.Tx) error); ok {
+		r1 = rf(ctx, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StorageMock_GetCurrentForkID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCurrentForkID'
+type StorageMock_GetCurrentForkID_Call struct {
+	*mock.Call
+}
+
+// GetCurrentForkID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) GetCurrentForkID(ctx interface{}, dbTx interface{}) *StorageMock_GetCurrentForkID_Call {
+	return &StorageMock_GetCurrentForkID_Call{Call: _e.mock.On("GetCurrentForkID", ctx, dbTx)}
+}
+
+func (_c *StorageMock_GetCurrentForkID_Call) Run(run func(ctx context.Context, dbTx pgx.Tx)) *StorageMock_GetCurrentForkID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_GetCurrentForkID_Call) Return(_a0 uint64, _a1 error) *StorageMock_GetCurrentForkID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *StorageMock_GetCurrentForkID_Call) RunAndReturn(run func(context.Context, pgx.Tx) (uint64, error)) *StorageMock_GetCurrentForkID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDSBatches provides a mock function with given fields: ctx, firstBatchNumber, lastBatchNumber, readWIPBatch, dbTx
 func (_m *StorageMock) GetDSBatches(ctx context.Context, firstBatchNumber uint64, lastBatchNumber uint64, readWIPBatch bool, dbTx pgx.Tx) ([]*state.DSBatch, error) {
 	ret := _m.Called(ctx, firstBatchNumber, lastBatchNumber, readWIPBatch, dbTx)
@@ -2617,6 +2674,66 @@ func (_c *StorageMock_GetForcedBatchesSince_Call) Return(_a0 []*state.ForcedBatc
 }
 
 func (_c *StorageMock_GetForcedBatchesSince_Call) RunAndReturn(run func(context.Context, uint64, uint64, pgx.Tx) ([]*state.ForcedBatch, error)) *StorageMock_GetForcedBatchesSince_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetForkByID provides a mock function with given fields: ctx, forkID, dbTx
+func (_m *StorageMock) GetForkByID(ctx context.Context, forkID uint64, dbTx pgx.Tx) (*state.ForkIDInterval, error) {
+	ret := _m.Called(ctx, forkID, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForkByID")
+	}
+
+	var r0 *state.ForkIDInterval
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) (*state.ForkIDInterval, error)); ok {
+		return rf(ctx, forkID, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, pgx.Tx) *state.ForkIDInterval); ok {
+		r0 = rf(ctx, forkID, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*state.ForkIDInterval)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, pgx.Tx) error); ok {
+		r1 = rf(ctx, forkID, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// StorageMock_GetForkByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetForkByID'
+type StorageMock_GetForkByID_Call struct {
+	*mock.Call
+}
+
+// GetForkByID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - forkID uint64
+//   - dbTx pgx.Tx
+func (_e *StorageMock_Expecter) GetForkByID(ctx interface{}, forkID interface{}, dbTx interface{}) *StorageMock_GetForkByID_Call {
+	return &StorageMock_GetForkByID_Call{Call: _e.mock.On("GetForkByID", ctx, forkID, dbTx)}
+}
+
+func (_c *StorageMock_GetForkByID_Call) Run(run func(ctx context.Context, forkID uint64, dbTx pgx.Tx)) *StorageMock_GetForkByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint64), args[2].(pgx.Tx))
+	})
+	return _c
+}
+
+func (_c *StorageMock_GetForkByID_Call) Return(_a0 *state.ForkIDInterval, _a1 error) *StorageMock_GetForkByID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *StorageMock_GetForkByID_Call) RunAndReturn(run func(context.Context, uint64, pgx.Tx) (*state.ForkIDInterval, error)) *StorageMock_GetForkByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/state/pgstatestorage/forkid_test.go
+++ b/state/pgstatestorage/forkid_test.go
@@ -17,7 +17,7 @@ func TestSortIndexForForkdIDSortedByBlockNumber(t *testing.T) {
 	}
 
 	expected := []int{3, 1, 0, 2}
-	actual := sortIndexForForkdIDSortedByBlockNumber(forkIDs)
+	actual := sortIndexForForkIDSortedByBlockNumber(forkIDs)
 
 	assert.Equal(t, expected, actual)
 


### PR DESCRIPTION
Closes #3781.

### What does this PR do?

add custom endpoints to provide fork information:

`zkevm_getForkId`: returns the network's current fork ID
`zkevm_getForkById`: returns the network fork ID interval given the provided fork id
`zkevm_getForkIdByBatchNumber`: returns the fork ID given the provided batch number
`zkevm_getForks`: returns the network fork ID intervals