### PR TITLE
Fix in README.md

### DIFF
--- a/tools/executor/README.md
+++ b/tools/executor/README.md
@@ -5,7 +5,7 @@ This way we can easily reproduce scenarios that are problematic.
 
 ## Run
 
-`cd` into this directory and `go run .`. You can decide which vectors will be run by seting `skip` to true/false, on the json files found at `./vectors`.
+`cd` into this directory and `go run .`. You can decide which vectors will be run by setting `skip` to true/false, on the json files found at `./vectors`.
 
 ## Generate vector
 


### PR DESCRIPTION
# Fix typo in README.md: `seting` → `setting`

## Description
This PR fixes a typo in the `tools/executor/README.md` file. The word `seting` has been corrected to `setting`.

## Changes
- **File:** `tools/executor/README.md`
- **Line:** 5
- **Change:** 
  ```diff
  - `cd` into this directory and `go run .`. You can decide which vectors will be run by seting `skip` to true/false, on the json files found at `./vectors`.
  + `cd` into this directory and `go run .`. You can decide which vectors will be run by setting `skip` to true/false, on the json files found at `./vectors`.