### PR TITLE
Fix typo in README.md

### DIFF
--- a/tools/datastreamer/README.md
+++ b/tools/datastreamer/README.md
@@ -56,7 +56,7 @@ Outputs = ["stdout"]
 
 ## Options
 
-To see avalible options type `make` once in the tool folder.
+To see available options type `make` once in the tool folder.
 
 ```
 decode-batch                   Runs the tool to decode a given batch


### PR DESCRIPTION
# Fix typo in `README.md`

## Description
This PR fixes a typo in the `README.md` file located in the `tools/datastreamer` directory. The word "avalible" was incorrectly spelled and has been corrected to "available."

## Changes
- **File:** `tools/datastreamer/README.md`
- **Line:** 56
- **Change:** Replaced "avalible" with "available."
